### PR TITLE
Add structured logger formatting

### DIFF
--- a/packages/logger-middleware/.changes/minor.structured-logging.md
+++ b/packages/logger-middleware/.changes/minor.structured-logging.md
@@ -1,0 +1,1 @@
+Add formatter callbacks to `logger()` for structured request logging. The callback receives the request, response, start and end times, and duration so it can safely serialize selected fields as JSON.

--- a/packages/logger-middleware/README.md
+++ b/packages/logger-middleware/README.md
@@ -7,7 +7,8 @@ HTTP request/response logging middleware for Remix. It logs request metadata and
 - **Request/Response Logging** - Logs method, path, status, and response metadata
 - **Context Logger** - Exposes `context.logger` (or `context.get(Logger)`)
 - **Token-Based Formatting** - Customize log output with built-in placeholders
-- **Structured Timing Data** - Includes request duration and timestamps
+- **Structured Logging** - Serialize typed request and response data as JSON
+- **Request Timing** - Includes request duration and timestamps
 - **Colorized Output** - Highlights method, status, duration, and content length in TTY output
 
 ## Installation
@@ -102,6 +103,34 @@ The following tokens are colorized when colors are enabled:
 - `%status`
 - `%duration`
 - `%contentLength`
+
+### Structured Logs
+
+Pass a formatter function to serialize request and response fields as JSON. The formatter receives the Web API `Request` and `Response`, start and end times, and the duration in milliseconds.
+
+```ts
+let router = createRouter({
+  middleware: [
+    logger({
+      format({ request, response, start, duration }) {
+        let url = new URL(request.url)
+
+        return JSON.stringify({
+          timestamp: start.toISOString(),
+          method: request.method,
+          path: url.pathname + url.search,
+          status: response.status,
+          duration,
+          contentType: response.headers.get('Content-Type'),
+        })
+      },
+    }),
+  ],
+})
+// Logs: {"timestamp":"2025-11-19T22:32:10.000Z","method":"GET","path":"/users/123","status":200,"duration":42,"contentType":"application/json"}
+```
+
+The resulting JSON line can be collected by structured logging systems. Use the `log` option to send it to a file, stream, or logging service.
 
 ### Custom Logger
 

--- a/packages/logger-middleware/src/index.ts
+++ b/packages/logger-middleware/src/index.ts
@@ -1,1 +1,7 @@
-export { Logger, type LoggerFunction, type LoggerOptions, logger } from './lib/logger.ts'
+export {
+  Logger,
+  type LoggerEvent,
+  type LoggerFunction,
+  type LoggerOptions,
+  logger,
+} from './lib/logger.ts'

--- a/packages/logger-middleware/src/lib/logger.test.ts
+++ b/packages/logger-middleware/src/lib/logger.test.ts
@@ -52,6 +52,35 @@ describe('logger', () => {
     assert.match(message, /\[\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} [+-]\d{4}\] GET \/ \d+ \d+/)
   })
 
+  it('formats the request with a callback', async () => {
+    let { message } = await logRequest({
+      loggerOptions: {
+        format({ request, response, start, end, duration }) {
+          let url = new URL(request.url)
+          return JSON.stringify({
+            timestamp: start.toISOString(),
+            method: request.method,
+            path: url.pathname + url.search,
+            status: response.status,
+            duration,
+            end: end.toISOString(),
+          })
+        },
+      },
+      requestInit: {
+        method: 'POST',
+      },
+      response: new Response(null, { status: 201 }),
+    })
+
+    let data = JSON.parse(message)
+    assert.equal(data.method, 'POST')
+    assert.equal(data.path, '/')
+    assert.equal(data.status, 201)
+    assert.equal(typeof data.duration, 'number')
+    assert.equal(new Date(data.timestamp).getTime() + data.duration, new Date(data.end).getTime())
+  })
+
   it('colorizes high-signal tokens when colors are enabled', async () => {
     await withNoColor(undefined, async () => {
       let { message } = await logRequest({

--- a/packages/logger-middleware/src/lib/logger.ts
+++ b/packages/logger-middleware/src/lib/logger.ts
@@ -19,13 +19,40 @@ export interface LoggerFunction {
 export const Logger: { defaultValue?: LoggerFunction } = createContextKey<LoggerFunction>()
 
 /**
+ * Request and response data available to a custom log formatter.
+ */
+export interface LoggerEvent {
+  /**
+   * The incoming request.
+   */
+  request: Request
+  /**
+   * The outgoing response.
+   */
+  response: Response
+  /**
+   * The time when request processing started.
+   */
+  start: Date
+  /**
+   * The time when request processing finished.
+   */
+  end: Date
+  /**
+   * The request duration in milliseconds.
+   */
+  duration: number
+}
+
+/**
  * Options for the {@link logger} middleware.
  */
 export interface LoggerOptions {
   /**
-   * The format to use for log messages.
+   * The template or formatter to use for request log messages. A formatter receives the request,
+   * response, start and end times, and duration, and returns the complete message to log.
    *
-   * The following tokens are available:
+   * String templates support the following tokens:
    *
    * - `%date` - The date and time of the request in Apache/nginx log format (dd/Mon/yyyy:HH:mm:ss ±zzzz)
    * - `%dateISO` - The date and time of the request in ISO format
@@ -48,7 +75,7 @@ export interface LoggerOptions {
    *
    * @default '[%date] %method %path %status %contentLength'
    */
-  format?: string
+  format?: string | ((event: LoggerEvent) => string)
   /**
    * The function to use to log messages.
    *
@@ -61,6 +88,7 @@ export interface LoggerOptions {
    * By default, colors are enabled when terminal color detection allows them. Set this to `false`
    * to opt out or `true` to force colors on. When the `process` global is defined, color
    * detection respects `CI`, `NO_COLOR`, `FORCE_COLOR`, `TERM=dumb`, and TTY output streams.
+   * This option only affects string templates; formatter callbacks control their complete output.
    *
    * The following tokens are colorized when colors are enabled:
    *
@@ -123,7 +151,10 @@ export function logger(
       userAgent: () => request.headers.get('User-Agent') ?? '-',
     }
 
-    let message = format.replace(/%(\w+)/g, (_, key) => tokens[key]?.() ?? '-')
+    let message =
+      typeof format === 'function'
+        ? format({ request, response, start, end, duration })
+        : format.replace(/%(\w+)/g, (_, key) => tokens[key]?.() ?? '-')
 
     log(message)
 

--- a/packages/remix/.changes/minor.logger-middleware.structured-logging.md
+++ b/packages/remix/.changes/minor.logger-middleware.structured-logging.md
@@ -1,0 +1,1 @@
+Add formatter callbacks to `logger()` from `remix/middleware/logger` for structured request logging.


### PR DESCRIPTION
The logger middleware currently flattens request and response details into a formatted string before passing them to the configured logger. This supports custom destinations, but prevents safely producing structured logs because JSON-shaped string templates do not escape dynamic values.

- Allow `format` to be a callback that receives a typed `LoggerEvent` with the request, response, start and end times, and duration
- Preserve the existing string-template and colorized logging behavior
- Document a JSON structured-logging example in the logger middleware overview
- Add release notes for the owning package and the `remix/middleware/logger` re-export

```ts
logger({
  format({ request, response, start, duration }) {
    let url = new URL(request.url)

    return JSON.stringify({
      timestamp: start.toISOString(),
      method: request.method,
      path: url.pathname + url.search,
      status: response.status,
      duration,
    })
  },
})
```
