### PR TITLE
Show destination SSR while client entry modules load

### DIFF
--- a/packages/ui/.changes/patch.show-destination-ssr.md
+++ b/packages/ui/.changes/patch.show-destination-ssr.md
@@ -1,0 +1,1 @@
+Show complete destination server-rendered client entry content during document and frame reloads while replacement modules load, instead of retaining only positionally matched source content.

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -627,6 +627,24 @@ function shouldPreserveFrameStartMarker(
   )
 }
 
+function shouldPreserveHydrationStartMarker(
+  current: Comment,
+  next: Comment,
+  context: FrameContext,
+): boolean {
+  if (!isVirtualRootStartMarker(next)) return false
+
+  let currentData = getHydrationMarkerData(current, context)
+  let nextData = getHydrationMarkerData(next, context)
+
+  return (
+    currentData !== undefined &&
+    nextData !== undefined &&
+    currentData.moduleUrl === nextData.moduleUrl &&
+    currentData.exportName === nextData.exportName
+  )
+}
+
 function getCommentMarkerRangeReplacement(
   current: Node,
   next: Node,
@@ -651,6 +669,30 @@ function getCommentMarkerRangeReplacement(
       nextEndIndex: findFrameEndIndex(nextNodes, nextIndex),
     }
   }
+
+  if (
+    isVirtualRootStartMarker(current) &&
+    isVirtualRootStartMarker(next) &&
+    !shouldPreserveHydrationStartMarker(current, next, context)
+  ) {
+    return {
+      currentStart: current,
+      nextStart: next,
+      currentEndIndex: findHydrationEndIndex(currentNodes, currentIndex),
+      nextEndIndex: findHydrationEndIndex(nextNodes, nextIndex),
+    }
+  }
+}
+
+function getHydrationMarkerData(marker: Comment, context: FrameContext) {
+  let id = getHydrationId(marker)
+  return context.data.h?.[id]
+}
+
+function getHydrationId(marker: Comment): string {
+  let trimmed = marker.data.trim()
+  invariant(trimmed.startsWith('rmx:h:'), 'Invalid hydration start marker')
+  return trimmed.slice('rmx:h:'.length)
 }
 
 function getFrameMarkerData(marker: Comment, context: FrameContext) {
@@ -669,8 +711,8 @@ function replaceCommentMarkerRange(
   parent: ParentNode,
   context: FrameContext,
 ): void {
-  let currentEnd = findFrameEndMarker(replacement.currentStart)
-  let nextEnd = findFrameEndMarker(replacement.nextStart)
+  let currentEnd = findCommentMarkerRangeEnd(replacement.currentStart)
+  let nextEnd = findCommentMarkerRangeEnd(replacement.nextStart)
   let nextNodes = collectNodeRange(replacement.nextStart, nextEnd)
   let currentNodes = collectNodeRange(replacement.currentStart, currentEnd)
 
@@ -681,6 +723,12 @@ function replaceCommentMarkerRange(
   for (let node of currentNodes) {
     removeNode(node, parent, context)
   }
+}
+
+function findCommentMarkerRangeEnd(start: Comment): Comment {
+  if (isFrameStartMarker(start)) return findFrameEndMarker(start)
+  if (isVirtualRootStartMarker(start)) return findHydrationEndMarker(start)
+  throw new Error('Comment marker range start not found')
 }
 
 function collectNodeRange(start: Node, end: Node): Node[] {

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -2,18 +2,20 @@ import { expect } from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import { invariant } from '../runtime/invariant.ts'
 import { diffNodes } from '../runtime/diff-dom.ts'
+import type { FrameContext } from '../runtime/frame.ts'
 
-function diffDomNodes(current: Node[], next: Node[]) {
+function diffDomNodes(current: Node[], next: Node[], data: FrameContext['data'] = {}) {
   diffNodes(current, next, {
     frameInstances: new WeakMap(),
     pendingClientEntries: new Map(),
+    data,
   } as any)
 }
 
-function diffDom(container: HTMLElement, next: string) {
+function diffDom(container: HTMLElement, next: string, data?: FrameContext['data']) {
   let template = document.createElement('template')
   template.innerHTML = next
-  diffDomNodes(Array.from(container.childNodes), Array.from(template.content.childNodes))
+  diffDomNodes(Array.from(container.childNodes), Array.from(template.content.childNodes), data)
 }
 
 describe('diffNodes', () => {
@@ -113,11 +115,32 @@ describe('diffNodes', () => {
       let container = document.createElement('div')
       container.innerHTML = '<!-- rmx:h:old --><button>Old</button><!-- /rmx:h -->'
 
-      diffDom(container, '<!-- rmx:h:new --><button>Old</button><!-- /rmx:h -->')
+      diffDom(container, '<!-- rmx:h:new --><button>Old</button><!-- /rmx:h -->', {
+        h: {
+          old: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+          new: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+        },
+      })
 
       let start = container.firstChild
       invariant(start && start.nodeType === Node.COMMENT_NODE)
       expect((start as Comment).data.trim()).toBe('rmx:h:new')
+    })
+
+    it('replaces hydration ranges with different client entry identities', () => {
+      let container = document.createElement('div')
+      container.innerHTML = '<!-- rmx:h:old --><button>Old</button><!-- /rmx:h -->'
+      let oldStart = container.firstChild
+
+      diffDom(container, '<!-- rmx:h:new --><button>New</button><!-- /rmx:h -->', {
+        h: {
+          old: { moduleUrl: '/old.js', exportName: 'Old', props: {} },
+          new: { moduleUrl: '/new.js', exportName: 'New', props: {} },
+        },
+      })
+
+      expect(container.firstChild).not.toBe(oldStart)
+      expect(container.querySelector('button')?.textContent).toBe('New')
     })
 
     it('does not match keyed elements owned by nested hydration ranges', () => {

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -786,12 +786,126 @@ describe('run', () => {
     app.dispose()
   })
 
-  it('keeps the prior entry styled while its replacement module is loading', async () => {
-    // Regression test for the demo-to-demo navigation FOUC: when a full-document
-    // reload replaces one client entry with another, `diffNodes` preserves the
-    // old DOM inside the hydration markers until the new module finishes
-    // loading. Server-adopted rules are pinned in the style registry, so the
-    // old entry's css-mixin rule stays live while its DOM is still visible.
+  it('shows destination SSR while a different client entry module is loading', async () => {
+    let pageTitleDisposeCount = 0
+    let collectionGridDisposeCount = 0
+
+    let PageTitle = clientEntry('/js/page-title.js#PageTitle', function PageTitle(handle: Handle) {
+      handle.signal.addEventListener('abort', () => {
+        pageTitleDisposeCount++
+      })
+      return () => <h1 id="collection-title">All products</h1>
+    })
+
+    let CollectionGrid = clientEntry(
+      '/js/collection-grid.js#CollectionGrid',
+      function CollectionGrid(handle: Handle) {
+        handle.signal.addEventListener('abort', () => {
+          collectionGridDisposeCount++
+        })
+        return () => (
+          <section id="collection-grid">
+            <a href="/products/test-product">Test product</a>
+          </section>
+        )
+      },
+    )
+
+    let ProductDetails = clientEntry(
+      '/js/product-details.js#ProductDetails',
+      function ProductDetails(handle: Handle) {
+        let added = false
+        return () => (
+          <article id="product-details">
+            <h1>Test product</h1>
+            <button
+              type="button"
+              mix={on('click', () => {
+                added = true
+                handle.update()
+              })}
+            >
+              {added ? 'Added' : 'Add to cart'}
+            </button>
+          </article>
+        )
+      },
+    )
+
+    async function renderCollectionDocument() {
+      return await renderDocumentContent(
+        <>
+          <PageTitle />
+          <CollectionGrid />
+        </>,
+      )
+    }
+
+    async function renderProductDocument() {
+      return await renderDocumentContent(<ProductDetails />)
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await renderCollectionDocument(),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [productModuleRequested, markProductModuleRequested] = withResolvers<void>()
+    let [productModuleGate, allowProductModule] = withResolvers<void>()
+    let app = run({
+      async loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/page-title.js' && exportName === 'PageTitle') return PageTitle
+        if (moduleUrl === '/js/collection-grid.js' && exportName === 'CollectionGrid') {
+          return CollectionGrid
+        }
+        if (moduleUrl === '/js/product-details.js' && exportName === 'ProductDetails') {
+          markProductModuleRequested()
+          await productModuleGate
+          return ProductDetails
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src: string) {
+        if (src === '/products/test-product') return await renderProductDocument()
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    try {
+      await app.ready()
+      expect(document.getElementById('collection-title')).not.toBeNull()
+      expect(document.getElementById('collection-grid')).not.toBeNull()
+
+      let topFrame = app.frames.top
+      topFrame.src = '/products/test-product'
+      let reloadPromise = topFrame.reload()
+      await productModuleRequested
+
+      expect(document.getElementById('collection-title')).toBeNull()
+      expect(document.getElementById('collection-grid')).toBeNull()
+      expect(document.getElementById('product-details')).not.toBeNull()
+      expect(pageTitleDisposeCount).toBe(1)
+      expect(collectionGridDisposeCount).toBe(1)
+
+      allowProductModule()
+      await reloadPromise
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      let addButton = document.querySelector('#product-details button')
+      invariant(addButton instanceof HTMLButtonElement)
+      addButton.click()
+      app.flush()
+      expect(addButton.textContent).toBe('Added')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('shows the replacement entry styled while its module is loading', async () => {
+    // Regression test for the demo-to-demo navigation FOUC: a full-document
+    // reload commits a different client entry's server-rendered DOM before its
+    // module finishes loading, so its adopted server styles must already be live.
 
     function rulePresent(selector: string): boolean {
       return Array.from(document.adoptedStyleSheets).some((sheet) =>
@@ -873,8 +987,8 @@ describe('run', () => {
     await app.ready()
     expect(rulePresent(aSelector)).toBe(true)
 
-    // Begin the reload but hold EntryB's module load so the old DOM stays
-    // inside the hydration markers — this is the FOUC window in production.
+    // Begin the reload but hold EntryB's module load to inspect its server DOM
+    // before hydration makes it interactive.
     let topFrame = app.frames.top
     topFrame.src = '/b'
     await topFrame.reload()
@@ -886,14 +1000,11 @@ describe('run', () => {
     let bSelectorFromB = findClassByPrefix(bDoc, 'entry-b')
     invariant(bSelectorFromB, 'expected SSR markup to carry an rmxc-* class for entry-b')
 
-    // Old DOM is still visible (entry-a div still in the document).
-    expect(document.getElementById('entry-a')).not.toBeNull()
-    // Its rule must still be live — otherwise we'd flash unstyled.
-    expect(rulePresent(aSelector)).toBe(true)
-    // The new entry's rule is already adopted from the streamed style tags.
+    expect(document.getElementById('entry-a')).toBeNull()
+    expect(document.getElementById('entry-b')).not.toBeNull()
     expect(rulePresent(bSelectorFromB)).toBe(true)
 
-    // Allow the module load to finish and let hydration swap the DOM.
+    // Allow the module load to finish and hydrate the destination SSR.
     allowBModule()
     await new Promise((resolve) => setTimeout(resolve, 0))
 


### PR DESCRIPTION
Full-document and frame reconciliation currently treats any two hydration start markers as the same client entry. During a many-to-one navigation with a cold destination module, that preserves the first source entry, disposes the remaining source entries, and temporarily exposes a partial source document even though complete destination HTML is available. This came up while working on migrating shop.remix.run (note: the bad font loading is not part of the problem, it's the FOUC going to the product details page)

https://github.com/user-attachments/assets/7a255e37-9601-4434-a86a-e63cda4a8149

This stacks on #11680 and extends its hydration-range ownership model to account for client-entry identity.

- Preserve existing virtual roots only when `moduleUrl` and `exportName` match, retaining local state for same-entry reloads.
- Replace different client-entry ranges with complete destination SSR before asynchronously loading and hydrating their modules.
- Update the #11402 styling regression to assert that destination SSR is visible and styled during the cold-module window.
- Cover the two-source-to-one-destination transition, exact source disposal, final destination interactivity, and low-level same/different identity behavior.
