### PR TITLE
Add rmx-history navigation attribute

### DIFF
--- a/.agents/skills/remix/references/hydration-frames-navigation.md
+++ b/.agents/skills/remix/references/hydration-frames-navigation.md
@@ -214,11 +214,12 @@ When `run({ resolveFrame })` is active, eligible same-origin forms progressively
 - Forms target `handle.frames.top` by default.
 - `rmx-target` selects a named frame.
 - `rmx-src` selects a different frame request URL while preserving the form action as the navigation destination.
+- `rmx-history="push|replace"` overrides how the navigation updates history.
 - `rmx-reset-scroll="false"` preserves scroll position.
 - `rmx-document` opts back into a document submission.
 - Cross-origin forms, `method="dialog"`, and `target="_blank"` remain browser-owned.
 
-GET controls are already encoded in `src`, so GET forms reach the resolver like links. Non-GET forms provide their native `FormData`, effective method, and encoding. The resolver owns body encoding and method-override conventions. Non-GET submissions to the current URL replace its history entry; GET submissions and submissions to a different URL push one.
+GET controls are already encoded in `src`, so GET forms reach the resolver like links. Non-GET forms provide their native `FormData`, effective method, and encoding. The resolver owns body encoding and method-override conventions. Non-GET submissions to the current URL replace its history entry; GET submissions and submissions to a different URL push one. The `rmx-history` attribute overrides those defaults.
 
 ### Nested frames
 
@@ -283,7 +284,7 @@ navigate('/dashboard', { history: 'replace' })
 
 Options: `src`, `target`, `history` (`'push' | 'replace'`), `resetScroll`.
 
-Attributes understood by the runtime: `rmx-target`, `rmx-src`, `rmx-reset-scroll`, `rmx-document`.
+Attributes understood by the runtime: `rmx-target`, `rmx-src`, `rmx-history`, `rmx-reset-scroll`, `rmx-document`.
 
 ## Head Management
 

--- a/.agents/skills/remix/references/mixins-styling-events.md
+++ b/.agents/skills/remix/references/mixins-styling-events.md
@@ -115,6 +115,8 @@ Adds client-side navigation behavior to any element. Makes non-anchor elements b
 
 Options match `NavigationOptions`: `src`, `target`, `history` (`'push' | 'replace'`), `resetScroll`.
 
+On a native anchor, the `history` option renders the corresponding `rmx-history="push|replace"` attribute so the enhanced navigation uses the same history behavior.
+
 ## Native press and keyboard interactions
 
 Use native DOM events directly with `on(...)`. For buttons and links, `click` already includes keyboard activation when the element has the right semantics:

--- a/demos/frame-navigation/app/actions/main/account/edit/edit-page.tsx
+++ b/demos/frame-navigation/app/actions/main/account/edit/edit-page.tsx
@@ -26,12 +26,7 @@ export function AccountEditor(handle: Handle<AccountEditorProps>) {
           resets when the demo server restarts.
         </p>
 
-        <form
-          method="POST"
-          action={routes.main.account.edit.action.href()}
-          rmx-target={frames.account}
-          mix={formStyle}
-        >
+        <form method="POST" action={routes.main.account.edit.action.href()} mix={formStyle}>
           <FormField
             label="Display name"
             name="displayName"

--- a/demos/frame-navigation/app/actions/main/courses-page.tsx
+++ b/demos/frame-navigation/app/actions/main/courses-page.tsx
@@ -34,6 +34,7 @@ export function MainCoursesPage(handle: Handle<MainCoursesPageProps>) {
           method="GET"
           action={routes.main.courses.href()}
           rmx-target={frames.courses}
+          rmx-history="replace"
           mix={filterFormStyle}
         >
           <label for="course-filter" mix={filterLabelStyle}>

--- a/demos/frame-navigation/app/app.test.e2e.ts
+++ b/demos/frame-navigation/app/app.test.e2e.ts
@@ -1,0 +1,200 @@
+import * as assert from 'remix/assert'
+import { SetCookie } from 'remix/headers/set-cookie'
+import { createTestServer } from 'remix/node-fetch-server/test'
+import { describe, it } from 'remix/test'
+import type { Page } from 'playwright'
+
+import { authCookie } from './middleware/auth.ts'
+import { router } from './router.ts'
+import { routes } from './routes.ts'
+
+declare global {
+  interface Window {
+    __frameNavigationTestDocument?: string
+  }
+}
+
+describe('frame navigation', () => {
+  it('redirects unauthenticated requests to sign in', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
+
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    await page.getByRole('heading', { name: 'Fake login page' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.auth.login.index.href())
+  })
+
+  it('signs in without reloading the document', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+
+    await page.getByRole('button', { name: 'Set auth cookie' }).click()
+    await page.getByRole('heading', { name: 'Learning dashboard' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.main.index.href())
+    await assertDocumentPreserved(page, documentMarker)
+  })
+
+  it('navigates without reloading the document and supports back navigation', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    await setAuthCookie(page, server.baseUrl)
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+
+    await page.getByRole('link', { name: 'Courses', exact: true }).click()
+    await page.locator('#courses-heading').waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.main.courses.href())
+    await assertDocumentPreserved(page, documentMarker)
+
+    await page.goBack()
+    await page.getByRole('heading', { name: 'Learning dashboard' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.main.index.href())
+    await assertDocumentPreserved(page, documentMarker)
+  })
+
+  it('replaces history when filtering courses', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    await setAuthCookie(page, server.baseUrl)
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+
+    await page.getByRole('link', { name: 'Courses', exact: true }).click()
+    await page.locator('#courses-heading').waitFor()
+    await page.getByLabel('Filter courses').fill('accessibility')
+    await page.getByRole('button', { name: 'Filter', exact: true }).click()
+    await page.getByText('1 course matching “accessibility”', { exact: true }).waitFor()
+
+    let filteredUrl = new URL(page.url())
+    assert.equal(filteredUrl.pathname, routes.main.courses.href())
+    assert.equal(filteredUrl.searchParams.get('q'), 'accessibility')
+    await assertDocumentPreserved(page, documentMarker)
+
+    await page.goBack()
+    await page.getByRole('heading', { name: 'Learning dashboard' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.main.index.href())
+    await assertDocumentPreserved(page, documentMarker)
+  })
+
+  it('submits a form and follows its redirect without reloading the document', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    await setAuthCookie(page, server.baseUrl)
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+
+    await page.getByRole('link', { name: 'Account', exact: true }).click()
+    await page.locator('#account-heading').waitFor()
+    await page.getByRole('link', { name: 'Edit', exact: true }).click()
+    await page.getByRole('heading', { name: 'Edit account' }).waitFor()
+
+    await page.getByLabel('Display name').fill('Ada Lovelace')
+    await page.getByLabel('Program').fill('Computer Science')
+    await page.getByLabel('Expected graduation').fill('2028-06')
+
+    let submission = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        new URL(request.url()).pathname === routes.main.account.edit.action.href(),
+    )
+    await page.getByRole('button', { name: 'Save account' }).click()
+    await submission
+    await page.getByText('Account saved', { exact: true }).waitFor()
+
+    let url = new URL(page.url())
+    assert.equal(url.pathname, routes.main.account.index.href())
+    assert.equal(url.searchParams.has('saved'), true)
+    assert.equal(await page.getByText('Ada Lovelace', { exact: true }).count(), 1)
+    await assertDocumentPreserved(page, documentMarker)
+  })
+
+  it('follows a frame redirect without reloading the document', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    await setAuthCookie(page, server.baseUrl)
+    await page.goto(routes.main.index.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+
+    await page.getByRole('link', { name: 'Settings', exact: true }).click()
+    await page.waitForURL((url) => url.pathname === routes.settings.overview.href())
+    await page.getByRole('heading', { name: 'Settings overview' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.settings.overview.href())
+    await assertDocumentPreserved(page, documentMarker)
+  })
+
+  it('reloads the document when a subframe redirects to sign in', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    await setAuthCookie(page, server.baseUrl)
+    await page.goto(routes.settings.overview.href())
+    await waitForNavigationRuntime(page)
+    let documentMarker = await markDocument(page)
+    await page.context().clearCookies()
+
+    await page.getByRole('link', { name: 'Profile', exact: true }).click()
+    await page.getByRole('heading', { name: 'Fake login page' }).waitFor()
+
+    assert.equal(new URL(page.url()).pathname, routes.auth.login.index.href())
+    await assertDocumentReplaced(page, documentMarker)
+  })
+})
+
+async function setAuthCookie(page: Page, baseUrl: string): Promise<void> {
+  let cookie = new SetCookie(await authCookie.serialize('1'))
+  assert.ok(cookie.name)
+  assert.ok(cookie.value)
+
+  await page.context().addCookies([
+    {
+      name: cookie.name,
+      value: cookie.value,
+      url: baseUrl,
+      httpOnly: cookie.httpOnly,
+      sameSite: cookie.sameSite,
+      secure: cookie.secure,
+    },
+  ])
+}
+
+async function waitForNavigationRuntime(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    let state = window.navigation.currentEntry?.getState()
+    return typeof state === 'object' && state != null && '$rmx' in state
+  })
+}
+
+async function markDocument(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    let marker = crypto.randomUUID()
+    window.__frameNavigationTestDocument = marker
+    return marker
+  })
+}
+
+async function assertDocumentPreserved(page: Page, marker: string): Promise<void> {
+  assert.equal(
+    await page.evaluate(() => window.__frameNavigationTestDocument),
+    marker,
+    'expected frame navigation to preserve the current document',
+  )
+}
+
+async function assertDocumentReplaced(page: Page, marker: string): Promise<void> {
+  assert.notEqual(
+    await page.evaluate(() => window.__frameNavigationTestDocument),
+    marker,
+    'expected document navigation to replace the current document',
+  )
+}

--- a/demos/frame-navigation/app/assets/entry.tsx
+++ b/demos/frame-navigation/app/assets/entry.tsx
@@ -38,8 +38,10 @@ async function resolveFrameResponse(
     signal: options?.signal,
   })
 
-  if (res.status === 401) {
-    window.location.assign(routes.auth.login.index.href())
+  // A redirected response may contain document UI that is not valid for the requested subframe.
+  // The destination opts into subframe rendering by returning the matching target header.
+  if (res.redirected && options?.target) {
+    window.location.assign(res.url)
     return new Promise<never>(() => {})
   }
 

--- a/demos/frame-navigation/app/middleware/auth.ts
+++ b/demos/frame-navigation/app/middleware/auth.ts
@@ -36,21 +36,6 @@ export function loadAuth() {
 
 export const requireAuth = requireAuthenticated<FrameAuthIdentity>({
   onFailure(context) {
-    let isSubFrameRequest =
-      context.request.headers.get('X-Remix-Frame') === 'true' &&
-      context.request.headers.get('X-Remix-Target') != null
-    if (isSubFrameRequest) {
-      return new Response(
-        '<div><h1>Not authorized</h1><p>Refresh the page to sign in again.</p></div>',
-        {
-          status: 401,
-          headers: {
-            'Content-Type': 'text/html; charset=UTF-8',
-          },
-        },
-      )
-    }
-
     return redirect(routes.auth.login.index.href())
   },
 })

--- a/demos/frame-navigation/package.json
+++ b/demos/frame-navigation/package.json
@@ -11,11 +11,13 @@
   "devDependencies": {
     "@types/dom-navigation": "^1.0.7",
     "@types/node": "catalog:",
+    "playwright": "catalog:",
     "typescript": "catalog:"
   },
   "scripts": {
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",
     "start": "node --import remix/node-tsx server.ts",
+    "test": "NODE_ENV=test remix test",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/docs/guides/app/actions/docs/chapters/05-interactivity.md
+++ b/docs/guides/app/actions/docs/chapters/05-interactivity.md
@@ -701,6 +701,7 @@ the `link(...)` and `navigate(...)` options:
 
 - `rmx-target` names the frame to reload.
 - `rmx-src` provides the URL to fetch for that frame while `href` remains the browser's destination.
+- `rmx-history="push|replace"` controls how the navigation updates history, including overriding a form's default.
 - `rmx-reset-scroll="false"` preserves the current scroll position.
 - `rmx-document` opts out of interception and lets the browser perform a full-document navigation.
 

--- a/docs/guides/app/actions/docs/chapters/06-streaming-ui-with-frames.md
+++ b/docs/guides/app/actions/docs/chapters/06-streaming-ui-with-frames.md
@@ -281,13 +281,14 @@ handler:
 The form remains a normal document navigation before the runtime starts. Native constraint
 validation and the form's `submit` event run before Remix intercepts it. `rmx-target` chooses a named
 frame, `rmx-src` can provide a different frame request URL, `rmx-reset-scroll="false"` preserves the
-current scroll position, and `rmx-document` opts out of interception.
+current scroll position, and `rmx-document` opts out of interception. `rmx-history="push|replace"`
+controls how the navigation updates history.
 
 GET controls are already encoded in the destination URL. For non-GET forms, `resolveFrame` receives
 `formData`, `method`, and `encType`. The action should return HTML for the targeted frame when it
 receives a frame request, while keeping its normal document response or redirect for unenhanced
 submissions. Non-GET submissions to the current URL replace that history entry; GET submissions and
-submissions to a different URL push one.
+submissions to a different URL push one. The `rmx-history` attribute overrides those defaults.
 
 ## Coordinate a mutation and a separate frame reload {#coordinating-forms-fetches-frame-reloads-and-navigation}
 
@@ -353,8 +354,8 @@ A link can keep its public destination in `href` while loading a smaller route i
 ```
 
 `rmx-target` chooses the frame, while `rmx-src` chooses the request used to fill it. The address bar
-still moves to `href`. Use `rmx-document` when a same-origin link must perform an ordinary document
-navigation instead.
+still moves to `href`. Add `rmx-history="replace"` when it should replace the current history entry. Use
+`rmx-document` when a same-origin link must perform an ordinary document navigation instead.
 
 ## Handle failures and cancellation
 

--- a/packages/remix/.changes/minor.ui.rmx-history-navigation.md
+++ b/packages/remix/.changes/minor.ui.rmx-history-navigation.md
@@ -1,0 +1,1 @@
+Enhanced navigations through `remix/ui` now support `rmx-history="push|replace"` on anchors and forms to override how they update browser history. Native anchors using `link(href, { history })` emit the corresponding attribute value automatically.

--- a/packages/ui/.changes/minor.rmx-history-navigation.md
+++ b/packages/ui/.changes/minor.rmx-history-navigation.md
@@ -1,0 +1,1 @@
+Add an `rmx-history="push|replace"` attribute for anchors and forms that overrides the history behavior of enhanced frame navigations. Native anchors using `link(href, { history })` emit the corresponding attribute value automatically.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -138,6 +138,8 @@ function AccountPage() {
 
 Native constraint validation and submitter overrides still apply. GET form values arrive in `src`; non-GET forms provide `formData`, `method`, and `encType` to the resolver. See [Frames](https://github.com/remix-run/remix/blob/main/packages/ui/docs/frames.md#form-navigation) for targeting, history behavior, request encoding, opt-outs, and server response guidance.
 
+Use `rmx-history="push|replace"` on an enhanced anchor or form to control how the navigation updates history. This can override the automatic replacement used for non-GET form submissions to the current URL.
+
 ## Preserving Client-Owned DOM
 
 Use `rmx-preserve-dom` on the smallest element whose live DOM should belong to client code after initial render, such as a custom element or third-party widget:

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -216,6 +216,18 @@ A client resolver may return frame content directly or return the fetched `Respo
 
 If omitted, frames resolve to `<p>resolve frame unimplemented</p>` and document navigations are left to the browser. Because this function defines the trust boundary for frame HTML, only return content from sources you trust.
 
+## Link navigation
+
+When `run({ resolveFrame })` is active, eligible same-origin anchor navigations reload `handle.frames.top` through the frame resolver instead of performing a full document navigation.
+
+- `rmx-target="name"` reloads a named frame.
+- `rmx-src="/frame"` overrides the URL resolved into that frame while `href` remains the navigation destination.
+- `rmx-history="push|replace"` controls how the navigation updates history.
+- `rmx-reset-scroll="false"` preserves the current scroll position.
+- `rmx-document` leaves the link as a normal document navigation.
+
+The `link(href, { history })` mixin adds the corresponding `rmx-history` value when its host is a native anchor. Download links, cross-origin links, and links marked with `rmx-document` are left to the browser.
+
 ## Form navigation
 
 When `run({ resolveFrame })` is active, eligible same-origin form submissions use the same frame navigation path as links. Native constraint validation and the form's `submit` event run first, so invalid forms never reach `resolveFrame`.
@@ -223,6 +235,7 @@ When `run({ resolveFrame })` is active, eligible same-origin form submissions us
 - Submissions reload `handle.frames.top` by default.
 - `rmx-target="name"` reloads a named frame.
 - `rmx-src="/frame"` overrides the URL resolved into that frame while the form action remains the navigation destination.
+- `rmx-history="push|replace"` overrides how the navigation updates history.
 - `rmx-reset-scroll="false"` preserves the current scroll position.
 - `rmx-document` leaves the submission as a normal document navigation.
 - Submitter overrides such as `formmethod`, `formenctype`, and `formtarget` take precedence over the form attributes.
@@ -244,9 +257,9 @@ For example, this form works as a normal document POST without JavaScript and re
 
 The action should return HTML suitable for the targeted frame when the resolver identifies a frame request, while retaining its normal document response or redirect for unenhanced submissions. The resolver above forwards app-defined `X-Remix-Frame` and `X-Remix-Target` headers for that distinction.
 
-Enhanced non-GET submissions to the current URL replace its navigation history entry instead of pushing a duplicate. Submissions to a different URL push a new entry, as do GET submissions whose values are represented in the destination URL. Non-GET `FormData` is used only for the active frame reload and is not retained in history.
+Enhanced non-GET submissions to the current URL replace its navigation history entry instead of pushing a duplicate. Submissions to a different URL push a new entry, as do GET submissions whose values are represented in the destination URL. The `rmx-history` attribute overrides that default: use `rmx-history="replace"` to force replacement or `rmx-history="push"` to force a push. Non-GET `FormData` is used only for the active frame reload and is not retained in history.
 
-Forms work as normal document submissions before the client runtime loads and whenever they use `rmx-document`, so this behavior remains progressively enhanced.
+Forms work as normal document submissions before the client runtime loads and whenever they use `rmx-document`, so this behavior remains progressively enhanced. Browsers ignore `rmx-history` without the client runtime and use their normal document history behavior.
 
 ## Frame lifecycle
 

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -1790,6 +1790,8 @@ export interface PartialAnchorHTMLProps<
   'rmx-target'?: Trackable<string | undefined>
   /** The `rmx-src` HTML attribute. */
   'rmx-src'?: Trackable<string | undefined>
+  /** Controls how activating this anchor updates the current history entry. */
+  'rmx-history'?: Trackable<'push' | 'replace' | undefined>
   /** The `rmx-reset-scroll` HTML attribute. */
   'rmx-reset-scroll'?: Trackable<string | undefined>
 }
@@ -2293,6 +2295,10 @@ export interface FormHTMLProps<
   role?: Trackable<'form' | 'none' | 'presentation' | 'search' | undefined>
   /** The `target` HTML attribute. */
   target?: Trackable<string | undefined>
+
+  // Non-standard Attributes
+  /** Overrides how submitting this form updates the current history entry. */
+  'rmx-history'?: Trackable<'push' | 'replace' | undefined>
 }
 
 /**

--- a/packages/ui/src/runtime/mixins/link-mixin.test.tsx
+++ b/packages/ui/src/runtime/mixins/link-mixin.test.tsx
@@ -26,7 +26,14 @@ describe('link mixin', () => {
 
   it('adds href and runtime attributes to anchors', () => {
     let { container } = render(
-      <a mix={link('/login', { src: '/partials/login', target: 'auth', resetScroll: false })}>
+      <a
+        mix={link('/login', {
+          src: '/partials/login',
+          target: 'auth',
+          history: 'replace',
+          resetScroll: false,
+        })}
+      >
         Login
       </a>,
     )
@@ -36,8 +43,17 @@ describe('link mixin', () => {
     expect(anchor.getAttribute('href')).toBe('/login')
     expect(anchor.getAttribute('rmx-target')).toBe('auth')
     expect(anchor.getAttribute('rmx-src')).toBe('/partials/login')
+    expect(anchor.getAttribute('rmx-history')).toBe('replace')
     expect(anchor.getAttribute('rmx-reset-scroll')).toBe('false')
     expect(anchor.getAttribute('role')).toBeNull()
+  })
+
+  it('adds push history to anchors', () => {
+    let { container } = render(<a mix={link('/login', { history: 'push' })}>Login</a>)
+
+    let anchor = container.querySelector('a')
+    invariant(anchor)
+    expect(anchor.getAttribute('rmx-history')).toBe('push')
   })
 
   it('adds link semantics to buttons', () => {
@@ -67,6 +83,7 @@ describe('link mixin', () => {
     expect(anchor.getAttribute('href')).toBe('/docs')
     expect(anchor.getAttribute('rmx-target')).toBeNull()
     expect(anchor.getAttribute('rmx-src')).toBeNull()
+    expect(anchor.getAttribute('rmx-history')).toBeNull()
   })
 
   it('navigates on plain click for non-anchor hosts', (t) => {

--- a/packages/ui/src/runtime/mixins/link-mixin.ts
+++ b/packages/ui/src/runtime/mixins/link-mixin.ts
@@ -36,6 +36,7 @@ export const link: MixinFactory<
           href,
           ...(options?.target == null ? {} : { 'rmx-target': options.target }),
           ...(options?.src == null ? {} : { 'rmx-src': options.src }),
+          ...(options?.history == null ? {} : { 'rmx-history': options.history }),
           ...(options?.resetScroll === false ? { 'rmx-reset-scroll': 'false' } : {}),
         })
       }

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -199,7 +199,12 @@ export function startNavigationListenerImpl(
         event.intercept({ handler })
       } else {
         // <a>/<form method="get"> navigations
-        event.intercept({ handler })
+        if (runtimeNavigation.replaceHistory && event.cancelable) {
+          event.preventDefault()
+          navigation.navigate(event.destination.url, { history: 'replace', state })
+        } else {
+          event.intercept({ handler })
+        }
       }
     },
     { signal },
@@ -293,11 +298,16 @@ function getSourceElementNavigation(
         resetScroll: linkElement.getAttribute('rmx-reset-scroll') !== 'false',
         $rmx: true,
       },
+      replaceHistory: getReplaceHistory(linkElement.getAttribute('rmx-history'), false),
     }
   }
 
   let formNavigation = resolveFormNavigation(event)
   if (!formNavigation || formNavigation.hasAttribute('rmx-document')) return
+
+  let replaceHistoryByDefault =
+    formNavigation.getSubmission !== undefined &&
+    event.destination.url === window.navigation.currentEntry?.url
 
   return {
     state: {
@@ -306,9 +316,16 @@ function getSourceElementNavigation(
       resetScroll: formNavigation.getAttribute('rmx-reset-scroll') !== 'false',
       $rmx: true,
     },
-    replaceHistory:
-      formNavigation.getSubmission !== undefined &&
-      event.destination.url === window.navigation.currentEntry?.url,
+    replaceHistory: getReplaceHistory(
+      formNavigation.getAttribute('rmx-history'),
+      replaceHistoryByDefault,
+    ),
     getSubmission: formNavigation.getSubmission,
   }
+}
+
+function getReplaceHistory(value: string | null, defaultValue: boolean): boolean {
+  if (value === 'replace') return true
+  if (value === 'push') return false
+  return defaultValue
 }

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -220,6 +220,45 @@ describe('navigate', () => {
     controller.abort()
   })
 
+  it('replaces marked anchor history without precommit support', async (t) => {
+    stubGlobalField(t, 'NavigationPrecommitController', undefined)
+
+    let originalUrl = window.location.href
+    let destination = new URL(originalUrl)
+    destination.searchParams.set('frame-navigation', 'replace-link')
+    let reload = mock.fn(async (_options?: ResolveFrameOptions) => new AbortController().signal)
+    let topFrame = { src: '' } as FrameHandle
+    let controller = new AbortController()
+    startNavigationListenerImpl(controller.signal, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: () => topFrame,
+      reloadFrame: async (_frame, options) => ({ signal: await reload(options) }),
+    })
+
+    let anchor = document.createElement('a')
+    anchor.href = destination.href
+    anchor.setAttribute('rmx-history', 'replace')
+    document.body.append(anchor)
+
+    let entryCountBeforeNavigation = window.navigation.entries().length
+    let didNavigate = false
+    try {
+      let navigationSucceeded = waitForNavigationSuccess()
+      anchor.click()
+      await navigationSucceeded
+      didNavigate = true
+
+      let entryAfterNavigation = getCurrentNavigationEntry()
+      expect(window.navigation.entries()).toHaveLength(entryCountBeforeNavigation)
+      expect(entryAfterNavigation.url).toBe(destination.href)
+      expect(topFrame.src).toBe(destination.href)
+      expect(reload).toHaveBeenCalledTimes(1)
+    } finally {
+      if (didNavigate) await navigate(originalUrl, { history: 'replace' })
+      controller.abort()
+    }
+  })
+
   it('replaces the navigation URL when the top frame reload follows a redirect', async () => {
     let originalUrl = window.location.href
     let requestedUrl = new URL(originalUrl)
@@ -405,6 +444,40 @@ describe('form navigation', () => {
     controller.abort()
   })
 
+  it('pushes same-location POST history when rmx-history is push', async () => {
+    let reload = mock.fn(async (_options?: ResolveFrameOptions) => new AbortController().signal)
+    let topFrame = { src: '' } as FrameHandle
+    let controller = new AbortController()
+    startNavigationListenerImpl(controller.signal, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: () => topFrame,
+      reloadFrame: async (_frame, options) => ({ signal: await reload(options) }),
+    })
+
+    let form = document.createElement('form')
+    form.action = window.location.href
+    form.method = 'post'
+    form.setAttribute('rmx-history', 'push')
+    document.body.append(form)
+
+    let entryBeforeSubmission = getCurrentNavigationEntry()
+    let didNavigate = false
+    try {
+      let navigationSucceeded = waitForNavigationSuccess()
+      form.requestSubmit()
+      await navigationSucceeded
+      didNavigate = true
+
+      let entryAfterSubmission = getCurrentNavigationEntry()
+      expect(entryAfterSubmission.index).toBe(entryBeforeSubmission.index + 1)
+      expect(entryAfterSubmission.url).toBe(entryBeforeSubmission.url)
+      expect(reload.mock.calls[0]?.arguments[0]?.method).toBe('post')
+    } finally {
+      if (didNavigate) await window.navigation.back().finished
+      controller.abort()
+    }
+  })
+
   it('pushes POST submission history for a different location', async () => {
     let reload = mock.fn(async (_options?: ResolveFrameOptions) => ({
       signal: new AbortController().signal,
@@ -540,6 +613,63 @@ describe('form navigation', () => {
       expect(options && Reflect.has(options, 'formData')).toBe(false)
     } finally {
       if (didNavigate) await window.navigation.back().finished
+      controller.abort()
+    }
+  })
+
+  it('replaces marked GET form history across frame redirects without submission metadata', async () => {
+    expect(typeof Reflect.get(window, 'NavigationPrecommitController')).toBe('function')
+
+    let originalUrl = window.location.href
+    let redirectedUrl = new URL(originalUrl)
+    redirectedUrl.searchParams.set('query', 'redirected-frames')
+    let topFrame = { src: '' } as FrameHandle
+    let shouldRedirect = true
+    let reload = mock.fn(async (_options?: ResolveFrameOptions) => {
+      if (shouldRedirect) {
+        shouldRedirect = false
+        return {
+          signal: new AbortController().signal,
+          redirectedTo: redirectedUrl.href,
+        }
+      }
+      return { signal: new AbortController().signal }
+    })
+    let controller = new AbortController()
+    startNavigationListenerImpl(controller.signal, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: () => topFrame,
+      reloadFrame: (_frame, options) => reload(options),
+    })
+
+    let form = document.createElement('form')
+    form.action = originalUrl
+    form.method = 'get'
+    form.setAttribute('rmx-history', 'replace')
+    let input = document.createElement('input')
+    input.name = 'query'
+    input.value = 'replace-frames'
+    form.append(input)
+    document.body.append(form)
+
+    let entryCountBeforeSubmission = window.navigation.entries().length
+    let didNavigate = false
+    try {
+      let redirected = waitForNavigationUrl(redirectedUrl.href)
+      form.requestSubmit()
+      await redirected
+      didNavigate = true
+
+      let entryAfterSubmission = getCurrentNavigationEntry()
+      expect(window.navigation.entries()).toHaveLength(entryCountBeforeSubmission)
+      expect(entryAfterSubmission.url).toBe(redirectedUrl.href)
+      expect(reload).toHaveBeenCalledTimes(1)
+      let options = reload.mock.calls[0]?.arguments[0]
+      expect(options && Reflect.has(options, 'method')).toBe(false)
+      expect(options && Reflect.has(options, 'encType')).toBe(false)
+      expect(options && Reflect.has(options, 'formData')).toBe(false)
+    } finally {
+      if (didNavigate) await navigate(originalUrl, { history: 'replace' })
       controller.abort()
     }
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
+      playwright:
+        specifier: 'catalog:'
+        version: 1.60.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2


### PR DESCRIPTION
This adds an explicit history override for progressively enhanced frame navigations. It is stacked on #11668, which adds form-driven frame navigation.

- Adds `rmx-history="push|replace"` support to enhanced anchors and forms.
- Allows forms to override the automatic replacement used for same-location non-GET submissions.
- Makes `link(href, { history })` emit the corresponding `rmx-history` value on native anchors.
- Preserves replacement behavior across frame redirects and fallback navigation replay.

```tsx
<a href="/search" rmx-history="replace">Search</a>

<form method="post" rmx-history="push">
  <button>Save as a new history entry</button>
</form>
```
