### PR TITLE
Escape server-rendered CSS style text

### DIFF
--- a/packages/ui/.changes/patch.escape-server-rendered-css.md
+++ b/packages/ui/.changes/patch.escape-server-rendered-css.md
@@ -1,0 +1,1 @@
+Escape less-than characters in server-rendered `css()` output so style values cannot terminate the generated `<style>` element.

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -1253,7 +1253,12 @@ function renderStyleTag(
 ): string {
   let wrappedCss = wrapStyleForLayer(selector, css, layer)
   if (!wrappedCss) return ''
-  return `<style data-rmx="${escapeHtml(selector)}">${wrappedCss}</style>`
+  return `<style data-rmx="${escapeHtml(selector)}">${escapeStyleText(wrappedCss)}</style>`
+}
+
+function escapeStyleText(css: string): string {
+  // A literal "</style" closes an HTML style element even when it appears inside a CSS string.
+  return css.replace(/</g, '\\3C ')
 }
 
 function buildRmxDataScript(context: RenderContext): string {

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -668,6 +668,16 @@ describe('stream', () => {
       expect(html).toMatch(/class="base rmxc-[a-z0-9]+ rmxc-[a-z0-9]+"/)
       expect(html).toContain('.rmxc-')
     })
+
+    it('prevents css mixin styles from breaking out of style tags', async () => {
+      let html = await renderToString(
+        <div mix={[css({ color: '</style><script>globalThis.__xss = true</script><style>' })]} />,
+      )
+
+      expect(html).not.toContain('</style><script>')
+      expect(html).not.toContain('<script>globalThis.__xss = true</script>')
+      expect(html).toContain('color: \\3C /style>\\3C script>globalThis.__xss = true\\3C /script>')
+    })
   })
 
   describe('svg', () => {


### PR DESCRIPTION
Server-rendered CSS mixins are embedded in raw-text `<style>` elements. A literal `<` in dynamic CSS could form a `</style>` end tag and cause the remaining content to be parsed as HTML.

- CSS-escape `<` as `\3C ` at the final style serialization boundary
- cover generated declarations, nested selectors, and at-rules while preserving their CSS meaning
- add a browser regression test and patch change note for `@remix-run/ui`
