### PR TITLE
Use stable TypeScript 7 compiler

### DIFF
--- a/demos/assets/package.json
+++ b/demos/assets/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --import remix/node-tsx server.ts",
     "start": "node --import remix/node-tsx server.ts",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/demos/bookstore/package.json
+++ b/demos/bookstore/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "playwright": "catalog:"
   },
   "scripts": {

--- a/demos/frame-navigation/package.json
+++ b/demos/frame-navigation/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",

--- a/demos/frame-navigation/tsconfig.json
+++ b/demos/frame-navigation/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "dom-navigation"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/demos/frames/package.json
+++ b/demos/frames/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",

--- a/demos/social-auth/package.json
+++ b/demos/social-auth/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",

--- a/demos/sse/package.json
+++ b/demos/sse/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",

--- a/demos/timeboxer/package.json
+++ b/demos/timeboxer/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",

--- a/demos/unpkg/package.json
+++ b/demos/unpkg/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "node --watch --import remix/node-tsx server.ts",
     "start": "node --import remix/node-tsx server.ts",
     "test": "remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/demos/unpkg/tsconfig.json
+++ b/demos/unpkg/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/docs/api/app/router.ts
+++ b/docs/api/app/router.ts
@@ -73,8 +73,12 @@ export function createApiRouter(options: ApiRouterOptions) {
     let versionApiController = createApiController(versionControllerOptions)
 
     // A mounted route builder does not match its own root path, so map the
-    // versioned home action on the parent router.
-    router.map(`${versionPathname}/`, versionRootController.actions.home)
+    // versioned home action on the parent router. Wrap the route-specific action so TypeScript 7
+    // can infer context for dynamic version paths.
+    let homeAction = versionRootController.actions.home
+    router.map(`${versionPathname}/`, (context) =>
+      typeof homeAction === 'function' ? homeAction(context) : homeAction.handler(context),
+    )
     router.mount(versionPathname, (versionRouter) => {
       versionRouter.map(routes.assets, versionRootController.actions.assets)
       versionRouter.map(routes.lookup, versionRootController.actions.lookup)

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -16,7 +16,7 @@
     "pagefind": "catalog:",
     "shiki": "catalog:",
     "typedoc": "0.28.19",
-    "typescript": "catalog:legacy-typescript"
+    "typescript": "6.0.3"
   },
   "scripts": {
     "build": "pnpm run --filter \".\" --parallel \"/^build:/\"",

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -16,7 +16,7 @@
     "pagefind": "catalog:",
     "shiki": "catalog:",
     "typedoc": "0.28.19",
-    "typescript": "catalog:"
+    "typescript": "catalog:legacy-typescript"
   },
   "scripts": {
     "build": "pnpm run --filter \".\" --parallel \"/^build:/\"",
@@ -29,6 +29,6 @@
     "prerender:serve": "npx http-server -p 44100 build/site",
     "start": "node --import remix/node-tsx server.ts",
     "test": "remix test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "pnpm -w exec tsc --noEmit -p docs/api/tsconfig.json"
   }
 }

--- a/docs/api/tsconfig.json
+++ b/docs/api/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "dom-navigation"]
+  },
   "exclude": ["dist"]
 }

--- a/docs/guides/package.json
+++ b/docs/guides/package.json
@@ -25,6 +25,6 @@
     "@types/mdast": "4.0.4",
     "@types/node": "catalog:",
     "pagefind": "catalog:",
-    "typescript": "catalog:legacy-typescript"
+    "typescript": "6.0.3"
   }
 }

--- a/docs/guides/package.json
+++ b/docs/guides/package.json
@@ -8,7 +8,7 @@
     "prerender:serve": "npx http-server -p 44100 build/site",
     "start": "node --import remix/node-tsx server.ts",
     "test": "NODE_ENV=test remix test",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "pnpm -w exec tsc --noEmit -p docs/guides/tsconfig.json",
     "validate": "node --import remix/node-tsx scripts/validate-docs.ts"
   },
   "engines": {
@@ -25,6 +25,6 @@
     "@types/mdast": "4.0.4",
     "@types/node": "catalog:",
     "pagefind": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:legacy-typescript"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,12 @@
   "packageManager": "pnpm@10.34.2",
   "dependencies": {
     "@oxlint/plugins": "^1.57.0",
-    "@typescript/native-preview": "catalog:",
     "oxc-parser": "^0.121.0",
     "oxfmt": "catalog:",
     "oxlint": "^1.57.0",
     "oxlint-tsgolint": "^0.17.4",
     "remix": "workspace:^",
-    "typescript": "catalog:",
-    "typescript-language-server": "catalog:"
+    "typescript": "catalog:"
   },
   "engines": {
     "node": ">=24.3.0"

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -32,16 +32,16 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "node --test",
     "test:bun": "bun test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "keywords": [
     "assert",

--- a/packages/assert/tsconfig.build.json
+++ b/packages/assert/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/assert/tsconfig.json
+++ b/packages/assert/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -54,16 +54,16 @@
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
     "@types/picomatch": "^4.0.3",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "bench": "pnpm --dir ./bench run bench",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/assets/tsconfig.build.json
+++ b/packages/assets/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/async-context-middleware/package.json
+++ b/packages/async-context-middleware/package.json
@@ -36,18 +36,18 @@
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/async-context-middleware/tsconfig.build.json
+++ b/packages/async-context-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/async-context-middleware/tsconfig.json
+++ b/packages/async-context-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/auth-middleware/package.json
+++ b/packages/auth-middleware/package.json
@@ -39,19 +39,19 @@
     "@remix-run/session-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/session": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/auth-middleware/src/lib/auth.ts
+++ b/packages/auth-middleware/src/lib/auth.ts
@@ -45,7 +45,9 @@ export type AuthState<identity = unknown> = GoodAuth<identity> | BadAuth
  * Context key used to read auth state with `context.get(Auth)`.
  * The `auth()` middleware also installs auth state as `context.auth`.
  */
-export const Auth = createContextKey<AuthState>()
+// Keep exported context keys structurally typed so TypeScript 7 declaration emit does not
+// reference fetch-router internals. Logger and Renderer require the same annotation.
+export const Auth: { defaultValue?: AuthState } = createContextKey<AuthState>()
 
 /**
  * Successful result returned by an auth scheme.

--- a/packages/auth-middleware/tsconfig.build.json
+++ b/packages/auth-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/auth-middleware/tsconfig.json
+++ b/packages/auth-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,19 +42,19 @@
     "@remix-run/session-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/session": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "auth",

--- a/packages/auth/tsconfig.build.json
+++ b/packages/auth/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,16 +48,16 @@
     "@remix-run/assert": "workspace:^",
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "postpack": "node ../../scripts/sync-cli-template.ts --clean",
     "prepack": "node ../../scripts/sync-cli-template.ts",
     "prepublishOnly": "pnpm run build",
     "test": "remix test --concurrency 1",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/compression-middleware/package.json
+++ b/packages/compression-middleware/package.json
@@ -38,7 +38,7 @@
     "@remix-run/response": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
@@ -46,12 +46,12 @@
     "@remix-run/response": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/compression-middleware/tsconfig.build.json
+++ b/packages/compression-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/compression-middleware/tsconfig.json
+++ b/packages/compression-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/cookie/package.json
+++ b/packages/cookie/package.json
@@ -35,18 +35,18 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/headers": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "http",

--- a/packages/cookie/tsconfig.build.json
+++ b/packages/cookie/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/cookie/tsconfig.json
+++ b/packages/cookie/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/cop-middleware/package.json
+++ b/packages/cop-middleware/package.json
@@ -36,18 +36,18 @@
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/cop-middleware/tsconfig.build.json
+++ b/packages/cop-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/cop-middleware/tsconfig.json
+++ b/packages/cop-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/cors-middleware/package.json
+++ b/packages/cors-middleware/package.json
@@ -37,19 +37,19 @@
     "@remix-run/headers": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/headers": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/cors-middleware/tsconfig.build.json
+++ b/packages/cors-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/cors-middleware/tsconfig.json
+++ b/packages/cors-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/csrf-middleware/package.json
+++ b/packages/csrf-middleware/package.json
@@ -40,19 +40,19 @@
     "@remix-run/session-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/session": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/csrf-middleware/tsconfig.build.json
+++ b/packages/csrf-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/csrf-middleware/tsconfig.json
+++ b/packages/csrf-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/data-schema/package.json
+++ b/packages/data-schema/package.json
@@ -56,15 +56,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "validation",

--- a/packages/data-schema/tsconfig.build.json
+++ b/packages/data-schema/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/data-table-mysql/package.json
+++ b/packages/data-table-mysql/package.json
@@ -37,7 +37,7 @@
     "@remix-run/data-table": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "mysql2": "^3.15.3"
   },
   "dependencies": {
@@ -52,13 +52,13 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
     "test:coverage": "remix test --coverage",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/data-table-mysql/tsconfig.build.json
+++ b/packages/data-table-mysql/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/data-table-postgres/package.json
+++ b/packages/data-table-postgres/package.json
@@ -38,7 +38,7 @@
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
     "@types/pg": "^8.15.6",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "pg": "^8.16.3"
   },
   "dependencies": {
@@ -53,13 +53,13 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
     "test:coverage": "remix test --coverage",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/data-table-postgres/tsconfig.build.json
+++ b/packages/data-table-postgres/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/data-table-sqlite/package.json
+++ b/packages/data-table-sqlite/package.json
@@ -37,19 +37,19 @@
     "@remix-run/data-table": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/data-table": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
     "test:coverage": "remix test --coverage",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/data-table-sqlite/tsconfig.build.json
+++ b/packages/data-table-sqlite/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -61,17 +61,17 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {},
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
     "test:coverage": "remix test --coverage",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "remix",

--- a/packages/data-table/tsconfig.build.json
+++ b/packages/data-table/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/fetch-proxy/package.json
+++ b/packages/fetch-proxy/package.json
@@ -39,16 +39,16 @@
     "@remix-run/response": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "undici": "^7.24.8"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/fetch-proxy/tsconfig.build.json
+++ b/packages/fetch-proxy/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/fetch-proxy/tsconfig.json
+++ b/packages/fetch-proxy/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/fetch-router/demos/bun/package.json
+++ b/packages/fetch-router/demos/bun/package.json
@@ -16,11 +16,11 @@
   },
   "devDependencies": {
     "@types/bun": "^1.1.8",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "bun --watch index.ts",
     "start": "bun index.ts",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/fetch-router/demos/bun/tsconfig.json
+++ b/packages/fetch-router/demos/bun/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["index.ts", "../../global.d.ts"],
   "compilerOptions": {
+    "types": ["bun"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/fetch-router/demos/cf-workers/package.json
+++ b/packages/fetch-router/demos/cf-workers/package.json
@@ -15,13 +15,13 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "wrangler": "^4.90.1"
   },
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev --port 44100",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsc --noEmit",
     "typegen": "wrangler types",
     "db:migrate": "wrangler d1 migrations apply fetch-router-blog"
   }

--- a/packages/fetch-router/demos/node/package.json
+++ b/packages/fetch-router/demos/node/package.json
@@ -16,11 +16,11 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "node --watch server.ts",
     "start": "node server.ts",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/fetch-router/demos/node/tsconfig.json
+++ b/packages/fetch-router/demos/node/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["server.ts", "../../global.d.ts"],
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/fetch-router/package.json
+++ b/packages/fetch-router/package.json
@@ -41,18 +41,18 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/route-pattern": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/fetch-router/tsconfig.build.json
+++ b/packages/fetch-router/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/fetch-router/tsconfig.json
+++ b/packages/fetch-router/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/file-storage-s3/package.json
+++ b/packages/file-storage-s3/package.json
@@ -39,15 +39,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "file",

--- a/packages/file-storage-s3/tsconfig.build.json
+++ b/packages/file-storage-s3/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/file-storage-s3/tsconfig.json
+++ b/packages/file-storage-s3/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -50,15 +50,15 @@
     "@remix-run/form-data-parser": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "file",

--- a/packages/file-storage/tsconfig.build.json
+++ b/packages/file-storage/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/file-storage/tsconfig.json
+++ b/packages/file-storage/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/form-data-middleware/package.json
+++ b/packages/form-data-middleware/package.json
@@ -37,19 +37,19 @@
     "@remix-run/form-data-parser": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/form-data-parser": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/form-data-middleware/tsconfig.build.json
+++ b/packages/form-data-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/form-data-middleware/tsconfig.json
+++ b/packages/form-data-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/form-data-parser/demos/node/package.json
+++ b/packages/form-data-parser/demos/node/package.json
@@ -10,10 +10,10 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "start": "node server.js",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/form-data-parser/package.json
+++ b/packages/form-data-parser/package.json
@@ -39,15 +39,15 @@
     "@remix-run/data-schema": "workspace:^",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "form-data",

--- a/packages/form-data-parser/tsconfig.build.json
+++ b/packages/form-data-parser/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/form-data-parser/tsconfig.json
+++ b/packages/form-data-parser/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -39,15 +39,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "file",

--- a/packages/fs/tsconfig.build.json
+++ b/packages/fs/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/fs/tsconfig.json
+++ b/packages/fs/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/headers/package.json
+++ b/packages/headers/package.json
@@ -110,15 +110,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/headers/tsconfig.build.json
+++ b/packages/headers/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/headers/tsconfig.json
+++ b/packages/headers/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -35,15 +35,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "html",

--- a/packages/html-template/tsconfig.build.json
+++ b/packages/html-template/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/html-template/tsconfig.json
+++ b/packages/html-template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/lazy-file/package.json
+++ b/packages/lazy-file/package.json
@@ -38,15 +38,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "file",

--- a/packages/lazy-file/tsconfig.build.json
+++ b/packages/lazy-file/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/lazy-file/tsconfig.json
+++ b/packages/lazy-file/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -36,19 +36,19 @@
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
     "@remix-run/terminal": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/logger-middleware/src/lib/logger.ts
+++ b/packages/logger-middleware/src/lib/logger.ts
@@ -16,7 +16,7 @@ export interface LoggerFunction {
  * Context key used to read the current request logger with `context.get(Logger)`.
  * The `logger()` middleware also installs the logger as `context.logger`.
  */
-export const Logger = createContextKey<LoggerFunction>()
+export const Logger: { defaultValue?: LoggerFunction } = createContextKey<LoggerFunction>()
 
 /**
  * Options for the {@link logger} middleware.

--- a/packages/logger-middleware/tsconfig.build.json
+++ b/packages/logger-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/logger-middleware/tsconfig.json
+++ b/packages/logger-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/method-override-middleware/package.json
+++ b/packages/method-override-middleware/package.json
@@ -37,18 +37,18 @@
     "@remix-run/form-data-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/method-override-middleware/tsconfig.build.json
+++ b/packages/method-override-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/method-override-middleware/tsconfig.json
+++ b/packages/method-override-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/mime/package.json
+++ b/packages/mime/package.json
@@ -35,17 +35,17 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "mime-db": "^1.53.0"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "codegen": "node ./scripts/codegen.ts",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "mime",

--- a/packages/mime/tsconfig.build.json
+++ b/packages/mime/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/mime/tsconfig.json
+++ b/packages/mime/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/multipart-parser/demos/bun/package.json
+++ b/packages/multipart-parser/demos/bun/package.json
@@ -9,10 +9,10 @@
   "devDependencies": {
     "@types/bun": "^1.1.6",
     "@types/tmp": "^0.2.6",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "start": "bun run server.ts",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/multipart-parser/demos/bun/tsconfig.json
+++ b/packages/multipart-parser/demos/bun/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["bun"],
     // Enable latest features
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",

--- a/packages/multipart-parser/demos/cf-workers/package.json
+++ b/packages/multipart-parser/demos/cf-workers/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "wrangler": "^4.90.1"
   },
   "scripts": {
@@ -16,6 +16,6 @@
     "dev": "wrangler dev --port 44100",
     "start": "wrangler dev --port 44100",
     "cf-typegen": "wrangler types",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/multipart-parser/demos/node/package.json
+++ b/packages/multipart-parser/demos/node/package.json
@@ -9,10 +9,10 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/tmp": "^0.2.6",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "start": "node server.js",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/multipart-parser/package.json
+++ b/packages/multipart-parser/package.json
@@ -43,7 +43,7 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "bench": "pnpm run bench:node && pnpm run bench:bun && pnpm run bench:deno",
@@ -53,12 +53,12 @@
     "bench:node:single": "node ./bench/runner.ts",
     "bench:node:profile": "node --cpu-prof --heap-prof ./bench/runner.ts",
     "bench:node:steady": "node --expose-gc ./bench/runner.ts --steady --metrics",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "multipart",

--- a/packages/multipart-parser/tsconfig.build.json
+++ b/packages/multipart-parser/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/multipart-parser/tsconfig.json
+++ b/packages/multipart-parser/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/node-fetch-server/demos/http2/package.json
+++ b/packages/node-fetch-server/demos/http2/package.json
@@ -7,9 +7,9 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/node-fetch-server/package.json
+++ b/packages/node-fetch-server/package.json
@@ -38,17 +38,17 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "bench": "bash ./bench/runner.sh",
-    "bench:typecheck": "tsgo --noEmit -p ./bench/tsconfig.json",
+    "bench:typecheck": "tsc --noEmit -p ./bench/tsconfig.json",
     "bench:update-readme": "node ./bench/update-readme.ts",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "http",

--- a/packages/node-fetch-server/tsconfig.build.json
+++ b/packages/node-fetch-server/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/node-fetch-server/tsconfig.json
+++ b/packages/node-fetch-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/node-tsx/package.json
+++ b/packages/node-tsx/package.json
@@ -40,11 +40,11 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "get-tsconfig": "^4.13.6",
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "keywords": [
     "remix",

--- a/packages/render-middleware/package.json
+++ b/packages/render-middleware/package.json
@@ -36,18 +36,18 @@
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/render-middleware/src/lib/render.ts
+++ b/packages/render-middleware/src/lib/render.ts
@@ -23,7 +23,7 @@ export type AnyRenderer = Renderer<never, never>
  * Context key used to read the current request renderer with `context.get(Renderer)`.
  * The `renderWith()` middleware also installs the renderer as `context.render`.
  */
-export const Renderer = createContextKey<AnyRenderer>()
+export const Renderer: { defaultValue?: AnyRenderer } = createContextKey<AnyRenderer>()
 
 type RendererFactory<renderer extends AnyRenderer> = (context: RequestContext<any, any>) => renderer
 

--- a/packages/render-middleware/tsconfig.build.json
+++ b/packages/render-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/render-middleware/tsconfig.json
+++ b/packages/render-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -52,7 +52,7 @@
     "@remix-run/mime": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/headers": "workspace:^",
@@ -60,12 +60,12 @@
     "@remix-run/mime": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/response/src/lib/html.ts
+++ b/packages/response/src/lib/html.ts
@@ -83,9 +83,11 @@ function prependDoctypeToStream(stream: ReadableStream<Uint8Array>): ReadableStr
 
         // Pass through remaining chunks
         while (true) {
-          let { done, value } = await reader.read()
-          if (done) break
-          controller.enqueue(value)
+          // Keep the result intact so TypeScript 7 can narrow value from done. The abortable UI
+          // stream uses the same pattern.
+          let result = await reader.read()
+          if (result.done) break
+          controller.enqueue(result.value)
         }
 
         controller.close()

--- a/packages/response/tsconfig.build.json
+++ b/packages/response/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/response/tsconfig.json
+++ b/packages/response/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/route-pattern/bench/package.json
+++ b/packages/route-pattern/bench/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@ark/attest": "^0.56.0",
-    "typescript": "catalog:legacy-typescript",
+    "typescript": "6.0.3",
     "vite": "7.3.3",
     "vitest": "4.1.6"
   }

--- a/packages/route-pattern/bench/package.json
+++ b/packages/route-pattern/bench/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@ark/attest": "^0.56.0",
+    "typescript": "catalog:legacy-typescript",
     "vite": "7.3.3",
     "vitest": "4.1.6"
   }

--- a/packages/route-pattern/package.json
+++ b/packages/route-pattern/package.json
@@ -58,16 +58,16 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "dedent": "^1.7.1"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "route",

--- a/packages/route-pattern/tsconfig.build.json
+++ b/packages/route-pattern/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/route-pattern/tsconfig.json
+++ b/packages/route-pattern/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",
@@ -11,5 +12,5 @@
     "erasableSyntaxOnly": true,
     "isolatedModules": true
   },
-  "exclude": ["vendor", "dist"]
+  "exclude": ["bench", "vendor", "dist"]
 }

--- a/packages/session-middleware/package.json
+++ b/packages/session-middleware/package.json
@@ -39,7 +39,7 @@
     "@remix-run/session": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/cookie": "workspace:^",
@@ -47,12 +47,12 @@
     "@remix-run/session": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/session-middleware/tsconfig.build.json
+++ b/packages/session-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/session-middleware/tsconfig.json
+++ b/packages/session-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/session-storage-memcache/package.json
+++ b/packages/session-storage-memcache/package.json
@@ -38,15 +38,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "session",

--- a/packages/session-storage-memcache/tsconfig.build.json
+++ b/packages/session-storage-memcache/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/session-storage-memcache/tsconfig.json
+++ b/packages/session-storage-memcache/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/session-storage-redis/package.json
+++ b/packages/session-storage-redis/package.json
@@ -35,7 +35,7 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "redis": "^5.10.0"
   },
   "dependencies": {
@@ -50,12 +50,12 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "session",

--- a/packages/session-storage-redis/tsconfig.build.json
+++ b/packages/session-storage-redis/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -50,15 +50,15 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "session",

--- a/packages/session/tsconfig.build.json
+++ b/packages/session/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/session/tsconfig.json
+++ b/packages/session/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/static-middleware/demos/list-files/package.json
+++ b/packages/static-middleware/demos/list-files/package.json
@@ -9,11 +9,11 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "dev": "node --watch server.js",
     "start": "node server.js",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -40,7 +40,7 @@
     "@remix-run/response": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@remix-run/fetch-router": "workspace:^",
@@ -50,12 +50,12 @@
     "@remix-run/response": "workspace:^"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/static-middleware/tsconfig.build.json
+++ b/packages/static-middleware/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/static-middleware/tsconfig.json
+++ b/packages/static-middleware/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/tar-parser/package.json
+++ b/packages/tar-parser/package.json
@@ -36,16 +36,16 @@
     "@remix-run/fs": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "bench": "node ./bench/runner.ts",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "tar",

--- a/packages/tar-parser/tsconfig.build.json
+++ b/packages/tar-parser/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/tar-parser/tsconfig.json
+++ b/packages/tar-parser/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -33,14 +33,14 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "node --disable-warning=ExperimentalWarning --test './src/**/*.test.ts'",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "terminal",

--- a/packages/terminal/tsconfig.build.json
+++ b/packages/terminal/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist"

--- a/packages/terminal/tsconfig.json
+++ b/packages/terminal/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -41,12 +41,12 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test --type server",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@remix-run/node-tsx": "workspace:^",
@@ -78,7 +78,7 @@
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-reports": "^3.0.4",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "clsx": "2.1.1",
     "decamelize": "6.0.1",
     "playwright": "catalog:"

--- a/packages/ui/demo/package.json
+++ b/packages/ui/demo/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "esbuild": "^0.25.10",
     "node-html-parser": "^7.0.2"
   },

--- a/packages/ui/demo/tsconfig.json
+++ b/packages/ui/demo/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "dom-navigation"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -242,9 +242,8 @@
     "@remix-run/assert": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
     "playwright": "catalog:",
-    "typescript": "^5.9.3"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@types/dom-navigation": "^1.0.7"

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1256,14 +1256,14 @@ function createAbortableReadableStream(
         signal.addEventListener('abort', onAbortRead, { once: true })
       })
 
-      let { done, value } = await Promise.race([reader.read(), abortRead])
+      let result = await Promise.race([reader.read(), abortRead])
       removeAbortReadListener?.()
 
-      if (done) {
+      if (result.done) {
         controller.close()
         return
       }
-      controller.enqueue(value)
+      controller.enqueue(result.value)
     },
     cancel(reason) {
       signal.removeEventListener('abort', onAbort)

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "dom-navigation"],
     "strict": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "NodeNext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@types/node':
       specifier: ^24.6.0
       version: 24.10.4
-    '@typescript/native-preview':
-      specifier: 7.0.0-dev.20251125.1
-      version: 7.0.0-dev.20251125.1
     github-slugger:
       specifier: 2.0.0
       version: 2.0.0
@@ -31,11 +28,12 @@ catalogs:
       specifier: 4.4.1
       version: 4.4.1
     typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
-    typescript-language-server:
-      specifier: ^5.1.3
-      version: 5.1.3
+      specifier: ^7.0.2
+      version: 7.0.2
+  legacy-typescript:
+    typescript:
+      specifier: ^6.0.3
+      version: 6.0.3
 
 importers:
 
@@ -44,9 +42,6 @@ importers:
       '@oxlint/plugins':
         specifier: ^1.57.0
         version: 1.57.0
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       oxc-parser:
         specifier: ^0.121.0
         version: 0.121.0
@@ -64,10 +59,7 @@ importers:
         version: link:packages/remix
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
-      typescript-language-server:
-        specifier: 'catalog:'
-        version: 5.1.3
+        version: 7.0.2
 
   demos/assets:
     dependencies:
@@ -81,9 +73,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/bookstore:
     dependencies:
@@ -97,12 +89,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   demos/frame-navigation:
     dependencies:
@@ -116,9 +108,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/frames:
     dependencies:
@@ -132,9 +124,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/social-auth:
     dependencies:
@@ -145,9 +137,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/sse:
     dependencies:
@@ -161,9 +153,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/timeboxer:
     dependencies:
@@ -174,9 +166,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   demos/unpkg:
     dependencies:
@@ -193,9 +185,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   docs/api:
     dependencies:
@@ -232,10 +224,10 @@ importers:
         version: 4.4.1
       typedoc:
         specifier: 0.28.19
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        specifier: catalog:legacy-typescript
+        version: 6.0.3
 
   docs/guides:
     dependencies:
@@ -265,8 +257,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.2
       typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
+        specifier: catalog:legacy-typescript
+        version: 6.0.3
 
   docs/shared:
     dependencies:
@@ -321,7 +313,7 @@ importers:
         version: 24.10.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 7.0.2
 
   docs/shared/prerender/bench:
     dependencies:
@@ -341,9 +333,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/assets:
     dependencies:
@@ -408,9 +400,9 @@ importers:
       '@types/picomatch':
         specifier: ^4.0.3
         version: 4.0.3
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/assets/bench:
     dependencies:
@@ -429,7 +421,7 @@ importers:
         version: 24.10.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 7.0.2
 
   packages/async-context-middleware:
     dependencies:
@@ -446,9 +438,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/auth:
     dependencies:
@@ -483,9 +475,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/auth-middleware:
     dependencies:
@@ -511,9 +503,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/cli:
     dependencies:
@@ -545,9 +537,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/cli/test/fixtures/doctor-camel-case-keys:
     dependencies:
@@ -662,9 +654,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/cookie:
     dependencies:
@@ -681,9 +673,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/cop-middleware:
     dependencies:
@@ -700,9 +692,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/cors-middleware:
     dependencies:
@@ -722,9 +714,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/csrf-middleware:
     dependencies:
@@ -753,9 +745,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/data-schema:
     dependencies:
@@ -772,9 +764,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/data-table:
     devDependencies:
@@ -787,9 +779,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/data-table-mysql:
     dependencies:
@@ -806,12 +798,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       mysql2:
         specifier: ^3.15.3
         version: 3.16.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/data-table-postgres:
     dependencies:
@@ -831,12 +823,12 @@ importers:
       '@types/pg':
         specifier: ^8.15.6
         version: 8.16.0
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       pg:
         specifier: ^8.16.3
         version: 8.18.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/data-table-sqlite:
     dependencies:
@@ -853,9 +845,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/fetch-proxy:
     dependencies:
@@ -875,9 +867,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
       undici:
         specifier: ^7.24.8
         version: 7.24.8
@@ -897,9 +889,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/fetch-router/demos/bun:
     dependencies:
@@ -934,9 +926,9 @@ importers:
       '@types/bun':
         specifier: ^1.1.8
         version: 1.1.8
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/fetch-router/demos/cf-workers:
     dependencies:
@@ -971,9 +963,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
       wrangler:
         specifier: ^4.90.1
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
@@ -1014,9 +1006,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/file-storage:
     dependencies:
@@ -1039,9 +1031,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/file-storage-s3:
     dependencies:
@@ -1061,9 +1053,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/form-data-middleware:
     dependencies:
@@ -1083,9 +1075,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/form-data-parser:
     dependencies:
@@ -1105,9 +1097,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/form-data-parser/demos/node:
     dependencies:
@@ -1127,9 +1119,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/fs:
     dependencies:
@@ -1149,9 +1141,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/headers:
     devDependencies:
@@ -1164,9 +1156,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/html-template:
     devDependencies:
@@ -1179,9 +1171,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/lazy-file:
     dependencies:
@@ -1198,9 +1190,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/logger-middleware:
     dependencies:
@@ -1220,9 +1212,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/method-override-middleware:
     dependencies:
@@ -1242,9 +1234,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/mime:
     devDependencies:
@@ -1257,12 +1249,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       mime-db:
         specifier: ^1.53.0
         version: 1.54.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/multipart-parser:
     dependencies:
@@ -1279,9 +1271,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/multipart-parser/bench:
     dependencies:
@@ -1320,9 +1312,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/multipart-parser/demos/cf-workers:
     dependencies:
@@ -1336,9 +1328,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
       wrangler:
         specifier: ^4.90.1
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
@@ -1371,18 +1363,18 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/node-fetch-server:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/node-fetch-server/bench:
     dependencies:
@@ -1406,9 +1398,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/node-tsx:
     dependencies:
@@ -1422,9 +1414,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/remix:
     dependencies:
@@ -1581,7 +1573,7 @@ importers:
         version: 24.10.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 7.0.2
 
   packages/render-middleware:
     dependencies:
@@ -1598,9 +1590,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/response:
     dependencies:
@@ -1626,9 +1618,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/route-pattern:
     devDependencies:
@@ -1641,12 +1633,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       dedent:
         specifier: ^1.7.1
         version: 1.7.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/route-pattern/bench:
     dependencies:
@@ -1662,7 +1654,10 @@ importers:
     devDependencies:
       '@ark/attest':
         specifier: ^0.56.0
-        version: 0.56.0(typescript@5.9.3)
+        version: 0.56.0(typescript@6.0.3)
+      typescript:
+        specifier: catalog:legacy-typescript
+        version: 6.0.3
       vite:
         specifier: 7.3.3
         version: 7.3.3(@types/node@24.10.4)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -1681,9 +1676,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/session-middleware:
     dependencies:
@@ -1709,9 +1704,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/session-storage-memcache:
     dependencies:
@@ -1728,9 +1723,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/session-storage-redis:
     dependencies:
@@ -1747,12 +1742,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       redis:
         specifier: ^5.10.0
         version: 5.11.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/static-middleware:
     dependencies:
@@ -1787,9 +1782,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/static-middleware/demos/list-files:
     dependencies:
@@ -1806,9 +1801,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/tar-parser:
     devDependencies:
@@ -1824,9 +1819,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/tar-parser/bench:
     dependencies:
@@ -1861,9 +1856,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
+      typescript:
         specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
+        version: 7.0.2
 
   packages/test:
     dependencies:
@@ -1925,9 +1920,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -1937,6 +1929,9 @@ importers:
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/ui:
     dependencies:
@@ -1953,15 +1948,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 'catalog:'
+        version: 7.0.2
 
   packages/ui/bench:
     dependencies:
@@ -2065,15 +2057,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       esbuild:
         specifier: ^0.25.10
         version: 0.25.12
       node-html-parser:
         specifier: ^7.0.2
         version: 7.1.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   scripts:
     dependencies:
@@ -2092,12 +2084,12 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20251125.1
       semver:
         specifier: ^7.6.3
         version: 7.6.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -2113,7 +2105,7 @@ importers:
         version: 24.10.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 7.0.2
 
 packages:
 
@@ -4329,44 +4321,125 @@ packages:
     resolution: {integrity: sha512-RnlSOPh14QbopGCApgkSx5UBgGda5MX1cHqp2fsqfiDyCwGL/m1jaeB9fzu7didVS81LQqGZZuxFBcg8YU8EVw==}
     hasBin: true
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-8fkL3vtHtrKoj8LGrsEfvZDNLd47ScCVOVyC+vn4t3SNGo6eLvHqaBUd5WlBEVLHAO6o71BDS4hHDNGiMc0hEA==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-Odq4ZtNOzlpTbjRpdP5AaCfVRVx0L05F7cI3UpPQgXjxJejKin14z6r+k2qlo77pwnpaviM2fou+hbNX5cj1oQ==}
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-YiM49tIFLfq0LHfPVhSufBABsyS79OqurRZwznkFUiv4HHFWuZ66Ne1w2eXzv3BeZkDOnPtrkmZ+ZSAeYtoEhw==}
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-abP56lp5GIDizVjQ3/36mryOawUTY+ODtw/rUJ+XMnH/zy6OSNS4g8z8XsmTnizsLLaWrrAYD3+PCdi0c6ra8w==}
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-nl0itKQowgb4snWPH4LjkdSzMIalG+qDoheAqadMEDUekKexNTmUAqbK0+qje0jsW9Jc/1+MCQHIcDr20abkzA==}
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-99AZ4Lv0Ez/RqtCszFDWCE+8Qrzjjw1Bsq2DYRnszeTIbwvr3I6x3edk2gr8/EuulrQLv7fzcintyp3EQgeZlQ==}
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-f483lMqW97udDCG0Deotbcmr+khmvcr9U0i5DB6z1ePjIVk8HkvdoFDnKuzSdtov0KvqPGkyRui0Vdqy/IwYJQ==}
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20251125.1':
-    resolution: {integrity: sha512-E1EboijTfMS99duAYDzPiIHzJDXA1xEj4UHvpjarlniYYmCFO/Rla4boiRBMns4eXNNkyEkvU4WSkjpOl0fzTg==}
-    hasBin: true
 
   '@typescript/vfs@1.6.1':
     resolution: {integrity: sha512-JwoxboBh7Oz1v38tPbkrZ62ZXNHAk9bJ7c9x0eI5zBfBnBYGhURdbnh7Z4smN/MV48Y5OCcZb58n972UtbazsA==}
@@ -5898,14 +5971,14 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typescript-language-server@5.1.3:
-    resolution: {integrity: sha512-r+pAcYtWdN8tKlYZPwiiHNA2QPjXnI02NrW5Sf2cVM3TRtuQ3V9EKKwOxqwaQ0krsaEXk/CbN90I5erBuf84Vg==}
-    engines: {node: '>=20'}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -6087,20 +6160,6 @@ packages:
       jsdom:
         optional: true
 
-  vscode-jsonrpc@5.0.1:
-    resolution: {integrity: sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==}
-    engines: {node: '>=8.0.0 || >=10.0.0'}
-
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -6183,16 +6242,16 @@ packages:
 
 snapshots:
 
-  '@ark/attest@0.56.0(typescript@5.9.3)':
+  '@ark/attest@0.56.0(typescript@6.0.3)':
     dependencies:
       '@ark/fs': 0.56.0
       '@ark/util': 0.56.0
       '@prettier/sync': 0.6.1(prettier@3.6.2)
       '@typescript/analyze-trace': 0.10.1
-      '@typescript/vfs': 1.6.1(typescript@5.9.3)
+      '@typescript/vfs': 1.6.1(typescript@6.0.3)
       arktype: 2.1.28
       prettier: 3.6.2
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7655,41 +7714,70 @@ snapshots:
       treeify: 1.1.0
       yargs: 16.2.0
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-darwin-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-darwin-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20251125.1':
+  '@typescript/typescript-freebsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-freebsd-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-linux-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20251125.1':
+  '@typescript/typescript-linux-arm@7.0.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20251125.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251125.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20251125.1
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
 
-  '@typescript/vfs@1.6.1(typescript@5.9.3)':
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/vfs@1.6.1(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9694,21 +9782,39 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typedoc@0.28.19(typescript@5.9.3):
+  typedoc@0.28.19(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 10.2.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
-  typescript-language-server@5.1.3:
-    dependencies:
-      vscode-jsonrpc: 5.0.1
-      vscode-languageserver-protocol: 3.17.5
+  typescript@6.0.3: {}
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
 
@@ -9863,17 +9969,6 @@ snapshots:
       '@types/node': 24.10.4
     transitivePeerDependencies:
       - msw
-
-  vscode-jsonrpc@5.0.1: {}
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-types@3.17.5: {}
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,6 @@ catalogs:
     typescript:
       specifier: ^7.0.2
       version: 7.0.2
-  legacy-typescript:
-    typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
 
 importers:
 
@@ -226,7 +222,7 @@ importers:
         specifier: 0.28.19
         version: 0.28.19(typescript@6.0.3)
       typescript:
-        specifier: catalog:legacy-typescript
+        specifier: 6.0.3
         version: 6.0.3
 
   docs/guides:
@@ -257,7 +253,7 @@ importers:
         specifier: 'catalog:'
         version: 1.5.2
       typescript:
-        specifier: catalog:legacy-typescript
+        specifier: 6.0.3
         version: 6.0.3
 
   docs/shared:
@@ -1656,7 +1652,7 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(typescript@6.0.3)
       typescript:
-        specifier: catalog:legacy-typescript
+        specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 7.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,14 +7,16 @@ allowBuilds:
 catalog:
   '@types/hast': 3.0.5
   '@types/node': ^24.6.0
-  '@typescript/native-preview': 7.0.0-dev.20251125.1
   github-slugger: 2.0.0
   oxfmt: ^0.51.0
   pagefind: 1.5.2
   playwright: ^1.60.0
   shiki: 4.4.1
-  typescript: ^5.9.3
-  typescript-language-server: ^5.1.3
+  typescript: ^7.0.2
+
+catalogs:
+  legacy-typescript:
+    typescript: ^6.0.3
 
 packages:
   - demos/*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,10 +14,6 @@ catalog:
   shiki: 4.4.1
   typescript: ^7.0.2
 
-catalogs:
-  legacy-typescript:
-    typescript: ^6.0.3
-
 packages:
   - demos/*
   - docs/api

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,12 +8,12 @@
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
     "@types/semver": "^7.5.8",
-    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
     "semver": "^7.6.3",
     "yaml": "^2.9.0"
   },
   "scripts": {
     "test": "remix test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsc --noEmit"
   }
 }


### PR DESCRIPTION
TypeScript 7 is now available as a stable release, so the repository no longer needs the `@typescript/native-preview` package or `tsgo` commands introduced in [#10863](https://github.com/remix-run/remix/pull/10863). This moves builds and type checks to the official `typescript@7.0.2` package and `tsc` command.

- Replace the native preview dependency throughout the workspace and remove the legacy `typescript-language-server` integration.
- Declare ambient `types` and build `rootDir` values explicitly where required by TypeScript 7.
- Address stricter stream-result narrowing, route inference, and portable declaration emit checks.
- Pin TypeScript 6.0.3 only for the docs tooling and route-pattern type benchmarks that still depend on the legacy compiler API. Their regular type checks continue to use the root TypeScript 7 compiler where applicable.
