### PR TITLE
Harden client entry and frame boundary reconciliation

### DIFF
--- a/demos/frames/app/router.test.ts
+++ b/demos/frames/app/router.test.ts
@@ -50,6 +50,13 @@ describe('router', () => {
     assert.ok(time.includes('In a frame'))
     assert.ok(!time.includes('<\\/template'))
   })
+
+  it('renders the reload scope page with source-resolved client entries', async () => {
+    let response = await router.fetch(new Request('http://localhost/reload-scope'))
+
+    assert.equal(response.status, 200)
+    assert.match(await response.text(), /Reload top frame/)
+  })
 })
 
 async function* readChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string, void, void> {

--- a/packages/ui/.changes/patch.harden-boundary-reconciliation.md
+++ b/packages/ui/.changes/patch.harden-boundary-reconciliation.md
@@ -1,0 +1,1 @@
+Preserve client entry and frame state only for live boundaries with matching semantic identities, while replacing pending client entry SSR during reloads and releasing temporary response metadata after hydration or cancellation.

--- a/packages/ui/src/runtime/client-entry-boundary.ts
+++ b/packages/ui/src/runtime/client-entry-boundary.ts
@@ -1,0 +1,54 @@
+import type { VirtualRoot } from './vdom.ts'
+
+export type ClientEntryIdentity = {
+  moduleUrl: string
+  exportName: string
+}
+
+type ClientEntryRoot = Pick<VirtualRoot, 'dispose' | 'render'>
+
+export type ClientEntryBoundaryOwner = {
+  identity: ClientEntryIdentity
+  root: ClientEntryRoot
+}
+
+const CLIENT_ENTRY_BOUNDARY_OWNER = Symbol('ClientEntryBoundaryOwner')
+
+type ClientEntryBoundaryMarker = Comment & {
+  [CLIENT_ENTRY_BOUNDARY_OWNER]?: ClientEntryBoundaryOwner
+  $rmx?: ClientEntryRoot
+}
+
+export function getClientEntryBoundaryOwner(marker: Comment): ClientEntryBoundaryOwner | undefined {
+  return (marker as ClientEntryBoundaryMarker)[CLIENT_ENTRY_BOUNDARY_OWNER]
+}
+
+export function setClientEntryBoundaryOwner(
+  marker: Comment,
+  identity: ClientEntryIdentity,
+  root: ClientEntryRoot,
+): ClientEntryBoundaryOwner {
+  let owner = { identity, root }
+  Object.defineProperties(marker, {
+    [CLIENT_ENTRY_BOUNDARY_OWNER]: {
+      configurable: true,
+      value: owner,
+    },
+    $rmx: {
+      configurable: true,
+      value: root,
+    },
+  })
+  return owner
+}
+
+export function disposeClientEntryBoundary(marker: Comment): boolean {
+  let boundaryMarker = marker as ClientEntryBoundaryMarker
+  let owner = boundaryMarker[CLIENT_ENTRY_BOUNDARY_OWNER]
+  if (!owner) return false
+
+  delete boundaryMarker[CLIENT_ENTRY_BOUNDARY_OWNER]
+  delete boundaryMarker.$rmx
+  owner.root.dispose()
+  return true
+}

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -66,43 +66,43 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
   // Comment -> Comment
   if (isCommentNode(current) && isCommentNode(next) && markerKindsMatch(current, next)) {
     let newData = next.data
-    if (current.data !== newData) {
-      let updated = false
-      if (isFrameStartMarker(current)) {
-        if (shouldPreserveFrameStartMarker(current, next, context)) {
+    let updated = false
+    if (isFrameStartMarker(current)) {
+      if (shouldPreserveFrameStartMarker(current, next, context)) {
+        if (current.data !== newData) {
           current.data = newData
-          updated = true
-
-          let frame = context.frameInstances.get(current)
-          let nextMarkerData = getFrameMarkerData(next, context)
-          if (frame && nextMarkerData) {
-            if (nextMarkerData.status === 'resolved') {
-              let nextEnd = findFrameEndMarker(next)
-              let nextContent = collectFrameContentFragment(current.ownerDocument, next, nextEnd)
-              void frame.renderMarkerContent(
-                { ...nextMarkerData, id: getFrameId(next) },
-                nextContent,
-                {
-                  data: context.data,
-                  signal: context.signal,
-                },
-              )
-              return nextEnd
-            }
-
-            if (frame.isDisplayingResolvedContent()) {
-              return findFrameEndMarker(next)
-            }
-          }
-        } else {
-          disposeFrameStartMarker(current, context)
-          current.data = newData
-          updated = true
         }
-      }
-      if (!updated) {
+        updated = true
+
+        let frame = context.frameInstances.get(current)
+        let nextMarkerData = getFrameMarkerData(next, context)
+        if (frame && nextMarkerData) {
+          if (nextMarkerData.status === 'resolved') {
+            let nextEnd = findFrameEndMarker(next)
+            let nextContent = collectFrameContentFragment(current.ownerDocument, next, nextEnd)
+            void frame.renderMarkerContent(
+              { ...nextMarkerData, id: getFrameId(next) },
+              nextContent,
+              {
+                data: context.data,
+                signal: context.signal,
+              },
+            )
+            return nextEnd
+          }
+
+          if (frame.isDisplayingResolvedContent()) {
+            return findFrameEndMarker(next)
+          }
+        }
+      } else if (current.data !== newData) {
+        disposeFrameStartMarker(current, context)
         current.data = newData
+        updated = true
       }
+    }
+    if (!updated && current.data !== newData) {
+      current.data = newData
     }
     return
   }
@@ -261,6 +261,8 @@ function diffSiblingUnits(
   let used = new Array<boolean>(currentUnits.length).fill(false)
   let matchIndexForNext = new Array<number>(nextUnits.length).fill(-1)
 
+  // Reserve globally matched keyed elements and semantic boundaries before
+  // positionally pairing the remaining ordinary siblings.
   for (let i = 0; i < nextUnits.length; i++) {
     let nextUnit = nextUnits[i]
     let matchIndex = -1
@@ -291,18 +293,39 @@ function diffSiblingUnits(
       }
     }
 
-    if (
-      matchIndex === -1 &&
-      nextUnit.kind === 'node' &&
-      i < currentUnits.length &&
-      !used[i] &&
-      siblingUnitsComparable(currentUnits[i], nextUnit)
-    ) {
-      matchIndex = i
-    }
-
     if (matchIndex !== -1) used[matchIndex] = true
     matchIndexForNext[i] = matchIndex
+  }
+
+  let remainingCurrentIndexes: number[] = []
+  for (let i = 0; i < currentUnits.length; i++) {
+    if (!used[i]) remainingCurrentIndexes.push(i)
+  }
+
+  let remainingNextIndexes: number[] = []
+  for (let i = 0; i < nextUnits.length; i++) {
+    if (matchIndexForNext[i] === -1) remainingNextIndexes.push(i)
+  }
+
+  let remainingLength = Math.min(remainingCurrentIndexes.length, remainingNextIndexes.length)
+  for (let i = 0; i < remainingLength; i++) {
+    let currentIndex = remainingCurrentIndexes[i]
+    let nextIndex = remainingNextIndexes[i]
+    let currentUnit = currentUnits[currentIndex]
+    let nextUnit = nextUnits[nextIndex]
+
+    if (
+      currentUnit.kind !== 'node' ||
+      nextUnit.kind !== 'node' ||
+      getSiblingUnitKey(currentUnit) !== undefined ||
+      getSiblingUnitKey(nextUnit) !== undefined ||
+      !siblingUnitsComparable(currentUnit, nextUnit)
+    ) {
+      continue
+    }
+
+    used[currentIndex] = true
+    matchIndexForNext[nextIndex] = currentIndex
   }
 
   let committed = new Array<SiblingUnit>(nextUnits.length)

--- a/packages/ui/src/runtime/diff-dom.ts
+++ b/packages/ui/src/runtime/diff-dom.ts
@@ -1,11 +1,6 @@
 import { invariant } from './invariant.ts'
 import type { FrameContext } from './frame.ts'
-
-type HydratedVirtualRootStartMarker = Comment & {
-  $rmx: {
-    dispose(): void
-  }
-}
+import { disposeClientEntryBoundary, getClientEntryBoundaryOwner } from './client-entry-boundary.ts'
 
 type MarkerKind = 'frame-start' | 'frame-end' | 'virtual-root-start' | 'virtual-root-end'
 
@@ -15,6 +10,23 @@ type CommentMarkerRangeReplacement = {
   currentEndIndex: number
   nextEndIndex: number
 }
+
+type NodeSiblingUnit = {
+  kind: 'node'
+  node: Node
+  startIndex: number
+  endIndex: number
+}
+
+type BoundarySiblingUnit = {
+  kind: 'frame' | 'hydration'
+  start: Comment
+  end: Comment
+  startIndex: number
+  endIndex: number
+}
+
+type SiblingUnit = NodeSiblingUnit | BoundarySiblingUnit
 
 const REMIX_PRESERVE_DOM_ATTRIBUTE = 'rmx-preserve-dom'
 
@@ -28,84 +40,7 @@ export function diffNodes(curr: Node[], next: Node[], context: FrameContext) {
     context.regionTailRef ??
     (curr.length > 0 ? (curr[curr.length - 1].nextSibling as ChildNode | null) : null)
 
-  let currentIndex = 0
-  let nextIndex = 0
-  while (currentIndex < curr.length || nextIndex < next.length) {
-    let c = curr[currentIndex]
-    let n = next[nextIndex]
-
-    if (!c && n) {
-      if (regionTailRef) {
-        parent.insertBefore(n, regionTailRef)
-      } else {
-        parent.appendChild(n)
-      }
-      nextIndex++
-    } else if (c && !n) {
-      removeNode(c, parent, context)
-      currentIndex++
-    } else if (c && n) {
-      let replacement = getCommentMarkerRangeReplacement(
-        c,
-        n,
-        curr,
-        next,
-        currentIndex,
-        nextIndex,
-        context,
-      )
-      if (replacement) {
-        replaceCommentMarkerRange(replacement, parent, context)
-        currentIndex = replacement.currentEndIndex + 1
-        nextIndex = replacement.nextEndIndex + 1
-        continue
-      }
-
-      // Skip hydrated client-entry marker ranges; hydration pass re-renders
-      // roots with new props from incoming payload
-      if (isVirtualRootStartMarker(c) && isVirtualRootStartMarker(n)) {
-        let currentEnd = findHydrationEndMarker(c)
-        let nextEnd = findHydrationEndMarker(n)
-        let nextData = n.data
-        if (c.data !== nextData) c.data = nextData
-
-        let currentEndIndex = curr.indexOf(currentEnd)
-        let nextEndIndex = next.indexOf(nextEnd)
-        currentIndex = currentEndIndex + 1
-        nextIndex = nextEndIndex + 1
-        continue
-      }
-
-      // An obsolete hydration root owns its entire marker-bounded range. Remove
-      // that range atomically so disposal cannot detach nodes that a later
-      // incoming sibling would otherwise match.
-      if (isVirtualRootStartMarker(c)) {
-        let currentEndIndex = findHydrationEndIndex(curr, currentIndex)
-        parent.insertBefore(n, c)
-        for (let i = currentIndex; i <= currentEndIndex; i++) {
-          removeNode(curr[i], parent, context)
-        }
-        currentIndex = currentEndIndex + 1
-        nextIndex++
-        continue
-      }
-
-      let cursor = diffNode(c, n, context)
-      if (cursor) {
-        let nextEndIndex = next.indexOf(cursor)
-        let currentEndIndex =
-          isFrameStartMarker(c) && isFrameEndMarker(cursor)
-            ? findFrameEndIndex(curr, currentIndex)
-            : currentIndex
-        currentIndex = currentEndIndex + 1
-        nextIndex = nextEndIndex + 1
-        continue
-      }
-
-      currentIndex++
-      nextIndex++
-    }
-  }
+  diffSiblingUnits(curr, next, parent, regionTailRef, context)
 }
 
 function diffNode(current: Node, next: Node, context: FrameContext): ChildNode | undefined {
@@ -148,6 +83,7 @@ function diffNode(current: Node, next: Node, context: FrameContext): ChildNode |
                 { ...nextMarkerData, id: getFrameId(next) },
                 nextContent,
                 {
+                  data: context.data,
                   signal: context.signal,
                 },
               )
@@ -303,199 +239,238 @@ function isPopoverOpen(element: Element): boolean {
 function diffElementChildren(current: Element, next: Element, context: FrameContext): void {
   let currentChildren = Array.from(current.childNodes)
   let nextChildren = Array.from(next.childNodes)
-  let ownedByHydrationRange = findNodesOwnedByHydrationRanges(currentChildren)
+  diffSiblingUnits(currentChildren, nextChildren, current, null, context)
+}
 
-  // Keyed map by data-key for current children
+function diffSiblingUnits(
+  currentNodes: Node[],
+  nextNodes: Node[],
+  parent: ParentNode,
+  regionTailRef: ChildNode | null,
+  context: FrameContext,
+): void {
+  let currentUnits = parseSiblingUnits(currentNodes)
+  let nextUnits = parseSiblingUnits(nextNodes)
   let keyToIndex = new Map<string, number>()
-  for (let i = 0; i < currentChildren.length; i++) {
-    if (ownedByHydrationRange[i]) continue
-    let node = currentChildren[i]
-    if (isElement(node)) {
-      let key = node.getAttribute('data-key')
-      if (key != null) keyToIndex.set(key, i)
-    }
+
+  for (let i = 0; i < currentUnits.length; i++) {
+    let key = getSiblingUnitKey(currentUnits[i])
+    if (key !== undefined) keyToIndex.set(key, i)
   }
 
-  let used = new Array<boolean>(currentChildren.length).fill(false)
-  let matchIndexForNext = new Array<number>(nextChildren.length).fill(-1)
+  let used = new Array<boolean>(currentUnits.length).fill(false)
+  let matchIndexForNext = new Array<number>(nextUnits.length).fill(-1)
 
-  for (let i = 0; i < nextChildren.length; i++) {
-    let nextChild = nextChildren[i]
+  for (let i = 0; i < nextUnits.length; i++) {
+    let nextUnit = nextUnits[i]
     let matchIndex = -1
+    let key = getSiblingUnitKey(nextUnit)
 
-    if (isFrameEndMarker(nextChild)) {
-      for (let j = 0; j < currentChildren.length; j++) {
-        if (!ownedByHydrationRange[j] && !used[j] && isFrameEndMarker(currentChildren[j])) {
+    if (key !== undefined) {
+      let keyedIndex = keyToIndex.get(key)
+      if (
+        keyedIndex !== undefined &&
+        !used[keyedIndex] &&
+        siblingUnitsComparable(currentUnits[keyedIndex], nextUnit)
+      ) {
+        matchIndex = keyedIndex
+      }
+    }
+
+    // Boundary identities behave like implicit keys. Repeated boundaries with
+    // the same identity are paired in source order because server markers do
+    // not carry a separate application key.
+    if (matchIndex === -1 && nextUnit.kind !== 'node') {
+      for (let j = 0; j < currentUnits.length; j++) {
+        let currentUnit = currentUnits[j]
+        if (used[j] || currentUnit.kind !== nextUnit.kind) continue
+        if (shouldPreserveBoundaryUnit(currentUnit, nextUnit, context)) {
           matchIndex = j
           break
         }
       }
-    } else if (isElement(nextChild)) {
-      let key = nextChild.getAttribute('data-key')
-      if (key != null && keyToIndex.has(key)) {
-        let idx = keyToIndex.get(key)!
-        if (!used[idx]) matchIndex = idx
-      }
     }
 
-    if (matchIndex === -1) {
-      let candidateIndex = i
-      if (
-        candidateIndex < currentChildren.length &&
-        !ownedByHydrationRange[candidateIndex] &&
-        !used[candidateIndex] &&
-        nodeTypesComparable(currentChildren[candidateIndex], nextChild)
-      ) {
-        matchIndex = candidateIndex
-      }
+    if (
+      matchIndex === -1 &&
+      nextUnit.kind === 'node' &&
+      i < currentUnits.length &&
+      !used[i] &&
+      siblingUnitsComparable(currentUnits[i], nextUnit)
+    ) {
+      matchIndex = i
     }
 
     if (matchIndex !== -1) used[matchIndex] = true
     matchIndexForNext[i] = matchIndex
   }
 
-  // Forward pass: update matched, collect committed
-  let committed: Array<Node | undefined> = new Array(nextChildren.length)
-  for (let i = 0; i < nextChildren.length; i++) {
-    let mi = matchIndexForNext[i]
-    if (mi !== -1) {
-      let curChild = currentChildren[mi]
-      let nextChild = nextChildren[i]
+  let committed = new Array<SiblingUnit>(nextUnits.length)
+  for (let i = 0; i < nextUnits.length; i++) {
+    let matchIndex = matchIndexForNext[i]
+    let nextUnit = nextUnits[i]
+    if (matchIndex === -1) {
+      committed[i] = nextUnit
+      continue
+    }
 
-      let replacement = getCommentMarkerRangeReplacement(
-        curChild,
-        nextChild,
-        currentChildren,
-        nextChildren,
-        mi,
-        i,
-        context,
+    let currentUnit = currentUnits[matchIndex]
+    if (currentUnit.kind === 'node' && nextUnit.kind === 'node') {
+      diffNode(currentUnit.node, nextUnit.node, context)
+      committed[i] = currentUnit
+      continue
+    }
+
+    invariant(currentUnit.kind !== 'node' && nextUnit.kind !== 'node', 'Expected boundaries')
+
+    let replacement = getCommentMarkerRangeReplacement(
+      currentUnit.start,
+      nextUnit.start,
+      currentNodes,
+      nextNodes,
+      currentUnit.startIndex,
+      nextUnit.startIndex,
+      context,
+    )
+    if (replacement) {
+      replaceCommentMarkerRange(replacement, parent, context)
+      committed[i] = nextUnit
+      continue
+    }
+
+    let cursor = diffNode(currentUnit.start, nextUnit.start, context)
+    if (!cursor && currentUnit.kind === 'frame' && nextUnit.kind === 'frame') {
+      diffNodes(
+        collectNodesBetween(currentUnit.start, currentUnit.end),
+        nextNodes.slice(nextUnit.startIndex + 1, nextUnit.endIndex),
+        {
+          ...context,
+          regionParent: parent,
+          regionTailRef: currentUnit.end,
+        },
       )
-      if (replacement) {
-        replaceCommentMarkerRange(replacement, current, context)
-
-        for (let k = mi; k <= replacement.currentEndIndex; k++) used[k] = true
-
-        committed[i] = replacement.nextStart
-        committed[replacement.nextEndIndex] = nextChildren[replacement.nextEndIndex]
-        for (let j = i + 1; j < replacement.nextEndIndex; j++) committed[j] = undefined
-
-        i = replacement.nextEndIndex
-        continue
-      }
-
-      let cursor = diffNode(curChild, nextChild, context)
-      if (cursor) {
-        // `diffNode` can preserve hydration and frame marker ranges by returning
-        // the next end marker, so skip the owned interior nodes here.
-        let nextEndIdx = nextChildren.indexOf(cursor)
-        let currEndIdx =
-          isFrameStartMarker(curChild) && isFrameEndMarker(cursor)
-            ? findFrameEndIndex(currentChildren, mi)
-            : findHydrationEndIndex(currentChildren, mi)
-
-        // Adjacent marker ranges can pre-match into the next range and leave an
-        // orphaned end marker behind. Clear those stale matches first.
-        for (let j = i + 1; j <= nextEndIdx; j++) {
-          let matchedIndex = matchIndexForNext[j]
-          if (matchedIndex > currEndIdx) {
-            used[matchedIndex] = false
-          }
-          matchIndexForNext[j] = -1
-        }
-
-        // Mark the entire current region as used to avoid removals.
-        for (let k = mi; k <= currEndIdx; k++) used[k] = true
-
-        // Preserve both comment markers in committed; skip interior in reorder pass.
-        committed[i] = curChild // start marker
-        committed[nextEndIdx] = currentChildren[currEndIdx] // end marker
-        for (let j = i + 1; j < nextEndIdx; j++) committed[j] = undefined
-
-        // Jump to end of region.
-        i = nextEndIdx
-        continue
-      }
-      committed[i] = curChild
-    } else {
-      committed[i] = nextChildren[i]
     }
+    committed[i] = currentUnit
   }
 
-  // Backward pass: reorder via inserts while avoiding redundant moves
-  let anchor: Node | undefined = undefined
+  let anchor: Node | null = regionTailRef
   for (let i = committed.length - 1; i >= 0; i--) {
-    let node = committed[i]
-    if (!node) continue
+    let unit = committed[i]
+    let first = getSiblingUnitFirstNode(unit)
+    let ref = anchor?.parentNode === parent ? anchor : null
 
-    // Use only an anchor that is actually a child of the current parent
-    let ref = anchor && anchor.parentNode === current ? anchor : null
-
-    // Existing comment markers delimit live ranges, so do not reorder them
-    // independently from their contents. New markers still need to be inserted
-    // before they can be used as anchors.
-    if (getMarkerKind(node) !== undefined) {
-      if (node.parentNode !== current) {
-        current.insertBefore(node, ref)
-      }
-      anchor = node
+    if (
+      unit.kind === 'node' &&
+      isPreservedDomElement(unit.node) &&
+      unit.node.parentNode === parent
+    ) {
+      anchor = unit.node
       continue
     }
 
-    if (isPreservedDomElement(node) && node.parentNode === current) {
-      anchor = node
-      continue
-    }
-
-    if (node.parentNode === current) {
-      // Node already in parent: move only if its nextSibling is not the desired ref.
-      let targetNext = ref
-      let alreadyInPlace =
-        (targetNext === null && node.nextSibling === null) || node.nextSibling === targetNext
-      if (!alreadyInPlace) {
-        current.insertBefore(node, targetNext)
-      }
-    } else {
-      // New node: insert relative to a valid ref or append
-      current.insertBefore(node, ref)
-    }
-
-    // Advance anchor only after the node is placed in the correct parent
-    if (node.parentNode === current) {
-      anchor = node
-    }
+    placeSiblingUnitBefore(unit, parent, ref)
+    if (first.parentNode === parent) anchor = first
   }
 
-  // Remove any current children not used
-  for (let i = 0; i < currentChildren.length; i++) {
-    if (!used[i]) {
-      let nodeToRemove = currentChildren[i]
-      removeNode(nodeToRemove, current, context)
-    }
+  for (let i = 0; i < currentUnits.length; i++) {
+    if (!used[i]) removeSiblingUnit(currentUnits[i], parent, context)
   }
 }
 
-function findNodesOwnedByHydrationRanges(nodes: Node[]): Uint8Array {
-  let owned = new Uint8Array(nodes.length)
+function parseSiblingUnits(nodes: Node[]): SiblingUnit[] {
+  let units: SiblingUnit[] = []
 
-  for (let startIndex = 0; startIndex < nodes.length; startIndex++) {
-    let start = nodes[startIndex]
-    let endIndex = isVirtualRootStartMarker(start)
-      ? findHydrationEndIndex(nodes, startIndex)
-      : startIndex
-
-    if (endIndex === startIndex) continue
-
-    // A hydration root owns its interior DOM even if reconciliation moves that
-    // DOM outside the marker comments. Keep those nodes out of ordinary matching
-    // so disposing the obsolete root cannot remove a newly committed sibling.
-    for (let i = startIndex + 1; i <= endIndex; i++) {
-      owned[i] = 1
+  for (let i = 0; i < nodes.length; i++) {
+    let node = nodes[i]
+    if (isVirtualRootStartMarker(node)) {
+      let endIndex = findHydrationEndIndex(nodes, i)
+      invariant(endIndex > i, 'Hydration end marker not found')
+      let end = nodes[endIndex]
+      invariant(isVirtualRootEndMarker(end), 'Expected hydration end marker')
+      units.push({ kind: 'hydration', start: node, end, startIndex: i, endIndex })
+      i = endIndex
+      continue
     }
-    startIndex = endIndex
+
+    if (isFrameStartMarker(node)) {
+      let endIndex = findFrameEndIndex(nodes, i)
+      invariant(endIndex > i, 'Frame end marker not found')
+      let end = nodes[endIndex]
+      invariant(isFrameEndMarker(end), 'Expected frame end marker')
+      units.push({ kind: 'frame', start: node, end, startIndex: i, endIndex })
+      i = endIndex
+      continue
+    }
+
+    invariant(!isVirtualRootEndMarker(node), 'Unexpected hydration end marker')
+    invariant(!isFrameEndMarker(node), 'Unexpected frame end marker')
+    units.push({ kind: 'node', node, startIndex: i, endIndex: i })
   }
 
-  return owned
+  return units
+}
+
+function getSiblingUnitKey(unit: SiblingUnit): string | undefined {
+  if (unit.kind !== 'node' || !isElement(unit.node)) return
+  return unit.node.getAttribute('data-key') ?? undefined
+}
+
+function siblingUnitsComparable(current: SiblingUnit, next: SiblingUnit): boolean {
+  if (current.kind !== next.kind) return false
+  if (current.kind !== 'node' || next.kind !== 'node') return true
+  return nodeTypesComparable(current.node, next.node)
+}
+
+function shouldPreserveBoundaryUnit(
+  current: BoundarySiblingUnit,
+  next: BoundarySiblingUnit,
+  context: FrameContext,
+): boolean {
+  if (current.kind !== next.kind) return false
+  return current.kind === 'frame'
+    ? shouldPreserveFrameStartMarker(current.start, next.start, context)
+    : shouldPreserveHydrationStartMarker(current.start, next.start, context)
+}
+
+function getSiblingUnitFirstNode(unit: SiblingUnit): Node {
+  return unit.kind === 'node' ? unit.node : unit.start
+}
+
+function placeSiblingUnitBefore(unit: SiblingUnit, parent: ParentNode, ref: Node | null): void {
+  if (unit.kind === 'node') {
+    if (unit.node.parentNode !== parent || unit.node.nextSibling !== ref) {
+      parent.insertBefore(unit.node, ref)
+    }
+    return
+  }
+
+  let nodes = collectNodeRange(unit.start, unit.end)
+  if (unit.start.parentNode === parent && unit.end.nextSibling === ref) return
+
+  let fragment = unit.start.ownerDocument.createDocumentFragment()
+  for (let node of nodes) fragment.appendChild(node)
+  parent.insertBefore(fragment, ref)
+}
+
+function removeSiblingUnit(unit: SiblingUnit, parent: ParentNode, context: FrameContext): void {
+  if (unit.kind === 'node') {
+    removeNode(unit.node, parent, context)
+    return
+  }
+
+  for (let node of collectNodeRange(unit.start, unit.end)) {
+    removeNode(node, parent, context)
+  }
+}
+
+function collectNodesBetween(start: Comment, end: Comment): Node[] {
+  let nodes: Node[] = []
+  let node = start.nextSibling
+  while (node && node !== end) {
+    nodes.push(node)
+    node = node.nextSibling
+  }
+  return nodes
 }
 
 function isPreservedDomElement(node: Node): node is Element {
@@ -616,14 +591,13 @@ function shouldPreserveFrameStartMarker(
 ): boolean {
   if (!isFrameStartMarker(next)) return false
 
-  let currentData = getFrameMarkerData(current, context)
   let nextData = getFrameMarkerData(next, context)
+  let currentFrame = context.frameInstances.get(current)
 
   return (
-    currentData !== undefined &&
+    currentFrame !== undefined &&
     nextData !== undefined &&
-    currentData.src === nextData.src &&
-    currentData.name === nextData.name
+    currentFrame.matchesIdentity(nextData.src, nextData.name)
   )
 }
 
@@ -634,14 +608,14 @@ function shouldPreserveHydrationStartMarker(
 ): boolean {
   if (!isVirtualRootStartMarker(next)) return false
 
-  let currentData = getHydrationMarkerData(current, context)
+  let currentOwner = getClientEntryBoundaryOwner(current)
   let nextData = getHydrationMarkerData(next, context)
 
   return (
-    currentData !== undefined &&
+    currentOwner !== undefined &&
     nextData !== undefined &&
-    currentData.moduleUrl === nextData.moduleUrl &&
-    currentData.exportName === nextData.exportName
+    currentOwner.identity.moduleUrl === nextData.moduleUrl &&
+    currentOwner.identity.exportName === nextData.exportName
   )
 }
 
@@ -776,8 +750,7 @@ function disposeRemovedVirtualRoots(node: Node): void {
     let next = stack.pop()
     if (!next) continue
 
-    if (isHydratedVirtualRootStartMarker(next)) {
-      next.$rmx.dispose()
+    if (isVirtualRootStartMarker(next) && disposeClientEntryBoundary(next)) {
       continue
     }
 
@@ -813,10 +786,6 @@ function disposeFrameStartMarker(marker: Comment, context: FrameContext): void {
 
 function isVirtualRootStartMarker(node: Node): node is Comment {
   return isCommentNode(node) && node.data.trim().startsWith('rmx:h:')
-}
-
-function isHydratedVirtualRootStartMarker(node: Node): node is HydratedVirtualRootStartMarker {
-  return isVirtualRootStartMarker(node) && '$rmx' in node
 }
 
 function isVirtualRootEndMarker(node: Node): node is Comment {

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -11,6 +11,12 @@ import { diffNodes } from './diff-dom.ts'
 import { createStyleManager, type StyleManager } from '../style/index.ts'
 import { findFlushMarker, type FlushKind } from './stream-protocol.ts'
 import { unwrapFrameResolution } from './frame-resolution.ts'
+import {
+  disposeClientEntryBoundary,
+  getClientEntryBoundaryOwner,
+  setClientEntryBoundaryOwner,
+  type ClientEntryIdentity,
+} from './client-entry-boundary.ts'
 
 type FrameRoot = [Comment, Comment] | Element | Document | DocumentFragment
 
@@ -133,7 +139,6 @@ export type FrameRuntime = {
   pendingClientEntries: PendingClientEntries
   scheduler: Scheduler
   styleManager: StyleManager
-  data: RmxData
   moduleCache: Map<string, ElementFunction>
   moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
@@ -178,6 +183,7 @@ export type FrameContext = {
   moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
   namedFrames: Map<string, FrameHandle>
+  lifecycleSignal: AbortSignal
   regionTailRef?: ChildNode | null
   regionParent?: ParentNode | null
   signal?: AbortSignal
@@ -219,6 +225,7 @@ export type Frame = {
     content: InternalFrameContent,
     options?: RenderOptions,
   ) => Promise<void>
+  matchesIdentity: (src: string, name: string | undefined) => boolean
   dispose: () => void
   handle: FrameHandle
 }
@@ -228,6 +235,7 @@ type RenderOptions = {
   initialHydrationTracker?: InitialHydrationTracker
   signal?: AbortSignal
   contentStatus?: 'pending' | 'resolved'
+  data?: RmxData
 }
 
 export function createFrame(root: FrameRoot, init: FrameInit): Frame {
@@ -247,6 +255,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let pendingTemplateUnsubscribe: (() => void) | undefined
   let inheritedReloadPending = false
   let inheritedReloadAbortUnsubscribe: (() => void) | undefined
+  let disposed = false
+  let lifecycleController = new AbortController()
 
   // Merge any rmx-data found in the current document once at startup.
   mergeRmxDataFromDocument(init.data, container.doc)
@@ -282,18 +292,38 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     moduleLoads: init.moduleLoads,
     frameInstances: init.frameInstances,
     namedFrames: init.namedFrames,
+    lifecycleSignal: lifecycleController.signal,
     regionTailRef: container.regionTailRef,
     regionParent: container.regionParent,
   }
 
   async function render(content: InternalFrameContent, options?: RenderOptions): Promise<void> {
+    let ownsData = options?.data === undefined
+    let renderOptions = { ...options, data: options?.data ?? {} }
+
+    try {
+      await renderContent(content, renderOptions)
+    } finally {
+      if (ownsData) clearRmxData(renderOptions.data)
+    }
+  }
+
+  async function renderContent(
+    content: InternalFrameContent,
+    options: RenderOptions & { data: RmxData },
+  ): Promise<void> {
     if (options?.signal?.aborted) return
 
     if (content instanceof ReadableStream) {
-      await renderFrameStream(content, container.doc, async (html, flushKind) => {
-        if (options?.signal?.aborted) return
-        await render(html, { ...options, flushKind })
-      })
+      await renderFrameStream(
+        content,
+        container.doc,
+        async (html, flushKind) => {
+          if (options.signal?.aborted) return
+          await render(html, { ...options, flushKind })
+        },
+        options.signal,
+      )
       return
     }
 
@@ -338,7 +368,9 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
     if (isFullDocumentReload && htmlContent !== undefined) {
       let parsed = new DOMParser().parseFromString(htmlContent, 'text/html')
-      mergeRmxDataFromDocument(context.data, parsed)
+      let responseData = options.data
+      mergeRmxDataFromDocument(responseData, parsed)
+      let responseContext = { ...context, data: responseData }
       context.styleManager.adoptServerStyles(
         collectFrameServerStyleTags(createElementContainer(parsed)),
       )
@@ -346,13 +378,13 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       syncElementAttributes(container.doc.documentElement, parsed.documentElement)
 
       diffNodes([container.doc.head], [parsed.head], {
-        ...context,
+        ...responseContext,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
         signal: options?.signal,
       })
       diffNodes([container.doc.body], [parsed.body], {
-        ...context,
+        ...responseContext,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
         signal: options?.signal,
@@ -362,11 +394,11 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       if (options?.signal?.aborted) return
       scheduleHydrationInContainer(
         bodyContainer,
-        context,
+        responseContext,
         options?.initialHydrationTracker,
         options?.signal,
       )
-      await createSubFrames(bodyContainer.childNodes, context, options)
+      await createSubFrames(bodyContainer.childNodes, responseContext, options)
       displayedContentStatus = options?.contentStatus ?? 'resolved'
       return
     }
@@ -377,14 +409,16 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       collectFrameServerStyleTags(createElementContainer(fragment)),
     )
     removeEmptyHeads(fragment)
-    mergeRmxDataFromFragment(context.data, fragment)
+    let responseData = options.data
+    mergeRmxDataFromFragment(responseData, fragment)
+    let responseContext = { ...context, data: responseData }
 
     let nextContainer = createContainer(fragment)
 
     if (options?.signal?.aborted) return
 
     diffNodes(container.childNodes, Array.from(nextContainer.childNodes), {
-      ...context,
+      ...responseContext,
       regionTailRef: container.regionTailRef,
       regionParent: container.regionParent,
       signal: options?.signal,
@@ -393,11 +427,11 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (options?.signal?.aborted) return
     scheduleHydrationInContainer(
       container,
-      context,
+      responseContext,
       options?.initialHydrationTracker,
       options?.signal,
     )
-    await createSubFrames(container.childNodes, context, options)
+    await createSubFrames(container.childNodes, responseContext, options)
     displayedContentStatus = options?.contentStatus ?? 'resolved'
   }
 
@@ -442,18 +476,28 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     let initialHydrationTracker = createInitialHydrationTracker()
 
     context.styleManager.adoptServerStyles(collectFrameServerStyleTags(container))
-    await createSubFrames(container.childNodes, context)
+    let subFramesReady = createSubFrames(container.childNodes, context)
     scheduleHydrationInContainer(container, context, initialHydrationTracker)
 
-    if (currentMarker?.status === 'pending') {
-      await watchPendingFrameTemplate(currentMarker, initialHydrationTracker)
-    }
+    try {
+      await subFramesReady
 
-    initialHydrationTracker.finalize()
-    await initialHydrationTracker.ready()
+      if (currentMarker?.status === 'pending') {
+        await watchPendingFrameTemplate(currentMarker, initialHydrationTracker)
+      }
+
+      initialHydrationTracker.finalize()
+      await initialHydrationTracker.ready()
+    } finally {
+      clearRmxData(context.data)
+    }
   }
 
   function dispose(): void {
+    if (disposed) return
+    disposed = true
+    lifecycleController.abort()
+    clearRmxData(context.data)
     reloadController?.abort()
     reloadController = undefined
     reloadAbortUnsubscribe?.()
@@ -492,6 +536,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     startInheritedReload,
     updateMarker,
     renderMarkerContent,
+    matchesIdentity: (src, name) => !disposed && frame.src === src && frameName === name,
     dispose,
     handle: frame,
   }
@@ -775,7 +820,6 @@ export function createFrameRuntime(init: {
   pendingClientEntries: PendingClientEntries
   scheduler: Scheduler
   styleManager: StyleManager
-  data: RmxData
   moduleCache: Map<string, ElementFunction>
   moduleLoads: Map<string, Promise<ElementFunction | undefined>>
   frameInstances: WeakMap<Comment, Frame>
@@ -791,7 +835,6 @@ export function createFrameRuntime(init: {
     pendingClientEntries: init.pendingClientEntries,
     scheduler: init.scheduler,
     styleManager: init.styleManager,
-    data: init.data,
     moduleCache: init.moduleCache,
     moduleLoads: init.moduleLoads,
     frameInstances: init.frameInstances,
@@ -860,6 +903,11 @@ function mergeRmxDataFromFragment(into: RmxData, fragment: DocumentFragment): vo
     mergeRmxData(into, parseRmxDataScript(script))
     script.remove()
   }
+}
+
+function clearRmxData(data: RmxData): void {
+  delete data.h
+  delete data.f
 }
 
 function removeEmptyHeads(fragment: DocumentFragment): void {
@@ -958,40 +1006,59 @@ function scheduleHydrationMarker(
   initialHydrationTracker?: InitialHydrationTracker,
   signal?: AbortSignal,
 ): void {
-  if (signal?.aborted) return
+  if (signal?.aborted || context.lifecycleSignal.aborted) return
 
   let done = initialHydrationTracker?.track()
   let key = `${entry.moduleUrl}#${entry.exportName}`
+  let identity: ClientEntryIdentity = {
+    moduleUrl: entry.moduleUrl,
+    exportName: entry.exportName,
+  }
+  let props: Record<string, unknown> | undefined = entry.props
+  let completed = false
+
+  let complete = () => {
+    if (completed) return
+    completed = true
+    props = undefined
+    signal?.removeEventListener('abort', complete)
+    context.lifecycleSignal.removeEventListener('abort', complete)
+    done?.()
+  }
+
+  signal?.addEventListener('abort', complete, { once: true })
+  context.lifecycleSignal.addEventListener('abort', complete, { once: true })
 
   let hydrateWithComponent = (component: ElementFunction) => {
-    if (signal?.aborted) return
+    if (signal?.aborted || context.lifecycleSignal.aborted) return
     if (!isHydrationMarkerLive(marker, context)) return
-    let vElement = createElement(component, entry.props)
+    if (!props) return
+    let vElement = createElement(component, props)
     context.pendingClientEntries.set(marker.start, [marker.end, vElement])
-    hydrateRegion(vElement, marker.start, marker.end, context, signal)
+    hydrateRegion(vElement, marker.start, marker.end, identity, context, signal)
   }
 
   let cached = context.moduleCache.get(key)
   if (cached) {
     hydrateWithComponent(cached)
-    done?.()
+    complete()
     return
   }
 
-  getOrStartModuleLoad(key, entry, marker.id, context)
+  getOrStartModuleLoad(key, identity, marker.id, context)
     .then((component) => {
       if (component) {
         hydrateWithComponent(component)
       }
     })
     .finally(() => {
-      done?.()
+      complete()
     })
 }
 
 function getOrStartModuleLoad(
   key: string,
-  entry: HydrationData,
+  identity: ClientEntryIdentity,
   markerId: string,
   context: FrameContext,
 ): Promise<ElementFunction | undefined> {
@@ -1000,9 +1067,11 @@ function getOrStartModuleLoad(
 
   let loadPromise = (async () => {
     try {
-      let mod = await context.loadModule(entry.moduleUrl, entry.exportName)
+      let mod = await context.loadModule(identity.moduleUrl, identity.exportName)
       if (!isElementFunction(mod)) {
-        throw new Error(`Export "${entry.exportName}" from "${entry.moduleUrl}" is not a function`)
+        throw new Error(
+          `Export "${identity.exportName}" from "${identity.moduleUrl}" is not a function`,
+        )
       }
       context.moduleCache.set(key, mod)
       return mod
@@ -1073,6 +1142,7 @@ function hydrateRegion(
   vElement: RemixElement,
   start: Comment,
   end: Comment,
+  identity: ClientEntryIdentity,
   context: FrameContext,
   signal?: AbortSignal,
 ): void {
@@ -1083,9 +1153,10 @@ function hydrateRegion(
   // The same marker can be discovered by overlapping hydration passes
   // (for example, document root + nested frame root). Reuse the existing
   // virtual root instead of redefining the marker property.
-  if (isHydratedVirtualRootMarker(start)) {
+  let owner = getClientEntryBoundaryOwner(start)
+  if (owner) {
     if (!signal) {
-      start.$rmx.render(vElement)
+      owner.root.render(vElement)
       return
     }
 
@@ -1099,7 +1170,7 @@ function hydrateRegion(
 
     frameRuntime.serverFrameReload = { signal }
     try {
-      start.$rmx.render(vElement)
+      owner.root.render(vElement)
     } finally {
       frameRuntime.serverFrameReload = previousServerFrameReload
     }
@@ -1116,7 +1187,7 @@ function hydrateRegion(
     context.errorTarget.dispatchEvent(createComponentErrorEvent(getComponentError(event)))
   })
 
-  Object.defineProperty(start, '$rmx', { value: root, enumerable: false })
+  setClientEntryBoundaryOwner(start, identity, root)
   root.render(vElement)
 }
 
@@ -1206,8 +1277,7 @@ function removeVirtualRoots(nodes: Node[]): void {
   for (let i = 0; i < nodes.length; i++) {
     let node = nodes[i]
 
-    if (isHydratedVirtualRootMarker(node)) {
-      node.$rmx.dispose()
+    if (isCommentNode(node) && isHydrationStart(node) && disposeClientEntryBoundary(node)) {
       let end = findEndMarker(node, isHydrationStart, isHydrationEnd)
       i = findMarkerRangeEndIndex(nodes, end, i)
       continue
@@ -1398,12 +1468,22 @@ async function renderFrameStream(
   stream: ReadableStream<Uint8Array>,
   doc: Document,
   applyHtml: (html: string, flushKind: FlushKind) => Promise<void>,
+  signal?: AbortSignal,
 ): Promise<void> {
   let reader = stream.getReader()
   let decoder = new TextDecoder()
   let buffer = ''
   let html = ''
   let appliedOnce = false
+  let abort = () => {
+    void reader.cancel().catch(() => {})
+  }
+  if (signal?.aborted) {
+    await reader.cancel()
+    reader.releaseLock()
+    return
+  }
+  signal?.addEventListener('abort', abort, { once: true })
 
   try {
     while (true) {
@@ -1442,6 +1522,7 @@ async function renderFrameStream(
       await applyHtml('', 'fragment')
     }
   } finally {
+    signal?.removeEventListener('abort', abort)
     reader.releaseLock()
   }
 }
@@ -1579,10 +1660,6 @@ function isHydrationStart(node: Comment): boolean {
 
 function isHydrationEnd(node: Comment): boolean {
   return node.data.trim() === '/rmx:h'
-}
-
-function isHydratedVirtualRootMarker(node: Node): node is VirtualRootMarker {
-  return isCommentNode(node) && '$rmx' in node
 }
 
 function isFrameStart(node: Node): node is Comment {

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -109,6 +109,32 @@ const bufferedFrameTemplates = new Map<string, DocumentFragment[]>()
 const frameTemplateListeners = new Map<string, Set<FrameTemplateListener>>()
 const DOCTYPE_PATTERN = /<!doctype(?:\s[^>]*)?>/gi
 
+function createLinkedAbortController(
+  first: AbortSignal,
+  second?: AbortSignal,
+): { controller: AbortController; disconnect: () => void } {
+  let controller = new AbortController()
+  let signals = second ? [first, second] : [first]
+  let abort = () => controller.abort()
+
+  for (let signal of signals) {
+    if (signal.aborted) {
+      controller.abort()
+      break
+    }
+    signal.addEventListener('abort', abort, { once: true })
+  }
+
+  return {
+    controller,
+    disconnect() {
+      for (let signal of signals) {
+        signal.removeEventListener('abort', abort)
+      }
+    },
+  }
+}
+
 function stripDoctypeMarkup(html: string): string {
   return html.replace(DOCTYPE_PATTERN, '')
 }
@@ -238,6 +264,10 @@ type RenderOptions = {
   data?: RmxData
 }
 
+type ActiveRenderOptions = RenderOptions & {
+  data: RmxData
+}
+
 export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   let container = createContainer(root)
   let contentRoot: VirtualRoot | undefined
@@ -298,8 +328,12 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   }
 
   async function render(content: InternalFrameContent, options?: RenderOptions): Promise<void> {
+    if (disposed || lifecycleController.signal.aborted || options?.signal?.aborted) return
     let ownsData = options?.data === undefined
-    let renderOptions = { ...options, data: options?.data ?? {} }
+    let renderOptions: ActiveRenderOptions = {
+      ...options,
+      data: options?.data ?? {},
+    }
 
     try {
       await renderContent(content, renderOptions)
@@ -310,20 +344,25 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
   async function renderContent(
     content: InternalFrameContent,
-    options: RenderOptions & { data: RmxData },
+    options: ActiveRenderOptions,
   ): Promise<void> {
-    if (options?.signal?.aborted) return
+    if (isRenderAborted(options.signal)) return
 
     if (content instanceof ReadableStream) {
-      await renderFrameStream(
-        content,
-        container.doc,
-        async (html, flushKind) => {
-          if (options.signal?.aborted) return
-          await render(html, { ...options, flushKind })
-        },
-        options.signal,
-      )
+      let linkedAbort = createLinkedAbortController(lifecycleController.signal, options.signal)
+      try {
+        await renderFrameStream(
+          content,
+          container.doc,
+          async (html, flushKind) => {
+            if (isRenderAborted(options.signal)) return
+            await render(html, { ...options, flushKind })
+          },
+          linkedAbort.controller.signal,
+        )
+      } finally {
+        linkedAbort.disconnect()
+      }
       return
     }
 
@@ -336,9 +375,9 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         contentRoot = createFrameContentRoot()
       }
 
-      if (options?.signal?.aborted) return
+      if (isRenderAborted(options.signal)) return
       contentRoot.render(content)
-      displayedContentStatus = options?.contentStatus ?? 'resolved'
+      displayedContentStatus = options.contentStatus ?? 'resolved'
       return
     }
 
@@ -364,7 +403,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     let isFullDocumentReload =
       container.root instanceof Document &&
       htmlContent !== undefined &&
-      options?.flushKind === 'document'
+      options.flushKind === 'document'
 
     if (isFullDocumentReload && htmlContent !== undefined) {
       let parsed = new DOMParser().parseFromString(htmlContent, 'text/html')
@@ -381,25 +420,26 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
         ...responseContext,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
-        signal: options?.signal,
+        signal: options.signal,
       })
       diffNodes([container.doc.body], [parsed.body], {
         ...responseContext,
         regionParent: container.doc.documentElement,
         regionTailRef: null,
-        signal: options?.signal,
+        signal: options.signal,
       })
 
       let bodyContainer = createElementContainer(container.doc.body)
-      if (options?.signal?.aborted) return
+      if (isRenderAborted(options.signal)) return
       scheduleHydrationInContainer(
         bodyContainer,
         responseContext,
-        options?.initialHydrationTracker,
-        options?.signal,
+        options.initialHydrationTracker,
+        options.signal,
       )
       await createSubFrames(bodyContainer.childNodes, responseContext, options)
-      displayedContentStatus = options?.contentStatus ?? 'resolved'
+      if (isRenderAborted(options.signal)) return
+      displayedContentStatus = options.contentStatus ?? 'resolved'
       return
     }
 
@@ -415,24 +455,29 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
     let nextContainer = createContainer(fragment)
 
-    if (options?.signal?.aborted) return
+    if (isRenderAborted(options.signal)) return
 
     diffNodes(container.childNodes, Array.from(nextContainer.childNodes), {
       ...responseContext,
       regionTailRef: container.regionTailRef,
       regionParent: container.regionParent,
-      signal: options?.signal,
+      signal: options.signal,
     })
 
-    if (options?.signal?.aborted) return
+    if (isRenderAborted(options.signal)) return
     scheduleHydrationInContainer(
       container,
       responseContext,
-      options?.initialHydrationTracker,
-      options?.signal,
+      options.initialHydrationTracker,
+      options.signal,
     )
     await createSubFrames(container.childNodes, responseContext, options)
-    displayedContentStatus = options?.contentStatus ?? 'resolved'
+    if (isRenderAborted(options.signal)) return
+    displayedContentStatus = options.contentStatus ?? 'resolved'
+  }
+
+  function isRenderAborted(signal?: AbortSignal): boolean {
+    return disposed || lifecycleController.signal.aborted || signal?.aborted === true
   }
 
   function createFrameContentRoot(): VirtualRoot {
@@ -481,6 +526,8 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
 
     try {
       await subFramesReady
+
+      if (disposed || context.lifecycleSignal.aborted) return
 
       if (currentMarker?.status === 'pending') {
         await watchPendingFrameTemplate(currentMarker, initialHydrationTracker)
@@ -542,7 +589,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
   }
 
   async function updateMarker(marker: FrameMarkerData, options?: RenderOptions): Promise<void> {
-    if (options?.signal?.aborted) return
+    if (disposed || context.lifecycleSignal.aborted || options?.signal?.aborted) return
     let previousMarker = currentMarker
     let isInheritedReload = previousMarker !== undefined && previousMarker.id !== marker.id
     currentMarker = marker
@@ -575,7 +622,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     content: InternalFrameContent,
     options?: RenderOptions,
   ): Promise<void> {
-    if (options?.signal?.aborted) return
+    if (disposed || context.lifecycleSignal.aborted || options?.signal?.aborted) return
     let previousMarker = currentMarker
     let isInheritedReload = previousMarker !== undefined && previousMarker.id !== marker.id
     currentMarker = marker
@@ -587,7 +634,12 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     clearPendingFrameTemplateWatch()
     await render(content, { ...options, contentStatus: 'resolved' })
 
-    if (isInheritedReload && !options?.signal?.aborted) {
+    if (
+      isInheritedReload &&
+      !disposed &&
+      !context.lifecycleSignal.aborted &&
+      !options?.signal?.aborted
+    ) {
       completeInheritedReload()
     }
   }
@@ -763,7 +815,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     signal?: AbortSignal,
     onResolved?: () => void,
   ): Promise<void> {
-    if (signal?.aborted) return
+    if (disposed || context.lifecycleSignal.aborted || signal?.aborted) return
     if (pendingTemplateMarkerId === marker.id) return
 
     clearPendingFrameTemplateWatch()
@@ -773,11 +825,11 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (early) {
       clearPendingFrameTemplateWatch()
       await render(early, { initialHydrationTracker, signal, contentStatus: 'resolved' })
-      if (!signal?.aborted) onResolved?.()
+      if (!disposed && !context.lifecycleSignal.aborted && !signal?.aborted) onResolved?.()
       return
     }
 
-    if (signal?.aborted) {
+    if (disposed || context.lifecycleSignal.aborted || signal?.aborted) {
       clearPendingFrameTemplateWatch()
       return
     }
@@ -785,11 +837,11 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     let observer = setupTemplateObserver()
     pendingTemplateObserver = observer
     let unsubscribe = subscribeFrameTemplate(marker.id, async (fragment) => {
-      if (signal?.aborted) return
+      if (disposed || context.lifecycleSignal.aborted || signal?.aborted) return
       if (pendingTemplateMarkerId !== marker.id) return
       clearPendingFrameTemplateWatch()
       await render(fragment, { signal, contentStatus: 'resolved' })
-      if (!signal?.aborted) onResolved?.()
+      if (!disposed && !context.lifecycleSignal.aborted && !signal?.aborted) onResolved?.()
     })
     pendingTemplateUnsubscribe = unsubscribe
 
@@ -807,7 +859,7 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
     if (buffered) {
       clearPendingFrameTemplateWatch()
       await render(buffered, { initialHydrationTracker, signal, contentStatus: 'resolved' })
-      if (!signal?.aborted) onResolved?.()
+      if (!disposed && !context.lifecycleSignal.aborted && !signal?.aborted) onResolved?.()
     }
   }
 }

--- a/packages/ui/src/runtime/reconcile.ts
+++ b/packages/ui/src/runtime/reconcile.ts
@@ -1080,22 +1080,19 @@ function insertFrame(
     let start = cursor.current
     let end = findFrameEndComment(start)
     if (end) {
-      let frameId = getFrameIdFromComment(start)
-      let marker = frameId ? runtime.data.f?.[frameId] : undefined
-      let src = marker?.src ?? getFrameSrc(node)
       let instance = runtime.frameInstances.get(start)
+      let src = instance?.handle.src ?? getFrameSrc(node)
       if (!instance) {
         instance = createFrame([start, end], {
           name: getFrameName(node),
           src,
-          marker: frameId && marker ? { ...marker, id: frameId } : undefined,
           errorTarget: runtime.errorTarget,
           loadModule: runtime.loadModule,
           resolveFrame: runtime.resolveFrame,
           pendingClientEntries: runtime.pendingClientEntries,
           scheduler: runtime.scheduler,
           styleManager: runtime.styleManager,
-          data: runtime.data,
+          data: {},
           moduleCache: runtime.moduleCache,
           moduleLoads: runtime.moduleLoads,
           frameInstances: runtime.frameInstances,
@@ -1145,7 +1142,7 @@ function insertFrame(
     pendingClientEntries: runtime.pendingClientEntries,
     scheduler: runtime.scheduler,
     styleManager: runtime.styleManager,
-    data: runtime.data,
+    data: {},
     moduleCache: runtime.moduleCache,
     moduleLoads: runtime.moduleLoads,
     frameInstances: runtime.frameInstances,
@@ -1340,12 +1337,6 @@ function isFrameEndComment(node: Node | null | undefined): node is Comment {
 
 function isCommentNode(node: Node | null | undefined): node is Comment {
   return node?.nodeType === Node.COMMENT_NODE
-}
-
-function getFrameIdFromComment(comment: Comment): string | undefined {
-  let text = comment.data.trim()
-  if (!text.startsWith('rmx:f:')) return undefined
-  return text.slice('rmx:f:'.length)
 }
 
 function findFrameEndComment(start: Comment): Comment | null {

--- a/packages/ui/src/runtime/vdom.ts
+++ b/packages/ui/src/runtime/vdom.ts
@@ -305,7 +305,6 @@ function createRootFrameHandle(init: {
     pendingClientEntries: new Map(),
     scheduler: init.scheduler,
     styleManager: init.styleManager,
-    data: {},
     moduleCache: new Map(),
     moduleLoads: new Map(),
     frameInstances: new WeakMap(),

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -3,6 +3,18 @@ import { describe, it } from '@remix-run/test'
 import { invariant } from '../runtime/invariant.ts'
 import { diffNodes } from '../runtime/diff-dom.ts'
 import type { FrameContext } from '../runtime/frame.ts'
+import {
+  setClientEntryBoundaryOwner,
+  type ClientEntryIdentity,
+} from '../runtime/client-entry-boundary.ts'
+
+function attachClientEntryOwner(
+  marker: Comment,
+  onDispose = () => {},
+  identity: ClientEntryIdentity = { moduleUrl: '/entry.js', exportName: 'Entry' },
+): void {
+  setClientEntryBoundaryOwner(marker, identity, { dispose: onDispose, render() {} })
+}
 
 function diffDomNodes(current: Node[], next: Node[], data: FrameContext['data'] = {}) {
   diffNodes(current, next, {
@@ -114,6 +126,9 @@ describe('diffNodes', () => {
     it('updates hydration marker ids while fast-forwarding boundaries', () => {
       let container = document.createElement('div')
       container.innerHTML = '<!-- rmx:h:old --><button>Old</button><!-- /rmx:h -->'
+      let start = container.firstChild
+      invariant(start instanceof Comment)
+      attachClientEntryOwner(start)
 
       diffDom(container, '<!-- rmx:h:new --><button>Old</button><!-- /rmx:h -->', {
         h: {
@@ -122,9 +137,23 @@ describe('diffNodes', () => {
         },
       })
 
-      let start = container.firstChild
-      invariant(start && start.nodeType === Node.COMMENT_NODE)
-      expect((start as Comment).data.trim()).toBe('rmx:h:new')
+      expect(start.data.trim()).toBe('rmx:h:new')
+      expect(container.firstChild).toBe(start)
+    })
+
+    it('replaces same-identity hydration ranges that do not have a live owner', () => {
+      let container = document.createElement('div')
+      container.innerHTML = '<!-- rmx:h:old --><button>Old</button><!-- /rmx:h -->'
+      let oldStart = container.firstChild
+
+      diffDom(container, '<!-- rmx:h:new --><button>New</button><!-- /rmx:h -->', {
+        h: {
+          new: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+        },
+      })
+
+      expect(container.firstChild).not.toBe(oldStart)
+      expect(container.querySelector('button')?.textContent).toBe('New')
     })
 
     it('replaces hydration ranges with different client entry identities', () => {
@@ -143,6 +172,171 @@ describe('diffNodes', () => {
       expect(container.querySelector('button')?.textContent).toBe('New')
     })
 
+    it('moves complete live hydration ranges when ordinary siblings shift', () => {
+      let container = document.createElement('div')
+      container.innerHTML =
+        '<!-- rmx:h:old --><button>Stateful</button><!-- /rmx:h --><span>After</span>'
+      let start = container.firstChild
+      invariant(start instanceof Comment)
+      attachClientEntryOwner(start)
+
+      diffDom(
+        container,
+        '<p>Before</p><!-- rmx:h:new --><button>Server</button><!-- /rmx:h --><span>After</span>',
+        {
+          h: {
+            new: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+          },
+        },
+      )
+
+      expect(container.childNodes.item(1)).toBe(start)
+      expect(start.data.trim()).toBe('rmx:h:new')
+      expect(container.querySelector('button')?.textContent).toBe('Stateful')
+    })
+
+    it('pairs repeated live hydration ranges by identity in source order', () => {
+      let container = document.createElement('div')
+      container.innerHTML = [
+        '<!-- rmx:h:first --><button>First</button><!-- /rmx:h -->',
+        '<!-- rmx:h:second --><button>Second</button><!-- /rmx:h -->',
+      ].join('')
+      let firstStart = container.childNodes.item(0)
+      let secondStart = container.childNodes.item(3)
+      invariant(firstStart instanceof Comment)
+      invariant(secondStart instanceof Comment)
+      let firstDisposeCount = 0
+      let secondDisposeCount = 0
+      attachClientEntryOwner(firstStart, () => {
+        firstDisposeCount++
+      })
+      attachClientEntryOwner(secondStart, () => {
+        secondDisposeCount++
+      })
+
+      diffDom(container, '<!-- rmx:h:next --><button>Server</button><!-- /rmx:h -->', {
+        h: {
+          next: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+        },
+      })
+
+      expect(container.firstChild).toBe(firstStart)
+      expect(secondStart.parentNode).toBeNull()
+      expect(container.querySelector('button')?.textContent).toBe('First')
+      expect(firstDisposeCount).toBe(0)
+      expect(secondDisposeCount).toBe(1)
+    })
+
+    it('does not let an unmatched boundary consume a later semantic match', () => {
+      let container = document.createElement('div')
+      container.innerHTML = '<!-- rmx:h:current --><button>Stateful</button><!-- /rmx:h -->'
+      let currentStart = container.firstChild
+      invariant(currentStart instanceof Comment)
+      let disposeCount = 0
+      attachClientEntryOwner(currentStart, () => {
+        disposeCount++
+      })
+
+      diffDom(
+        container,
+        [
+          '<!-- rmx:h:inserted --><button>Inserted</button><!-- /rmx:h -->',
+          '<!-- rmx:h:preserved --><button>Server</button><!-- /rmx:h -->',
+        ].join(''),
+        {
+          h: {
+            inserted: { moduleUrl: '/other.js', exportName: 'Other', props: {} },
+            preserved: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+          },
+        },
+      )
+
+      expect(container.childNodes.item(3)).toBe(currentStart)
+      expect(currentStart.data.trim()).toBe('rmx:h:preserved')
+      expect(container.querySelectorAll('button').item(1).textContent).toBe('Stateful')
+      expect(disposeCount).toBe(0)
+    })
+
+    it('keeps generated boundary lists balanced with exact ordinary destination DOM', () => {
+      let identities: ClientEntryIdentity[] = [
+        { moduleUrl: '/a.js', exportName: 'Entry' },
+        { moduleUrl: '/b.js', exportName: 'Entry' },
+        { moduleUrl: '/b.js', exportName: 'Other' },
+      ]
+
+      for (let seed = 0; seed < 24; seed++) {
+        let host = document.createElement('div')
+        let current = document.createElement('div')
+        let next = document.createElement('div')
+        host.appendChild(current)
+        let disposeCounts: number[] = []
+        let currentCount = (seed % 4) + 1
+        let nextCount = ((seed * 3) % 5) + 1
+
+        for (let i = 0; i < currentCount; i++) {
+          if ((seed + i) % 2 === 0) {
+            let ordinary = document.createElement('span')
+            ordinary.setAttribute('data-source', `${seed}-${i}`)
+            current.appendChild(ordinary)
+          }
+
+          let start = document.createComment(`rmx:h:current-${seed}-${i}`)
+          let content = document.createElement('button')
+          content.textContent = `Current ${seed}-${i}`
+          let end = document.createComment('/rmx:h')
+          current.append(start, content, end)
+
+          disposeCounts.push(0)
+          let disposeIndex = disposeCounts.length - 1
+          attachClientEntryOwner(
+            start,
+            () => {
+              disposeCounts[disposeIndex]++
+            },
+            identities[(seed + i) % identities.length],
+          )
+        }
+
+        let hydrationData: NonNullable<FrameContext['data']['h']> = {}
+        let data: FrameContext['data'] = { h: hydrationData }
+        let expectedOrdinaryIds: string[] = []
+        for (let i = 0; i < nextCount; i++) {
+          if ((seed + i) % 3 !== 0) {
+            let id = `${seed}-${i}`
+            let ordinary = document.createElement('span')
+            ordinary.setAttribute('data-destination', id)
+            next.appendChild(ordinary)
+            expectedOrdinaryIds.push(id)
+          }
+
+          let id = `next-${seed}-${i}`
+          let identity = identities[(seed * 2 + i) % identities.length]
+          let start = document.createComment(`rmx:h:${id}`)
+          let content = document.createElement('button')
+          content.textContent = `Next ${seed}-${i}`
+          let end = document.createComment('/rmx:h')
+          next.append(start, content, end)
+          hydrationData[id] = { ...identity, props: {} }
+        }
+
+        diffDomNodes([current], [next], data)
+
+        let comments = Array.from(current.childNodes).filter(
+          (node): node is Comment => node instanceof Comment,
+        )
+        let starts = comments.filter((comment) => comment.data.trim().startsWith('rmx:h:'))
+        let ends = comments.filter((comment) => comment.data.trim() === '/rmx:h')
+        let ordinaryIds = Array.from(current.querySelectorAll('[data-destination]')).map(
+          (element) => element.getAttribute('data-destination') ?? '',
+        )
+
+        expect(starts).toHaveLength(nextCount)
+        expect(ends).toHaveLength(nextCount)
+        expect(ordinaryIds).toEqual(expectedOrdinaryIds)
+        expect(disposeCounts.every((count) => count === 0 || count === 1)).toBe(true)
+      }
+    })
+
     it('does not match keyed elements owned by nested hydration ranges', () => {
       let container = document.createElement('div')
       let current = document.createElement('div')
@@ -159,13 +353,9 @@ describe('diffNodes', () => {
       current.append(outerStart, innerStart, innerContent, innerEnd, owned, outerEnd)
 
       let disposeCount = 0
-      Object.assign(outerStart, {
-        $rmx: {
-          dispose() {
-            disposeCount++
-            owned.remove()
-          },
-        },
+      attachClientEntryOwner(outerStart, () => {
+        disposeCount++
+        owned.remove()
       })
 
       let next = document.createElement('div')
@@ -200,16 +390,12 @@ describe('diffNodes', () => {
       )
 
       let disposeCount = 0
-      Object.assign(hydrationStart, {
-        $rmx: {
-          dispose() {
-            disposeCount++
-            let range = document.createRange()
-            range.setStartBefore(currentFrameStart)
-            range.setEndAfter(currentFrameEnd)
-            range.deleteContents()
-          },
-        },
+      attachClientEntryOwner(hydrationStart, () => {
+        disposeCount++
+        let range = document.createRange()
+        range.setStartBefore(currentFrameStart)
+        range.setEndAfter(currentFrameEnd)
+        range.deleteContents()
       })
 
       let next = document.createElement('div')
@@ -242,7 +428,7 @@ describe('diffNodes', () => {
       diffDom(container, next)
 
       expect(root.childNodes.item(3)).not.toBe(currentFrameEnd)
-      expect(currentFrameEnd.parentNode).toBe(root)
+      expect(currentFrameEnd.parentNode).toBeNull()
       expect(root.outerHTML).toBe(next)
     })
   })

--- a/packages/ui/src/test/diff-dom.test.tsx
+++ b/packages/ui/src/test/diff-dom.test.tsx
@@ -24,10 +24,26 @@ function diffDomNodes(current: Node[], next: Node[], data: FrameContext['data'] 
   } as any)
 }
 
-function diffDom(container: HTMLElement, next: string, data?: FrameContext['data']) {
+type TestFrame = {
+  dispose(): void
+  isDisplayingResolvedContent(): boolean
+  matchesIdentity(src: string, name: string | undefined): boolean
+  renderMarkerContent(): Promise<void>
+}
+
+function diffDom(
+  container: HTMLElement,
+  next: string,
+  data?: FrameContext['data'],
+  frameInstances: WeakMap<Comment, TestFrame> = new WeakMap(),
+) {
   let template = document.createElement('template')
   template.innerHTML = next
-  diffDomNodes(Array.from(container.childNodes), Array.from(template.content.childNodes), data)
+  diffNodes(Array.from(container.childNodes), Array.from(template.content.childNodes), {
+    frameInstances,
+    pendingClientEntries: new Map(),
+    data: data ?? {},
+  } as any)
 }
 
 describe('diffNodes', () => {
@@ -193,6 +209,43 @@ describe('diffNodes', () => {
       expect(container.childNodes.item(1)).toBe(start)
       expect(start.data.trim()).toBe('rmx:h:new')
       expect(container.querySelector('button')?.textContent).toBe('Stateful')
+    })
+
+    it('keeps ordinary sibling state with its node when a hydration range moves', () => {
+      let container = document.createElement('div')
+      container.innerHTML = [
+        '<input id="first" value="First">',
+        '<input id="second" value="Second">',
+        '<!-- rmx:h:old --><button>Stateful</button><!-- /rmx:h -->',
+      ].join('')
+      let first = container.querySelector('#first')
+      let second = container.querySelector('#second')
+      let start = container.childNodes.item(2)
+      invariant(first instanceof HTMLInputElement)
+      invariant(second instanceof HTMLInputElement)
+      invariant(start instanceof Comment)
+      first.value = 'Edited first'
+      second.value = 'Edited second'
+      attachClientEntryOwner(start)
+
+      diffDom(
+        container,
+        [
+          '<!-- rmx:h:new --><button>Server</button><!-- /rmx:h -->',
+          '<input id="first" value="First">',
+          '<input id="second" value="Second">',
+        ].join(''),
+        {
+          h: {
+            new: { moduleUrl: '/entry.js', exportName: 'Entry', props: {} },
+          },
+        },
+      )
+
+      expect(container.querySelector('#first')).toBe(first)
+      expect(container.querySelector('#second')).toBe(second)
+      expect(first.value).toBe('Edited first')
+      expect(second.value).toBe('Edited second')
     })
 
     it('pairs repeated live hydration ranges by identity in source order', () => {
@@ -430,6 +483,38 @@ describe('diffNodes', () => {
       expect(root.childNodes.item(3)).not.toBe(currentFrameEnd)
       expect(currentFrameEnd.parentNode).toBeNull()
       expect(root.outerHTML).toBe(next)
+    })
+
+    it('preserves resolved frame content when a pending marker reuses the same id', () => {
+      let container = document.createElement('div')
+      container.innerHTML = '<!-- rmx:f:same --><p>Resolved current</p><!-- /rmx:f -->'
+      let start = container.firstChild
+      invariant(start instanceof Comment)
+      let renderCount = 0
+      let frameInstances = new WeakMap<Comment, TestFrame>()
+      frameInstances.set(start, {
+        dispose() {},
+        isDisplayingResolvedContent: () => true,
+        matchesIdentity: (src, name) => src === '/same' && name === undefined,
+        async renderMarkerContent() {
+          renderCount++
+        },
+      })
+
+      diffDom(
+        container,
+        '<!-- rmx:f:same --><p>Pending fallback</p><!-- /rmx:f -->',
+        {
+          f: {
+            same: { src: '/same', status: 'pending' },
+          },
+        },
+        frameInstances,
+      )
+
+      expect(container.firstChild).toBe(start)
+      expect(container.querySelector('p')?.textContent).toBe('Resolved current')
+      expect(renderCount).toBe(0)
     })
   })
 

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -12,6 +12,7 @@ import { jsx } from '../runtime/jsx.ts'
 import { createScheduler } from '../runtime/scheduler.ts'
 import { appendFlushMarker } from '../runtime/stream-protocol.ts'
 import { createStyleManager } from '../style/index.ts'
+import { withResolvers } from './utils.ts'
 
 describe('frames', () => {
   afterEach(() => {
@@ -51,6 +52,7 @@ describe('frames', () => {
       expect(exportName).toBe('StreamingEntry')
       return StreamingEntry
     }) satisfies LoadModule
+    let data = {}
 
     let frame = createFrame(document, {
       src: 'https://example.com/initial',
@@ -72,7 +74,7 @@ describe('frames', () => {
       pendingClientEntries: new Map(),
       scheduler,
       styleManager,
-      data: {},
+      data,
       moduleCache: new Map(),
       moduleLoads: new Map(),
       frameInstances: new WeakMap(),
@@ -81,6 +83,7 @@ describe('frames', () => {
 
     try {
       await frame.ready()
+      expect(data).toEqual({})
       expect(document.querySelector('[data-entry]')?.textContent).toBe('initial')
       let setupCountBeforeReload = setupCount
       let disconnectCountBeforeReload = disconnectCount
@@ -93,6 +96,43 @@ describe('frames', () => {
     } finally {
       frame.dispose()
     }
+  })
+
+  it('releases pending hydration metadata when its frame is disposed', async () => {
+    document.body.innerHTML = [
+      '<!-- rmx:h:h1 -->',
+      '<section data-entry="">initial</section>',
+      '<!-- /rmx:h -->',
+      rmxDataScript('initial'),
+    ].join('')
+
+    let [modulePromise, resolveModule] = withResolvers<Function>()
+    let data = {}
+    let frame = createFrame(document, {
+      src: 'https://example.com/initial',
+      errorTarget: new EventTarget(),
+      loadModule: () => modulePromise,
+      resolveFrame: () => '',
+      pendingClientEntries: new Map(),
+      scheduler: createScheduler(document, new EventTarget(), createStyleManager()),
+      data,
+      moduleCache: new Map(),
+      moduleLoads: new Map(),
+      frameInstances: new WeakMap(),
+      namedFrames: new Map(),
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(data).not.toEqual({})
+
+    frame.dispose()
+    await frame.ready()
+
+    expect(data).toEqual({})
+
+    resolveModule(() => () => jsx('section', { children: 'late' }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(document.querySelector('[data-entry]')?.textContent).toBe('initial')
   })
 
   it('renders a redirected response without changing the frame source', async () => {
@@ -217,6 +257,48 @@ describe('frames', () => {
 
       expect(result.signal.aborted).toBe(true)
       expect(resolverSignal?.aborted).toBe(true)
+      expect(document.getElementById('initial')?.textContent).toBe('Initial')
+    } finally {
+      frame.dispose()
+    }
+  })
+
+  it('stops reading the active response stream when the reload signal is aborted', async () => {
+    let root = document.createElement('div')
+    root.innerHTML = '<p id="initial">Initial</p>'
+    document.body.append(root)
+    let [streamRead, markStreamRead] = withResolvers<void>()
+    let frame = createFrame(root, {
+      src: 'https://example.com/account',
+      errorTarget: new EventTarget(),
+      loadModule() {
+        throw new Error('Unexpected client entry')
+      },
+      resolveFrame() {
+        return new ReadableStream<Uint8Array>({
+          pull() {
+            markStreamRead()
+          },
+        })
+      },
+      pendingClientEntries: new Map(),
+      scheduler: createScheduler(document, new EventTarget(), createStyleManager()),
+      data: {},
+      moduleCache: new Map(),
+      moduleLoads: new Map(),
+      frameInstances: new WeakMap(),
+      namedFrames: new Map(),
+    })
+    let controller = new AbortController()
+
+    try {
+      await frame.ready()
+      let reload = reloadFrameForNavigation(frame.handle, { signal: controller.signal })
+      await streamRead
+      controller.abort()
+      let result = await reload
+
+      expect(result.signal.aborted).toBe(true)
       expect(document.getElementById('initial')?.textContent).toBe('Initial')
     } finally {
       frame.dispose()

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, it } from '@remix-run/test'
 
 import type { Handle } from '../runtime/component.ts'
 import {
+  consumeFrameTemplate,
   createFrame,
+  publishFrameTemplate,
   reloadFrameForNavigation,
   type LoadModule,
   type ResolveFrameOptions,
@@ -133,6 +135,53 @@ describe('frames', () => {
     resolveModule(() => () => jsx('section', { children: 'late' }))
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(document.querySelector('[data-entry]')?.textContent).toBe('initial')
+  })
+
+  it('does not render a pending template after its frame is disposed', async () => {
+    let markerId = 'disposed-pending-frame'
+    let start = document.createComment(` rmx:f:${markerId} `)
+    let fallback = document.createElement('p')
+    fallback.textContent = 'Fallback'
+    let end = document.createComment(' /rmx:f ')
+    document.body.append(start, fallback, end)
+
+    let errorTarget = new EventTarget()
+    let styleManager = createStyleManager()
+    let frame = createFrame([start, end], {
+      src: '/child',
+      marker: { id: markerId, src: '/child', status: 'pending' },
+      errorTarget,
+      loadModule() {
+        throw new Error('Unexpected client entry')
+      },
+      resolveFrame: () => '',
+      pendingClientEntries: new Map(),
+      scheduler: createScheduler(document, errorTarget, styleManager),
+      styleManager,
+      data: {},
+      moduleCache: new Map(),
+      moduleLoads: new Map(),
+      frameInstances: new WeakMap(),
+      namedFrames: new Map(),
+    })
+
+    frame.dispose()
+    start.remove()
+    fallback.remove()
+    end.remove()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    let fragment = document.createDocumentFragment()
+    let late = document.createElement('p')
+    late.id = 'late-frame-content'
+    fragment.append(late)
+    publishFrameTemplate(markerId, fragment)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    consumeFrameTemplate(markerId)
+    expect(document.getElementById('late-frame-content')).toBeNull()
+    await frame.ready()
   })
 
   it('renders a redirected response without changing the frame source', async () => {

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -1242,6 +1242,156 @@ describe('run', () => {
     app.dispose()
   })
 
+  it('shows updated SSR when reloading an entry whose initial module is still loading', async () => {
+    let reloadPromise: Promise<AbortSignal> | undefined
+    let Fast = clientEntry('/js/partial-fast.js#Fast', function Fast(handle: Handle) {
+      return () => (
+        <button
+          id="partial-fast"
+          type="button"
+          mix={on('click', () => {
+            reloadPromise = handle.frame.reload()
+          })}
+        >
+          Reload
+        </button>
+      )
+    })
+
+    let Slow = clientEntry(
+      '/js/partial-slow.js#Slow',
+      function Slow(handle: Handle<{ label: string }>) {
+        return () => <p id="partial-slow">{handle.props.label}</p>
+      },
+    )
+
+    async function renderDocument(label: string) {
+      return await renderDocumentContent(
+        <>
+          <Fast />
+          <Slow label={label} />
+        </>,
+      )
+    }
+
+    let initialDocument = new DOMParser().parseFromString(
+      await renderDocument('Initial'),
+      'text/html',
+    )
+    document.documentElement.innerHTML = initialDocument.documentElement.innerHTML
+
+    let [slowModulePromise, resolveSlowModule] = withResolvers<Function>()
+    let slowLoadCount = 0
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/partial-fast.js' && exportName === 'Fast') return Fast
+        if (moduleUrl === '/js/partial-slow.js' && exportName === 'Slow') {
+          slowLoadCount++
+          return slowModulePromise
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src) {
+        if (src === '/reloaded') return await renderDocument('Reloaded')
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      let fastButton = document.getElementById('partial-fast')
+      invariant(fastButton instanceof HTMLButtonElement)
+      let initialSlow = document.getElementById('partial-slow')
+      invariant(initialSlow instanceof HTMLParagraphElement)
+
+      app.frames.top.src = '/reloaded'
+      fastButton.click()
+      invariant(reloadPromise)
+      await reloadPromise
+
+      let reloadedSlow = document.getElementById('partial-slow')
+      invariant(reloadedSlow instanceof HTMLParagraphElement)
+      expect(reloadedSlow).not.toBe(initialSlow)
+      expect(reloadedSlow.textContent).toBe('Reloaded')
+      expect(slowLoadCount).toBe(1)
+
+      resolveSlowModule(Slow)
+      await app.ready()
+      expect(document.getElementById('partial-slow')?.textContent).toBe('Reloaded')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('shows updated SSR when reloading a named frame entry whose module is still loading', async () => {
+    let entrySetupCount = 0
+    let Slow = clientEntry(
+      '/js/named-partial-slow.js#Slow',
+      function Slow(handle: Handle<{ label: string }>) {
+        entrySetupCount++
+        return () => <p id="named-partial-slow">{handle.props.label}</p>
+      },
+    )
+
+    async function renderEntry(label: string) {
+      return await drain(renderToStream(<Slow label={label} />))
+    }
+
+    let initialHtml = await drain(
+      renderToStream(<Frame name="partial-target" src="/initial" />, {
+        resolveFrame: () => renderEntry('Initial'),
+      }),
+    )
+    document.body.innerHTML = initialHtml
+
+    let [slowModulePromise, resolveSlowModule] = withResolvers<Function>()
+    let [moduleRequested, markModuleRequested] = withResolvers<void>()
+    let slowLoadCount = 0
+    let app = run({
+      loadModule(moduleUrl, exportName) {
+        if (moduleUrl === '/js/named-partial-slow.js' && exportName === 'Slow') {
+          slowLoadCount++
+          markModuleRequested()
+          return slowModulePromise
+        }
+        throw new Error(`Unexpected module: ${moduleUrl}#${exportName}`)
+      },
+      async resolveFrame(src, options) {
+        expect(options?.target).toBe('partial-target')
+        if (src === '/reloaded') return await renderEntry('Reloaded')
+        throw new Error(`Unexpected frame src: ${src}`)
+      },
+    })
+
+    try {
+      await moduleRequested
+
+      let initialSlow = document.getElementById('named-partial-slow')
+      invariant(initialSlow instanceof HTMLParagraphElement)
+      let targetFrame = app.frames.get('partial-target')
+      invariant(targetFrame)
+
+      targetFrame.src = '/reloaded'
+      await targetFrame.reload()
+
+      let reloadedSlow = document.getElementById('named-partial-slow')
+      invariant(reloadedSlow instanceof HTMLParagraphElement)
+      expect(reloadedSlow).not.toBe(initialSlow)
+      expect(reloadedSlow.textContent).toBe('Reloaded')
+      expect(slowLoadCount).toBe(1)
+
+      let setupCountBeforeHydration = entrySetupCount
+      resolveSlowModule(Slow)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(document.getElementById('named-partial-slow')?.textContent).toBe('Reloaded')
+      expect(entrySetupCount).toBe(setupCountBeforeHydration + 1)
+    } finally {
+      app.dispose()
+    }
+  })
+
   it('handles complex props', async () => {
     let Card = clientEntry(
       '/js/card.js#Card',


### PR DESCRIPTION
Stacks on #11683.

Client entry and frame marker IDs are intentionally temporary: they correlate streamed response metadata with DOM ranges, but a later server response cannot reproduce them. This change separates that transport concern from reconciliation:

- response-local random IDs correlate metadata and templates
- semantic identity matches boundaries across responses
- live owner records determine whether state can actually be preserved and disposed

DOM reconciliation now parses sibling lists into complete ordinary-node, hydration-range, and frame-range units so it can match, move, replace, and dispose boundaries atomically. Pending client entries show the latest destination SSR while reusing in-flight module loads, frame preservation requires a live instance with matching src and name, and repeated semantic identities pair in source order.

The runtime also scopes serialized metadata to a response, releases hydration props after completion or cancellation, cancels pending work when frames are disposed, and stops reading response streams after aborts. Regression coverage includes full-document and named-frame partial-boot reloads, shifted and adjacent ranges, repeated identities, lifecycle cleanup, stream cancellation, and a deterministic boundary scenario matrix.

The Frames demo now exercises this path through `/reload-scope`: its top-frame client entry uses the source-resolved identity from `clientEntry(import.meta.url, ...)` instead of a stale hard-coded bundle path, and a router regression test verifies the route renders successfully.
