### PR TITLE
Fix sibling removal when disposing hydration ranges

### DIFF
--- a/packages/ui/.changes/patch.preserve-reconciled-siblings.md
+++ b/packages/ui/.changes/patch.preserve-reconciled-siblings.md
@@ -1,0 +1,1 @@
+Prevent document and frame reloads from dropping newly rendered sibling elements when client entries from the previous content are disposed.

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -76,6 +76,20 @@ export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
         continue
       }
 
+      // An obsolete hydration root owns its entire marker-bounded range. Remove
+      // that range atomically so disposal cannot detach nodes that a later
+      // incoming sibling would otherwise match.
+      if (isVirtualRootStartMarker(c)) {
+        let currentEndIndex = findHydrationEndIndex(curr, currentIndex)
+        parent.insertBefore(n, c)
+        for (let i = currentIndex; i <= currentEndIndex; i++) {
+          removeNode(curr[i], parent, context)
+        }
+        currentIndex = currentEndIndex + 1
+        nextIndex++
+        continue
+      }
+
       let cursor = diffNode(c, n, context)
       if (cursor) {
         let nextEndIndex = next.indexOf(cursor)
@@ -289,10 +303,12 @@ function isPopoverOpen(element: Element): boolean {
 function diffElementChildren(current: Element, next: Element, context: FrameContext): void {
   let currentChildren = Array.from(current.childNodes)
   let nextChildren = Array.from(next.childNodes)
+  let ownedByHydrationRange = findNodesOwnedByHydrationRanges(currentChildren)
 
   // Keyed map by data-key for current children
   let keyToIndex = new Map<string, number>()
   for (let i = 0; i < currentChildren.length; i++) {
+    if (ownedByHydrationRange[i]) continue
     let node = currentChildren[i]
     if (isElement(node)) {
       let key = node.getAttribute('data-key')
@@ -309,7 +325,7 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
 
     if (isFrameEndMarker(nextChild)) {
       for (let j = 0; j < currentChildren.length; j++) {
-        if (!used[j] && isFrameEndMarker(currentChildren[j])) {
+        if (!ownedByHydrationRange[j] && !used[j] && isFrameEndMarker(currentChildren[j])) {
           matchIndex = j
           break
         }
@@ -326,6 +342,7 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
       let candidateIndex = i
       if (
         candidateIndex < currentChildren.length &&
+        !ownedByHydrationRange[candidateIndex] &&
         !used[candidateIndex] &&
         nodeTypesComparable(currentChildren[candidateIndex], nextChild)
       ) {
@@ -458,6 +475,29 @@ function diffElementChildren(current: Element, next: Element, context: FrameCont
   }
 }
 
+function findNodesOwnedByHydrationRanges(nodes: Node[]): Uint8Array {
+  let owned = new Uint8Array(nodes.length)
+
+  for (let startIndex = 0; startIndex < nodes.length; startIndex++) {
+    let start = nodes[startIndex]
+    let endIndex = isVirtualRootStartMarker(start)
+      ? findHydrationEndIndex(nodes, startIndex)
+      : startIndex
+
+    if (endIndex === startIndex) continue
+
+    // A hydration root owns its interior DOM even if reconciliation moves that
+    // DOM outside the marker comments. Keep those nodes out of ordinary matching
+    // so disposing the obsolete root cannot remove a newly committed sibling.
+    for (let i = startIndex + 1; i <= endIndex; i++) {
+      owned[i] = 1
+    }
+    startIndex = endIndex
+  }
+
+  return owned
+}
+
 function isPreservedDomElement(node: Node): node is Element {
   return isElement(node) && node.hasAttribute(REMIX_PRESERVE_DOM_ATTRIBUTE)
 }
@@ -505,8 +545,15 @@ function findHydrationEndMarker(start: Comment): Comment {
 }
 
 function findHydrationEndIndex(nodes: Node[], startIdx: number): number {
+  let depth = 1
+
   for (let j = startIdx + 1; j < nodes.length; j++) {
-    if (isHydrationEndComment(nodes[j])) return j
+    let node = nodes[j]
+    if (isVirtualRootStartMarker(node)) depth++
+    if (isHydrationEndComment(node)) {
+      depth--
+      if (depth === 0) return j
+    }
   }
   return startIdx
 }

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -3,14 +3,17 @@ import { describe, it } from '@remix-run/test'
 import { invariant } from '../runtime/invariant.ts'
 import { diffNodes } from '../runtime/diff-dom.ts'
 
-function diffDom(container: HTMLElement, next: string) {
-  let template = document.createElement('template')
-  template.innerHTML = next
-
-  diffNodes(Array.from(container.childNodes), Array.from(template.content.childNodes), {
+function diffDomNodes(current: Node[], next: Node[]) {
+  diffNodes(current, next, {
     frameInstances: new WeakMap(),
     pendingClientEntries: new Map(),
   } as any)
+}
+
+function diffDom(container: HTMLElement, next: string) {
+  let template = document.createElement('template')
+  template.innerHTML = next
+  diffDomNodes(Array.from(container.childNodes), Array.from(template.content.childNodes))
 }
 
 describe('diffNodes', () => {
@@ -115,6 +118,90 @@ describe('diffNodes', () => {
       let start = container.firstChild
       invariant(start && start.nodeType === Node.COMMENT_NODE)
       expect((start as Comment).data.trim()).toBe('rmx:h:new')
+    })
+
+    it('does not match keyed elements owned by nested hydration ranges', () => {
+      let container = document.createElement('div')
+      let current = document.createElement('div')
+      container.appendChild(current)
+
+      let outerStart = document.createComment('rmx:h:outer')
+      let innerStart = document.createComment('rmx:h:inner')
+      let innerContent = document.createElement('span')
+      let innerEnd = document.createComment('/rmx:h')
+      let owned = document.createElement('section')
+      let outerEnd = document.createComment('/rmx:h')
+      let dataKey = 'data-key'
+      owned.setAttribute(dataKey, 'entry')
+      current.append(outerStart, innerStart, innerContent, innerEnd, owned, outerEnd)
+
+      let disposeCount = 0
+      Object.assign(outerStart, {
+        $rmx: {
+          dispose() {
+            disposeCount++
+            owned.remove()
+          },
+        },
+      })
+
+      let next = document.createElement('div')
+      let replacement = document.createElement('section')
+      replacement.id = 'replacement'
+      replacement.setAttribute(dataKey, 'entry')
+      next.appendChild(replacement)
+
+      diffDomNodes([current], [next])
+
+      expect(current.childNodes).toHaveLength(1)
+      expect(current.firstChild).toBe(replacement)
+      expect(disposeCount).toBe(1)
+    })
+
+    it('does not match frame end markers owned by hydration ranges', () => {
+      let container = document.createElement('div')
+      let current = document.createElement('div')
+      container.appendChild(current)
+
+      let hydrationStart = document.createComment('rmx:h:entry')
+      let currentFrameStart = document.createComment('rmx:f:current')
+      let currentFrameContent = document.createElement('p')
+      let currentFrameEnd = document.createComment('/rmx:f')
+      let hydrationEnd = document.createComment('/rmx:h')
+      current.append(
+        hydrationStart,
+        currentFrameStart,
+        currentFrameContent,
+        currentFrameEnd,
+        hydrationEnd,
+      )
+
+      let disposeCount = 0
+      Object.assign(hydrationStart, {
+        $rmx: {
+          dispose() {
+            disposeCount++
+            let range = document.createRange()
+            range.setStartBefore(currentFrameStart)
+            range.setEndAfter(currentFrameEnd)
+            range.deleteContents()
+          },
+        },
+      })
+
+      let next = document.createElement('div')
+      let nextFrameStart = document.createComment('rmx:f:next')
+      let nextFrameContent = document.createElement('section')
+      let nextFrameEnd = document.createComment('/rmx:f')
+      next.append(nextFrameStart, nextFrameContent, nextFrameEnd)
+
+      diffDomNodes([current], [next])
+
+      expect(current.childNodes).toHaveLength(3)
+      expect(current.childNodes.item(0)).toBe(nextFrameStart)
+      expect(current.childNodes.item(1)).toBe(nextFrameContent)
+      expect(current.childNodes.item(2)).toBe(nextFrameEnd)
+      expect(disposeCount).toBe(1)
     })
 
     it('does not match a shifted frame start with the current frame end', () => {

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -2,7 +2,7 @@ import { expect } from '@remix-run/assert'
 import { afterEach, beforeEach, describe, it, mock, type TestContext } from '@remix-run/test'
 import type { Handle, RemixNode } from '../runtime/component.ts'
 import { Frame } from '../runtime/component.ts'
-import { clientEntry } from '../runtime/client-entries.ts'
+import { clientEntry, type EntryComponent } from '../runtime/client-entries.ts'
 import { getNamedFrame, getTopFrame, run } from '../runtime/run.ts'
 import { createRangeRoot, createRoot } from '../runtime/vdom.ts'
 import { invariant } from '../runtime/invariant.ts'
@@ -41,6 +41,43 @@ async function drainWithProtocol(stream: ReadableStream<Uint8Array>): Promise<st
   }
 
   return html
+}
+
+async function renderDocumentContent(content: RemixNode): Promise<string> {
+  return await drainWithProtocol(
+    renderToStream(
+      <html>
+        <head />
+        <body>
+          <main>{content}</main>
+        </body>
+      </html>,
+    ),
+  )
+}
+
+async function renderFrameContent(content: RemixNode): Promise<string> {
+  return await drain(renderToStream(content))
+}
+
+function createDisposableEntry(id: string, onDispose: () => void) {
+  return clientEntry(id, function Entry(handle: Handle) {
+    handle.signal.addEventListener('abort', onDispose)
+    return () => <section>Entry</section>
+  })
+}
+
+function createObsoleteEntryContent(Entry: EntryComponent): RemixNode {
+  return <Entry />
+}
+
+function createReplacementContent(): RemixNode {
+  return (
+    <>
+      <section id="gallery">Gallery</section>
+      <section id="details">Details</section>
+    </>
+  )
 }
 
 async function waitForTransitionWindow(): Promise<void> {
@@ -486,6 +523,104 @@ describe('run', () => {
     expect(hydrationStarts).toBe(hydrationEnds)
 
     app.dispose()
+  })
+
+  it('keeps siblings inserted while obsolete client entries are disposed during document reloads', async () => {
+    let disposeCount = 0
+
+    let Entry = createDisposableEntry('/js/entry.js#Entry', () => {
+      disposeCount++
+    })
+
+    let initialDocument = new DOMParser().parseFromString(
+      await renderDocumentContent(createObsoleteEntryContent(Entry)),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/entry.js' && exportName === 'Entry') return Entry
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === '/destination') {
+          return await renderDocumentContent(createReplacementContent())
+        }
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    try {
+      await app.ready()
+
+      let topFrame = app.frames.top
+      topFrame.src = '/destination'
+      await topFrame.reload()
+
+      expect(document.querySelector('main')?.innerHTML).toBe(
+        '<section id="gallery">Gallery</section><section id="details">Details</section>',
+      )
+      expect(disposeCount).toBe(1)
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('keeps siblings inserted while obsolete client entries are disposed during frame reloads', async () => {
+    let disposeCount = 0
+
+    let Entry = createDisposableEntry('/js/frame-entry.js#FrameEntry', () => {
+      disposeCount++
+    })
+
+    let html = await drain(
+      renderToStream(<Frame name="target" src="/initial" />, {
+        resolveFrame(src) {
+          if (src === '/initial') {
+            return renderFrameContent(
+              <>
+                {createObsoleteEntryContent(Entry)}
+                <section id="trailing">Trailing</section>
+              </>,
+            )
+          }
+          throw new Error(`Unexpected server frame src: ${src}`)
+        },
+      }),
+    )
+    document.body.innerHTML = html
+
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/frame-entry.js' && exportName === 'FrameEntry') return Entry
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      resolveFrame(src) {
+        if (src === '/destination') return renderFrameContent(createReplacementContent())
+        throw new Error(`Unexpected client frame src: ${src}`)
+      },
+    })
+
+    try {
+      await app.ready()
+
+      let trailingSibling = document.querySelector('#trailing')
+      invariant(trailingSibling)
+
+      let targetFrame = app.frames.get('target')
+      invariant(targetFrame)
+      targetFrame.src = '/destination'
+      await targetFrame.reload()
+
+      expect(document.body.innerHTML).toContain(
+        '<section id="gallery">Gallery</section><section id="details">Details</section>',
+      )
+      expect(document.querySelector('#details')).toBe(trailingSibling)
+      expect(disposeCount).toBe(1)
+    } finally {
+      app.dispose()
+    }
   })
 
   it('preserves hydrated client entries across full-document reloads', async () => {


### PR DESCRIPTION
A client-side document or frame reload could remove valid HTML that was present in the response. This showed up when navigating from a `<main>` containing a mix of hydrated `clientEntry()` boundaries and ordinary DOM to a page with two ordinary top-level siblings: both siblings arrived in the fetched HTML, but reconciliation removed the second one.

The problem was stale DOM ownership. Reconciliation could reuse a node from an obsolete hydration range as a new ordinary sibling. Disposing the old client entry afterward still treated that node as part of its range and deleted it. The report reproduced against preview revision `e52c100544a93f85f3ea566a1acfc5be49d70655`, built from the repository after [#11678](https://github.com/remix-run/remix/pull/11678); the behavior traces back to the range reconciliation added in [#11346](https://github.com/remix-run/remix/pull/11346).

- Removes obsolete hydration ranges atomically before matching later incoming siblings.
- Keeps hydration-owned nodes out of keyed, positional, and frame-marker matching.
- Makes hydration end-marker lookup nesting-aware.
- Covers full-document and named-frame reloads, nested hydration ranges, frame markers inside hydration ranges, and cursor advancement to an ordinary trailing source sibling.
- Verifies both destination siblings remain while the obsolete client entry is disposed exactly once.
