### PR TITLE
Add data-schema memory benchmarks

### DIFF
--- a/packages/data-schema/bench/README.md
+++ b/packages/data-schema/bench/README.md
@@ -1,0 +1,52 @@
+# data-schema benchmarks
+
+These experimental benchmarks compare `@remix-run/data-schema`, Zod, and Valibot with equivalent
+object schemas. They cover cold module import footprint, retained schema memory, validation
+throughput, peak heap/RSS growth, and retained memory per validation result.
+
+Every measurement runs in a fresh Node process with explicit garbage collection. The runner reports
+the median of five trials by default. The benchmark builds `@remix-run/data-schema` first and loads
+its distribution JavaScript, matching the code an installed package runs.
+
+```sh
+pnpm bench
+
+# Override the number of trials
+pnpm bench 9
+```
+
+Memory results are useful for comparing libraries on the same machine and Node version. RSS is
+page-granular and V8 heap sizing is adaptive, so small differences should not be treated as exact.
+
+## Latest evidence
+
+Recorded August 12, 2026 on an Apple M4 Pro running macOS 26.5 and Node 24.15.0. Values are the
+median of five trials using `@remix-run/data-schema` 0.3.0, Valibot 1.4.2, and Zod 4.4.3.
+
+| Memory metric        | data-schema |   Valibot |        Zod |
+| -------------------- | ----------: | --------: | ---------: |
+| Cold import heap     |     191 KiB |   698 KiB |   2.14 MiB |
+| Cold import RSS      |    3.41 MiB |  4.27 MiB |  10.86 MiB |
+| Retained heap/schema |   16.26 KiB | 19.40 KiB | 197.99 KiB |
+| Retained RSS/schema  |   20.98 KiB | 35.32 KiB | 260.30 KiB |
+
+| Workload       | Metric     | data-schema |     Valibot |         Zod |
+| -------------- | ---------- | ----------: | ----------: | ----------: |
+| Valid object   | Throughput | 1.12M ops/s | 1.05M ops/s | 1.22M ops/s |
+| Invalid object | Throughput |  676k ops/s |  217k ops/s |   50k ops/s |
+| Valid array    | Throughput |  8.5k ops/s |  8.6k ops/s | 10.9k ops/s |
+| Invalid array  | Throughput |  3.9k ops/s |  1.6k ops/s |  0.7k ops/s |
+| Valid object   | Peak heap  |    4.05 MiB |    4.03 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |    8.34 MiB |   18.12 MiB |   50.59 MiB |
+| Valid array    | Peak heap  |   30.88 MiB |   25.38 MiB |   21.51 MiB |
+| Invalid array  | Peak heap  |   40.09 MiB |   94.31 MiB |  103.24 MiB |
+
+| Retained heap/result | data-schema |    Valibot |        Zod |
+| -------------------- | ----------: | ---------: | ---------: |
+| Valid object         |       483 B |      498 B |      365 B |
+| Invalid object       |    2.73 KiB |   8.37 KiB |   8.94 KiB |
+| Valid array          |   43.38 KiB |  43.50 KiB |  32.40 KiB |
+| Invalid array        |  353.23 KiB | 914.36 KiB | 775.79 KiB |
+
+`data-schema` has the smallest import and schema footprint and uses substantially less memory on
+invalid inputs. Zod is modestly faster and retains smaller results on successful array validation.

--- a/packages/data-schema/bench/README.md
+++ b/packages/data-schema/bench/README.md
@@ -18,35 +18,37 @@ pnpm bench 9
 Memory results are useful for comparing libraries on the same machine and Node version. RSS is
 page-granular and V8 heap sizing is adaptive, so small differences should not be treated as exact.
 
-## Latest evidence
+## Latest stack results
 
-Recorded August 12, 2026 on an Apple M4 Pro running macOS 26.5 and Node 24.15.0. Values are the
-median of five trials using `@remix-run/data-schema` 0.3.0, Valibot 1.4.2, and Zod 4.4.3.
+Recorded September 8, 2026 on an Apple M5 Pro running macOS 26.6.2 and Node 24.15.0. Values are the median of five trials using the full stack, including the validation changes in [#11689 at `0b41dc6`](https://github.com/remix-run/remix/commit/0b41dc68284f2374672217dd6a55d4b9ad01b7f0), with package version 0.3.0, Valibot 1.4.2, and Zod 4.4.3.
 
-| Memory metric        | data-schema |   Valibot |        Zod |
-| -------------------- | ----------: | --------: | ---------: |
-| Cold import heap     |     191 KiB |   698 KiB |   2.14 MiB |
-| Cold import RSS      |    3.41 MiB |  4.27 MiB |  10.86 MiB |
-| Retained heap/schema |   16.26 KiB | 19.40 KiB | 197.99 KiB |
-| Retained RSS/schema  |   20.98 KiB | 35.32 KiB | 260.30 KiB |
+| Memory metric        | data-schema |    Valibot |        Zod |
+| -------------------- | ----------: | ---------: | ---------: |
+| Cold import heap     |  193.41 KiB | 698.14 KiB |   2.13 MiB |
+| Cold import RSS      |    3.59 MiB |   4.41 MiB |  10.69 MiB |
+| Retained heap/schema |   15.83 KiB |  19.39 KiB | 197.99 KiB |
+| Retained RSS/schema  |   22.62 KiB |  35.50 KiB | 260.33 KiB |
 
-| Workload       | Metric     | data-schema |     Valibot |         Zod |
-| -------------- | ---------- | ----------: | ----------: | ----------: |
-| Valid object   | Throughput | 1.12M ops/s | 1.05M ops/s | 1.22M ops/s |
-| Invalid object | Throughput |  676k ops/s |  217k ops/s |   50k ops/s |
-| Valid array    | Throughput |  8.5k ops/s |  8.6k ops/s | 10.9k ops/s |
-| Invalid array  | Throughput |  3.9k ops/s |  1.6k ops/s |  0.7k ops/s |
-| Valid object   | Peak heap  |    4.05 MiB |    4.03 MiB |    4.07 MiB |
-| Invalid object | Peak heap  |    8.34 MiB |   18.12 MiB |   50.59 MiB |
-| Valid array    | Peak heap  |   30.88 MiB |   25.38 MiB |   21.51 MiB |
-| Invalid array  | Peak heap  |   40.09 MiB |   94.31 MiB |  103.24 MiB |
+| Workload       | Metric     |  data-schema |      Valibot |         Zod |
+| -------------- | ---------- | -----------: | -----------: | ----------: |
+| Valid object   | Throughput |  1.64M ops/s |  1.31M ops/s | 1.48M ops/s |
+| Invalid object | Throughput | 901.5k ops/s | 351.6k ops/s | 60.7k ops/s |
+| Valid array    | Throughput |  14.8k ops/s |  10.4k ops/s | 13.1k ops/s |
+| Invalid array  | Throughput |   5.4k ops/s |   1.8k ops/s |  0.8k ops/s |
+| Valid object   | Peak heap  |     2.04 MiB |     4.02 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |     3.98 MiB |    17.99 MiB |   67.18 MiB |
+| Valid array    | Peak heap  |    19.40 MiB |    25.32 MiB |   21.48 MiB |
+| Invalid array  | Peak heap  |    20.91 MiB |    94.31 MiB |  103.70 MiB |
+| Valid object   | Peak RSS   |      352 KiB |     2.69 MiB |     320 KiB |
+| Invalid object | Peak RSS   |     4.42 MiB |    23.38 MiB |   66.59 MiB |
+| Valid array    | Peak RSS   |    41.66 MiB |    44.38 MiB |   39.28 MiB |
+| Invalid array  | Peak RSS   |    35.84 MiB |   128.95 MiB |  125.56 MiB |
 
 | Retained heap/result | data-schema |    Valibot |        Zod |
 | -------------------- | ----------: | ---------: | ---------: |
-| Valid object         |       483 B |      498 B |      365 B |
-| Invalid object       |    2.73 KiB |   8.37 KiB |   8.94 KiB |
-| Valid array          |   43.38 KiB |  43.50 KiB |  32.40 KiB |
-| Invalid array        |  353.23 KiB | 914.36 KiB | 775.79 KiB |
+| Valid object         |       371 B |      498 B |      365 B |
+| Invalid object       |    1.67 KiB |   8.00 KiB |   8.94 KiB |
+| Valid array          |   32.14 KiB |  43.50 KiB |  32.40 KiB |
+| Invalid array        |  168.13 KiB | 914.31 KiB | 775.79 KiB |
 
-`data-schema` has the smallest import and schema footprint and uses substantially less memory on
-invalid inputs. Zod is modestly faster and retains smaller results on successful array validation.
+On these workloads, `data-schema` leads throughput in all four cases and has the lowest peak heap use, import footprint, and retained schema memory. Zod retains 6 fewer bytes per valid object and has lower peak RSS on successful inputs. Small memory differences should be treated as run-to-run variation.

--- a/packages/data-schema/bench/adapters/data-schema.ts
+++ b/packages/data-schema/bench/adapters/data-schema.ts
@@ -1,0 +1,46 @@
+import * as checks from '../../dist/checks.js'
+import * as s from '../../dist/index.js'
+
+import { expectsSuccess, getInput } from '../fixtures.ts'
+import type { BenchmarkAdapter, PreparedBenchmark, WorkloadId } from '../types.ts'
+
+function createUserSchema() {
+  return s.object({
+    id: s.string().pipe(checks.minLength(1), checks.maxLength(64)),
+    name: s.string().pipe(checks.minLength(1), checks.maxLength(80)),
+    email: s.string().pipe(checks.email()),
+    age: s.number().pipe(checks.min(0), checks.max(130)),
+    active: s.boolean(),
+    role: s.enum_(['admin', 'member', 'viewer']),
+    address: s.object({
+      street: s.string().pipe(checks.minLength(1)),
+      city: s.string().pipe(checks.minLength(1)),
+      postalCode: s.string().pipe(checks.minLength(1), checks.maxLength(20)),
+    }),
+    tags: s.array(s.string().pipe(checks.maxLength(24))),
+    metadata: s.object({
+      createdAt: s.string(),
+      score: s.number(),
+      verified: s.boolean(),
+    }),
+  })
+}
+
+function createSchema(): object {
+  return createUserSchema()
+}
+
+function prepare(workload: WorkloadId): PreparedBenchmark {
+  let input = getInput(workload)
+  let expectedSuccess = expectsSuccess(workload)
+
+  if (workload.endsWith('-array')) {
+    let schema = s.array(createUserSchema())
+    return { expectedSuccess, run: () => s.parseSafe(schema, input) }
+  }
+
+  let schema = createUserSchema()
+  return { expectedSuccess, run: () => s.parseSafe(schema, input) }
+}
+
+export const adapter: BenchmarkAdapter = { createSchema, prepare }

--- a/packages/data-schema/bench/adapters/valibot.ts
+++ b/packages/data-schema/bench/adapters/valibot.ts
@@ -1,0 +1,40 @@
+import * as v from 'valibot'
+
+import { expectsSuccess, getInput } from '../fixtures.ts'
+import type { BenchmarkAdapter, PreparedBenchmark, WorkloadId } from '../types.ts'
+
+function createUserSchema() {
+  return v.object({
+    id: v.pipe(v.string(), v.minLength(1), v.maxLength(64)),
+    name: v.pipe(v.string(), v.minLength(1), v.maxLength(80)),
+    email: v.pipe(v.string(), v.email()),
+    age: v.pipe(v.number(), v.minValue(0), v.maxValue(130)),
+    active: v.boolean(),
+    role: v.picklist(['admin', 'member', 'viewer']),
+    address: v.object({
+      street: v.pipe(v.string(), v.minLength(1)),
+      city: v.pipe(v.string(), v.minLength(1)),
+      postalCode: v.pipe(v.string(), v.minLength(1), v.maxLength(20)),
+    }),
+    tags: v.array(v.pipe(v.string(), v.maxLength(24))),
+    metadata: v.object({
+      createdAt: v.string(),
+      score: v.number(),
+      verified: v.boolean(),
+    }),
+  })
+}
+
+function createSchema(): object {
+  return createUserSchema()
+}
+
+function prepare(workload: WorkloadId): PreparedBenchmark {
+  let schema = workload.endsWith('-array') ? v.array(createUserSchema()) : createUserSchema()
+  let input = getInput(workload)
+  let expectedSuccess = expectsSuccess(workload)
+
+  return { expectedSuccess, run: () => v.safeParse(schema, input) }
+}
+
+export const adapter: BenchmarkAdapter = { createSchema, prepare }

--- a/packages/data-schema/bench/adapters/zod.ts
+++ b/packages/data-schema/bench/adapters/zod.ts
@@ -1,0 +1,40 @@
+import * as z from 'zod'
+
+import { expectsSuccess, getInput } from '../fixtures.ts'
+import type { BenchmarkAdapter, PreparedBenchmark, WorkloadId } from '../types.ts'
+
+function createUserSchema() {
+  return z.object({
+    id: z.string().min(1).max(64),
+    name: z.string().min(1).max(80),
+    email: z.string().email(),
+    age: z.number().min(0).max(130),
+    active: z.boolean(),
+    role: z.enum(['admin', 'member', 'viewer']),
+    address: z.object({
+      street: z.string().min(1),
+      city: z.string().min(1),
+      postalCode: z.string().min(1).max(20),
+    }),
+    tags: z.array(z.string().max(24)),
+    metadata: z.object({
+      createdAt: z.string(),
+      score: z.number(),
+      verified: z.boolean(),
+    }),
+  })
+}
+
+function createSchema(): object {
+  return createUserSchema()
+}
+
+function prepare(workload: WorkloadId): PreparedBenchmark {
+  let schema = workload.endsWith('-array') ? z.array(createUserSchema()) : createUserSchema()
+  let input = getInput(workload)
+  let expectedSuccess = expectsSuccess(workload)
+
+  return { expectedSuccess, run: () => schema.safeParse(input) }
+}
+
+export const adapter: BenchmarkAdapter = { createSchema, prepare }

--- a/packages/data-schema/bench/fixtures.ts
+++ b/packages/data-schema/bench/fixtures.ts
@@ -1,0 +1,68 @@
+import type { WorkloadId } from './types.ts'
+
+const validUser = {
+  id: 'user_123',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  age: 36,
+  active: true,
+  role: 'admin',
+  address: {
+    street: '12 St James Square',
+    city: 'London',
+    postalCode: 'SW1Y 4JH',
+  },
+  tags: ['math', 'programming', 'history'],
+  metadata: {
+    createdAt: '2026-08-12T12:00:00.000Z',
+    score: 99.5,
+    verified: true,
+  },
+}
+
+const invalidUser = {
+  id: '',
+  name: '',
+  email: 'not-an-email',
+  age: -1,
+  active: 'yes',
+  role: 'owner',
+  address: {
+    street: 12,
+    city: '',
+    postalCode: 90210,
+  },
+  tags: ['this tag is much longer than twenty-four characters', 42],
+  metadata: {
+    createdAt: null,
+    score: Number.NaN,
+    verified: 'yes',
+  },
+}
+
+const validUsers = Array.from({ length: 100 }, (_, index) => ({
+  ...validUser,
+  id: `user_${index}`,
+}))
+
+const invalidUsers = Array.from({ length: 100 }, (_, index) => ({
+  ...invalidUser,
+  id: index % 2 === 0 ? '' : index,
+}))
+
+export function getInput(workload: WorkloadId): unknown {
+  switch (workload) {
+    case 'valid-object':
+      return validUser
+    case 'invalid-object':
+      return invalidUser
+    case 'valid-array':
+      return validUsers
+    case 'invalid-array':
+      return invalidUsers
+  }
+}
+
+export function expectsSuccess(workload: WorkloadId): boolean {
+  return workload === 'valid-object' || workload === 'valid-array'
+}

--- a/packages/data-schema/bench/package.json
+++ b/packages/data-schema/bench/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "data-schema-bench",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prebench": "pnpm --dir .. run build",
+    "bench": "node --disable-warning=ExperimentalWarning runner.ts",
+    "pretypecheck": "pnpm --dir .. run build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@remix-run/data-schema": "workspace:*",
+    "valibot": "1.4.2",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/data-schema/bench/runner.ts
+++ b/packages/data-schema/bench/runner.ts
@@ -1,0 +1,261 @@
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { spawn } from 'node:child_process'
+
+import { libraryIds, workloadIds } from './types.ts'
+import type {
+  ImportResult,
+  LibraryId,
+  RetainedResult,
+  SchemaResult,
+  ValidationResult,
+  WorkerResult,
+  WorkloadId,
+} from './types.ts'
+
+const defaultTrials = 5
+const workerPath = path.join(import.meta.dirname, 'worker.ts')
+
+function median(values: number[]): number {
+  let sorted = values.toSorted((left, right) => left - right)
+  let middle = Math.floor(sorted.length / 2)
+  let value = sorted[middle]
+  if (value === undefined) throw new Error('Cannot take the median of an empty array')
+  if (sorted.length % 2 === 1) return value
+  let previous = sorted[middle - 1]
+  if (previous === undefined) throw new Error('Invalid median input')
+  return (previous + value) / 2
+}
+
+function formatBytes(value: number): string {
+  let absolute = Math.abs(value)
+  if (absolute >= 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(2)} MiB`
+  if (absolute >= 1024) return `${(value / 1024).toFixed(2)} KiB`
+  return `${value.toFixed(0)} B`
+}
+
+function formatOps(value: number): string {
+  return value >= 1_000_000
+    ? `${(value / 1_000_000).toFixed(2)}M ops/s`
+    : `${(value / 1_000).toFixed(1)}k ops/s`
+}
+
+function runWorker(
+  mode: WorkerResult['mode'],
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<WorkerResult> {
+  return new Promise((resolve, reject) => {
+    let child = spawn(
+      process.execPath,
+      ['--expose-gc', workerPath, mode, library, ...(workload ? [workload] : [])],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => (stdout += chunk))
+    child.stderr.on('data', (chunk: string) => (stderr += chunk))
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Worker failed (${mode}/${library}/${workload ?? '-'}): ${stderr}`))
+        return
+      }
+
+      try {
+        resolve(parseWorkerResult(JSON.parse(stdout)))
+      } catch (error) {
+        reject(new Error(`Invalid worker output: ${stdout}`, { cause: error }))
+      }
+    })
+  })
+}
+
+function readString(value: object, key: string): string {
+  let result = Reflect.get(value, key)
+  if (typeof result !== 'string') throw new Error(`Expected ${key} to be a string`)
+  return result
+}
+
+function readNumber(value: object, key: string): number {
+  let result = Reflect.get(value, key)
+  if (typeof result !== 'number' || !Number.isFinite(result)) {
+    throw new Error(`Expected ${key} to be a finite number`)
+  }
+  return result
+}
+
+function parseWorkerResult(value: unknown): WorkerResult {
+  if (typeof value !== 'object' || value === null) throw new Error('Expected an object')
+  let mode = readString(value, 'mode')
+  let libraryValue = readString(value, 'library')
+  let library = libraryIds.find((candidate) => candidate === libraryValue)
+  if (library === undefined) throw new Error(`Unknown result library: ${libraryValue}`)
+
+  switch (mode) {
+    case 'import':
+      return {
+        mode,
+        library,
+        heapUsedDelta: readNumber(value, 'heapUsedDelta'),
+        heapTotalDelta: readNumber(value, 'heapTotalDelta'),
+        rssDelta: readNumber(value, 'rssDelta'),
+        externalDelta: readNumber(value, 'externalDelta'),
+      }
+    case 'schema':
+      return {
+        mode,
+        library,
+        count: readNumber(value, 'count'),
+        retainedHeapBytesPerSchema: readNumber(value, 'retainedHeapBytesPerSchema'),
+        rssBytesPerSchema: readNumber(value, 'rssBytesPerSchema'),
+      }
+    case 'validate':
+    case 'retain': {
+      let workloadValue = readString(value, 'workload')
+      let workload = workloadIds.find((candidate) => candidate === workloadValue)
+      if (workload === undefined) throw new Error(`Unknown result workload: ${workloadValue}`)
+      if (mode === 'validate') {
+        return {
+          mode,
+          library,
+          workload,
+          iterations: readNumber(value, 'iterations'),
+          operationsPerSecond: readNumber(value, 'operationsPerSecond'),
+          peakHeapDelta: readNumber(value, 'peakHeapDelta'),
+          peakRssDelta: readNumber(value, 'peakRssDelta'),
+          retainedHeapDelta: readNumber(value, 'retainedHeapDelta'),
+        }
+      }
+      return {
+        mode,
+        library,
+        workload,
+        count: readNumber(value, 'count'),
+        retainedHeapBytesPerResult: readNumber(value, 'retainedHeapBytesPerResult'),
+      }
+    }
+    default:
+      throw new Error(`Unknown result mode: ${mode}`)
+  }
+}
+
+function repeat(
+  trials: number,
+  mode: 'import',
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<ImportResult[]>
+function repeat(
+  trials: number,
+  mode: 'schema',
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<SchemaResult[]>
+function repeat(
+  trials: number,
+  mode: 'validate',
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<ValidationResult[]>
+function repeat(
+  trials: number,
+  mode: 'retain',
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<RetainedResult[]>
+async function repeat(
+  trials: number,
+  mode: WorkerResult['mode'],
+  library: LibraryId,
+  workload?: WorkloadId,
+): Promise<WorkerResult[]> {
+  let results: WorkerResult[] = []
+  for (let trial = 0; trial < trials; trial++) {
+    let result = await runWorker(mode, library, workload)
+    if (result.mode !== mode) throw new Error(`Expected ${mode} result, received ${result.mode}`)
+    results.push(result)
+  }
+  return results
+}
+
+async function main(): Promise<void> {
+  let trials = Number.parseInt(process.argv[2] ?? String(defaultTrials), 10)
+  if (!Number.isSafeInteger(trials) || trials < 1) throw new Error('Trials must be positive')
+
+  console.log(`Platform: ${os.type()} ${os.release()} (${os.arch()})`)
+  console.log(`CPU: ${os.cpus()[0]?.model ?? 'unknown'}`)
+  console.log(`Node: ${process.version}`)
+  console.log(`Trials: ${trials} (median reported; each trial uses a fresh process)\n`)
+
+  let importTable: Record<string, Record<string, string>> = {}
+  for (let library of libraryIds) {
+    let results = await repeat(trials, 'import', library)
+    importTable[library] = {
+      'heap used': formatBytes(median(results.map((result) => result.heapUsedDelta))),
+      'heap capacity': formatBytes(median(results.map((result) => result.heapTotalDelta))),
+      RSS: formatBytes(median(results.map((result) => result.rssDelta))),
+    }
+  }
+  console.log('Cold module import footprint')
+  console.table(importTable)
+
+  let schemaTable: Record<string, Record<string, string>> = {}
+  for (let library of libraryIds) {
+    let results = await repeat(trials, 'schema', library)
+    schemaTable[library] = {
+      'retained heap/schema': formatBytes(
+        median(results.map((result) => result.retainedHeapBytesPerSchema)),
+      ),
+      'RSS/schema': formatBytes(median(results.map((result) => result.rssBytesPerSchema))),
+    }
+  }
+  console.log('\nRetained memory for 2,000 independently constructed equivalent schemas')
+  console.table(schemaTable)
+
+  let throughputTable: Record<string, Record<string, string>> = {}
+  let peakTable: Record<string, Record<string, string>> = {}
+  let peakRssTable: Record<string, Record<string, string>> = {}
+  for (let library of libraryIds) {
+    throughputTable[library] = {}
+    peakTable[library] = {}
+    peakRssTable[library] = {}
+    for (let workload of workloadIds) {
+      let results = await repeat(trials, 'validate', library, workload)
+      throughputTable[library][workload] = formatOps(
+        median(results.map((result) => result.operationsPerSecond)),
+      )
+      peakTable[library][workload] = formatBytes(
+        median(results.map((result) => result.peakHeapDelta)),
+      )
+      peakRssTable[library][workload] = formatBytes(
+        median(results.map((result) => result.peakRssDelta)),
+      )
+    }
+  }
+  console.log('\nValidation throughput')
+  console.table(throughputTable)
+  console.log('\nPeak heap growth during validation batch')
+  console.table(peakTable)
+  console.log('\nPeak RSS growth during validation batch')
+  console.table(peakRssTable)
+
+  let retainedResultTable: Record<string, Record<string, string>> = {}
+  for (let library of libraryIds) {
+    retainedResultTable[library] = {}
+    for (let workload of workloadIds) {
+      let results = await repeat(trials, 'retain', library, workload)
+      retainedResultTable[library][workload] = formatBytes(
+        median(results.map((result) => result.retainedHeapBytesPerResult)),
+      )
+    }
+  }
+  console.log('\nRetained heap per validation result')
+  console.table(retainedResultTable)
+}
+
+await main()

--- a/packages/data-schema/bench/tsconfig.json
+++ b/packages/data-schema/bench/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true
+  }
+}

--- a/packages/data-schema/bench/types.ts
+++ b/packages/data-schema/bench/types.ts
@@ -1,0 +1,65 @@
+export const libraryIds = ['data-schema', 'zod', 'valibot'] as const
+export type LibraryId = (typeof libraryIds)[number]
+
+export const workloadIds = [
+  'valid-object',
+  'invalid-object',
+  'valid-array',
+  'invalid-array',
+] as const
+export type WorkloadId = (typeof workloadIds)[number]
+
+export interface PreparedBenchmark {
+  expectedSuccess: boolean
+  run(): unknown
+}
+
+export interface BenchmarkAdapter {
+  createSchema(): object
+  prepare(workload: WorkloadId): PreparedBenchmark
+}
+
+export type MemorySnapshot = {
+  heapUsed: number
+  heapTotal: number
+  rss: number
+  external: number
+}
+
+export type ImportResult = {
+  mode: 'import'
+  library: LibraryId
+  heapUsedDelta: number
+  heapTotalDelta: number
+  rssDelta: number
+  externalDelta: number
+}
+
+export type SchemaResult = {
+  mode: 'schema'
+  library: LibraryId
+  count: number
+  retainedHeapBytesPerSchema: number
+  rssBytesPerSchema: number
+}
+
+export type ValidationResult = {
+  mode: 'validate'
+  library: LibraryId
+  workload: WorkloadId
+  iterations: number
+  operationsPerSecond: number
+  peakHeapDelta: number
+  peakRssDelta: number
+  retainedHeapDelta: number
+}
+
+export type RetainedResult = {
+  mode: 'retain'
+  library: LibraryId
+  workload: WorkloadId
+  count: number
+  retainedHeapBytesPerResult: number
+}
+
+export type WorkerResult = ImportResult | SchemaResult | ValidationResult | RetainedResult

--- a/packages/data-schema/bench/worker.ts
+++ b/packages/data-schema/bench/worker.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+
+import { libraryIds, workloadIds } from './types.ts'
+import type {
+  BenchmarkAdapter,
+  ImportResult,
+  LibraryId,
+  MemorySnapshot,
+  RetainedResult,
+  SchemaResult,
+  ValidationResult,
+  WorkerResult,
+  WorkloadId,
+} from './types.ts'
+
+type Mode = WorkerResult['mode']
+
+const schemaCount = 2_000
+const warmupIterations = 2_000
+const objectIterations = 20_000
+const arrayIterations = 500
+
+function collectGarbage(): void {
+  if (globalThis.gc === undefined) {
+    throw new Error('Run the benchmark worker with --expose-gc')
+  }
+
+  for (let index = 0; index < 3; index++) globalThis.gc()
+}
+
+function getMemory(): MemorySnapshot {
+  let memory = process.memoryUsage()
+  return {
+    heapUsed: memory.heapUsed,
+    heapTotal: memory.heapTotal,
+    rss: memory.rss,
+    external: memory.external,
+  }
+}
+
+async function loadAdapter(library: LibraryId): Promise<BenchmarkAdapter> {
+  switch (library) {
+    case 'data-schema':
+      return (await import('./adapters/data-schema.ts')).adapter
+    case 'zod':
+      return (await import('./adapters/zod.ts')).adapter
+    case 'valibot':
+      return (await import('./adapters/valibot.ts')).adapter
+  }
+}
+
+async function measureImport(library: LibraryId): Promise<ImportResult> {
+  collectGarbage()
+  let before = getMemory()
+  let adapter = await loadAdapter(library)
+  assert.equal(typeof adapter.createSchema, 'function')
+  collectGarbage()
+  let after = getMemory()
+
+  return {
+    mode: 'import',
+    library,
+    heapUsedDelta: after.heapUsed - before.heapUsed,
+    heapTotalDelta: after.heapTotal - before.heapTotal,
+    rssDelta: after.rss - before.rss,
+    externalDelta: after.external - before.external,
+  }
+}
+
+async function measureSchema(library: LibraryId): Promise<SchemaResult> {
+  let adapter = await loadAdapter(library)
+  adapter.createSchema()
+  collectGarbage()
+  let before = getMemory()
+  let schemas: object[] = []
+
+  for (let index = 0; index < schemaCount; index++) schemas.push(adapter.createSchema())
+
+  collectGarbage()
+  let after = getMemory()
+  assert.equal(schemas.length, schemaCount)
+  assert.ok(schemas[0] !== schemas[schemaCount - 1])
+
+  return {
+    mode: 'schema',
+    library,
+    count: schemaCount,
+    retainedHeapBytesPerSchema: (after.heapUsed - before.heapUsed) / schemaCount,
+    rssBytesPerSchema: (after.rss - before.rss) / schemaCount,
+  }
+}
+
+function getIterations(workload: WorkloadId): number {
+  if (workload === 'invalid-array') return 100
+  if (workload === 'valid-array') return arrayIterations
+  if (workload === 'invalid-object') return 5_000
+  return objectIterations
+}
+
+function getWarmupIterations(workload: WorkloadId): number {
+  return workload.endsWith('-array') ? 50 : warmupIterations
+}
+
+function verifyResult(result: unknown, expectedSuccess: boolean): void {
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    Reflect.get(result, 'success') !== expectedSuccess
+  ) {
+    throw new Error(`Validation result did not have success=${String(expectedSuccess)}`)
+  }
+}
+
+async function measureValidation(
+  library: LibraryId,
+  workload: WorkloadId,
+): Promise<ValidationResult> {
+  let adapter = await loadAdapter(library)
+  let benchmark = adapter.prepare(workload)
+  for (let index = 0; index < getWarmupIterations(workload); index++) {
+    verifyResult(benchmark.run(), benchmark.expectedSuccess)
+  }
+
+  collectGarbage()
+  let before = getMemory()
+  let peakHeapUsed = before.heapUsed
+  let peakRss = before.rss
+  let iterations = getIterations(workload)
+  let retainedResults: unknown[] = new Array(256)
+  let startedAt = performance.now()
+
+  for (let index = 0; index < iterations; index++) {
+    let result = benchmark.run()
+    verifyResult(result, benchmark.expectedSuccess)
+    retainedResults[index % retainedResults.length] = result
+    if (index % 50 === 0) {
+      let memory = process.memoryUsage()
+      peakHeapUsed = Math.max(peakHeapUsed, memory.heapUsed)
+      peakRss = Math.max(peakRss, memory.rss)
+    }
+  }
+
+  let elapsed = performance.now() - startedAt
+  let beforeGc = getMemory()
+  peakHeapUsed = Math.max(peakHeapUsed, beforeGc.heapUsed)
+  peakRss = Math.max(peakRss, beforeGc.rss)
+  retainedResults.length = 0
+  collectGarbage()
+  let afterGc = getMemory()
+
+  return {
+    mode: 'validate',
+    library,
+    workload,
+    iterations,
+    operationsPerSecond: iterations / (elapsed / 1_000),
+    peakHeapDelta: peakHeapUsed - before.heapUsed,
+    peakRssDelta: peakRss - before.rss,
+    retainedHeapDelta: afterGc.heapUsed - before.heapUsed,
+  }
+}
+
+function getRetentionCount(workload: WorkloadId): number {
+  if (workload === 'invalid-array') return 20
+  if (workload === 'valid-array') return 100
+  return 2_000
+}
+
+async function measureRetainedResults(
+  library: LibraryId,
+  workload: WorkloadId,
+): Promise<RetainedResult> {
+  let adapter = await loadAdapter(library)
+  let benchmark = adapter.prepare(workload)
+  for (let index = 0; index < getWarmupIterations(workload); index++) {
+    verifyResult(benchmark.run(), benchmark.expectedSuccess)
+  }
+
+  collectGarbage()
+  let before = getMemory()
+  let count = getRetentionCount(workload)
+  let retainedResults: unknown[] = []
+  for (let index = 0; index < count; index++) {
+    let result = benchmark.run()
+    verifyResult(result, benchmark.expectedSuccess)
+    retainedResults.push(result)
+  }
+  collectGarbage()
+  let after = getMemory()
+  assert.equal(retainedResults.length, count)
+  assert.ok(retainedResults[0] !== retainedResults[count - 1])
+
+  return {
+    mode: 'retain',
+    library,
+    workload,
+    count,
+    retainedHeapBytesPerResult: (after.heapUsed - before.heapUsed) / count,
+  }
+}
+
+function parseLibrary(value: string | undefined): LibraryId {
+  for (let library of libraryIds) if (library === value) return library
+  throw new Error(`Unknown library: ${value ?? '<missing>'}`)
+}
+
+function parseWorkload(value: string | undefined): WorkloadId {
+  for (let workload of workloadIds) if (workload === value) return workload
+  throw new Error(`Unknown workload: ${value ?? '<missing>'}`)
+}
+
+function parseMode(value: string | undefined): Mode {
+  switch (value) {
+    case 'import':
+    case 'schema':
+    case 'validate':
+    case 'retain':
+      return value
+    default:
+      throw new Error(`Unknown mode: ${value ?? '<missing>'}`)
+  }
+}
+
+async function main(): Promise<void> {
+  let mode = parseMode(process.argv[2])
+  let library = parseLibrary(process.argv[3])
+  let result: WorkerResult
+
+  switch (mode) {
+    case 'import':
+      result = await measureImport(library)
+      break
+    case 'schema':
+      result = await measureSchema(library)
+      break
+    case 'validate':
+      result = await measureValidation(library, parseWorkload(process.argv[4]))
+      break
+    case 'retain':
+      result = await measureRetainedResults(library, parseWorkload(process.argv[4]))
+      break
+  }
+
+  process.stdout.write(JSON.stringify(result))
+}
+
+await main()

--- a/packages/data-schema/tsconfig.json
+++ b/packages/data-schema/tsconfig.json
@@ -12,5 +12,5 @@
     "erasableSyntaxOnly": true,
     "isolatedModules": true
   },
-  "exclude": ["vendor", "dist"]
+  "exclude": ["bench", "vendor", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  packages/data-schema/bench:
+    dependencies:
+      '@remix-run/data-schema':
+        specifier: workspace:*
+        version: link:..
+      valibot:
+        specifier: 1.4.2
+        version: 1.4.2(typescript@7.0.2)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   packages/data-table:
     devDependencies:
       '@remix-run/assert':
@@ -6129,6 +6148,14 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -6330,6 +6357,9 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -9973,6 +10003,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
   vary@1.1.2: {}
 
   vfile-message@4.0.3:
@@ -10140,5 +10174,7 @@ snapshots:
       '@speed-highlight/core': 1.2.12
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  packages/data-schema/bench:
+    dependencies:
+      '@remix-run/data-schema':
+        specifier: workspace:*
+        version: link:..
+      valibot:
+        specifier: 1.4.2
+        version: 1.4.2(typescript@7.0.2)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   packages/data-table:
     devDependencies:
       '@remix-run/assert':
@@ -6166,6 +6185,14 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -6367,6 +6394,9 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10041,6 +10071,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
   vary@1.1.2: {}
 
   vfile-message@4.0.3:
@@ -10208,5 +10242,7 @@ snapshots:
       '@speed-highlight/core': 1.2.12
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ packages:
   - packages/*/demo
   - packages/assets/bench
   - packages/cli/test/fixtures/*
+  - packages/data-schema/bench
   - packages/fetch-router/demos/*
   - packages/form-data-parser/demos/*
   - packages/ui/bench

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ packages:
   - packages/*/demo
   - packages/assets/bench
   - packages/cli/test/fixtures/*
+  - packages/data-schema/bench
   - packages/fetch-router/demos/*
   - packages/form-data-parser/demos/*
   - packages/ui/bench


### PR DESCRIPTION
Adds a reproducible benchmark suite for comparing `@remix-run/data-schema` with Zod and Valibot. It measures cold import footprint, retained schema memory, validation throughput, peak heap/RSS growth, and retained memory per result. The results below cover the full stack, including the optimization in #11689.

Recorded September 8, 2026 on an Apple M5 Pro running macOS 26.6.2 and Node 24.15.0. Values are the median of five trials using the full stack, including the validation changes in [#11689 at `0b41dc6`](https://github.com/remix-run/remix/commit/0b41dc68284f2374672217dd6a55d4b9ad01b7f0), with package version 0.3.0, Valibot 1.4.2, and Zod 4.4.3.

| Memory metric | data-schema | Valibot | Zod |
| --- | ---: | ---: | ---: |
| Cold import heap | 193.41 KiB | 698.14 KiB | 2.13 MiB |
| Cold import RSS | 3.59 MiB | 4.41 MiB | 10.69 MiB |
| Retained heap/schema | 15.83 KiB | 19.39 KiB | 197.99 KiB |
| Retained RSS/schema | 22.62 KiB | 35.50 KiB | 260.33 KiB |

| Workload | Metric | data-schema | Valibot | Zod |
| --- | --- | ---: | ---: | ---: |
| Valid object | Throughput | 1.64M ops/s | 1.31M ops/s | 1.48M ops/s |
| Invalid object | Throughput | 901.5k ops/s | 351.6k ops/s | 60.7k ops/s |
| Valid array | Throughput | 14.8k ops/s | 10.4k ops/s | 13.1k ops/s |
| Invalid array | Throughput | 5.4k ops/s | 1.8k ops/s | 0.8k ops/s |
| Valid object | Peak heap | 2.04 MiB | 4.02 MiB | 4.07 MiB |
| Invalid object | Peak heap | 3.98 MiB | 17.99 MiB | 67.18 MiB |
| Valid array | Peak heap | 19.40 MiB | 25.32 MiB | 21.48 MiB |
| Invalid array | Peak heap | 20.91 MiB | 94.31 MiB | 103.70 MiB |
| Valid object | Peak RSS | 352 KiB | 2.69 MiB | 320 KiB |
| Invalid object | Peak RSS | 4.42 MiB | 23.38 MiB | 66.59 MiB |
| Valid array | Peak RSS | 41.66 MiB | 44.38 MiB | 39.28 MiB |
| Invalid array | Peak RSS | 35.84 MiB | 128.95 MiB | 125.56 MiB |

| Retained heap/result | data-schema | Valibot | Zod |
| --- | ---: | ---: | ---: |
| Valid object | 371 B | 498 B | 365 B |
| Invalid object | 1.67 KiB | 8.00 KiB | 8.94 KiB |
| Valid array | 32.14 KiB | 43.50 KiB | 32.40 KiB |
| Invalid array | 168.13 KiB | 914.31 KiB | 775.79 KiB |

On these workloads, `data-schema` leads throughput in all four cases and has the lowest peak heap use, import footprint, and retained schema memory. Zod retains 6 fewer bytes per valid object and has lower peak RSS on successful inputs. Small memory differences should be treated as run-to-run variation.

Each measurement runs in a fresh Node process with explicit garbage collection, exercises equivalent valid and invalid object/array workloads, and loads data-schema’s built distribution.

```sh
pnpm --dir packages/data-schema/bench bench 5
```
