### PR TITLE
Optimize data-schema validation allocations

### DIFF
--- a/packages/data-schema/.changes/patch.reduce-validation-allocations.md
+++ b/packages/data-schema/.changes/patch.reduce-validation-allocations.md
@@ -1,0 +1,1 @@
+Reduce allocations and improve throughput when validating nested schemas and arrays.

--- a/packages/data-schema/.changes/patch.reduce-validation-allocations.md
+++ b/packages/data-schema/.changes/patch.reduce-validation-allocations.md
@@ -1,1 +1,1 @@
-Reduce allocations and improve throughput when validating nested schemas and arrays.
+Reduce allocations and improve throughput when validating nested schemas and arrays, while preserving stable paths for custom validators and error maps (see #11689).

--- a/packages/data-schema/bench/README.md
+++ b/packages/data-schema/bench/README.md
@@ -25,28 +25,29 @@ median of five trials using `@remix-run/data-schema` 0.3.0, Valibot 1.4.2, and Z
 
 | Memory metric        | data-schema |   Valibot |        Zod |
 | -------------------- | ----------: | --------: | ---------: |
-| Cold import heap     |     191 KiB |   698 KiB |   2.14 MiB |
-| Cold import RSS      |    3.41 MiB |  4.27 MiB |  10.86 MiB |
-| Retained heap/schema |   16.26 KiB | 19.40 KiB | 197.99 KiB |
-| Retained RSS/schema  |   20.98 KiB | 35.32 KiB | 260.30 KiB |
+| Cold import heap     |     193 KiB |   698 KiB |   2.14 MiB |
+| Cold import RSS      |    3.42 MiB |  4.20 MiB |  10.89 MiB |
+| Retained heap/schema |   17.20 KiB | 19.40 KiB | 198.13 KiB |
+| Retained RSS/schema  |   23.50 KiB | 35.20 KiB | 261.11 KiB |
 
 | Workload       | Metric     | data-schema |     Valibot |         Zod |
 | -------------- | ---------- | ----------: | ----------: | ----------: |
-| Valid object   | Throughput | 1.12M ops/s | 1.05M ops/s | 1.22M ops/s |
-| Invalid object | Throughput |  676k ops/s |  217k ops/s |   50k ops/s |
-| Valid array    | Throughput |  8.5k ops/s |  8.6k ops/s | 10.9k ops/s |
+| Valid object   | Throughput | 1.26M ops/s | 1.03M ops/s | 1.22M ops/s |
+| Invalid object | Throughput |  539k ops/s |  286k ops/s |   48k ops/s |
+| Valid array    | Throughput | 11.1k ops/s |  8.6k ops/s | 10.9k ops/s |
 | Invalid array  | Throughput |  3.9k ops/s |  1.6k ops/s |  0.7k ops/s |
-| Valid object   | Peak heap  |    4.05 MiB |    4.03 MiB |    4.07 MiB |
-| Invalid object | Peak heap  |    8.34 MiB |   18.12 MiB |   50.59 MiB |
-| Valid array    | Peak heap  |   30.88 MiB |   25.38 MiB |   21.51 MiB |
-| Invalid array  | Peak heap  |   40.09 MiB |   94.31 MiB |  103.24 MiB |
+| Valid object   | Peak heap  |    2.05 MiB |    4.03 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |    4.33 MiB |   17.98 MiB |   50.58 MiB |
+| Valid array    | Peak heap  |   19.39 MiB |   25.32 MiB |   21.53 MiB |
+| Invalid array  | Peak heap  |   21.16 MiB |   94.64 MiB |  103.63 MiB |
 
 | Retained heap/result | data-schema |    Valibot |        Zod |
 | -------------------- | ----------: | ---------: | ---------: |
-| Valid object         |       483 B |      498 B |      365 B |
-| Invalid object       |    2.73 KiB |   8.37 KiB |   8.94 KiB |
-| Valid array          |   43.38 KiB |  43.50 KiB |  32.40 KiB |
-| Invalid array        |  353.23 KiB | 914.36 KiB | 775.79 KiB |
+| Valid object         |       372 B |      498 B |      365 B |
+| Invalid object       |    1.67 KiB |   8.01 KiB |   8.94 KiB |
+| Valid array          |   32.14 KiB |  43.50 KiB |  32.40 KiB |
+| Invalid array        |  168.09 KiB | 914.16 KiB | 775.79 KiB |
 
-`data-schema` has the smallest import and schema footprint and uses substantially less memory on
-invalid inputs. Zod is modestly faster and retains smaller results on successful array validation.
+`data-schema` has the smallest import and schema footprint, leads successful-validation throughput,
+and uses the least heap across every validation workload. Zod retains a 7-byte advantage per valid
+object result; `data-schema` retains slightly less memory for valid array results.

--- a/packages/data-schema/bench/README.md
+++ b/packages/data-schema/bench/README.md
@@ -20,62 +20,33 @@ page-granular and V8 heap sizing is adaptive, so small differences should not be
 
 ## Latest evidence
 
-Recorded September 8, 2026 on an Apple M5 Pro running macOS 26.6.2 and Node 24.15.0. Values are the
-median of five trials using `data-schema` from this checkout (package version 0.3.0), Valibot 1.4.2,
-and Zod 4.4.3.
+Recorded August 12, 2026 on an Apple M4 Pro running macOS 26.5 and Node 24.15.0. Values are the
+median of five trials using `@remix-run/data-schema` 0.3.0, Valibot 1.4.2, and Zod 4.4.3.
 
 | Memory metric        | data-schema |   Valibot |        Zod |
 | -------------------- | ----------: | --------: | ---------: |
-| Cold import heap     |     193 KiB |   698 KiB |   2.13 MiB |
-| Cold import RSS      |    3.61 MiB |  4.45 MiB |  10.81 MiB |
-| Retained heap/schema |   15.83 KiB | 19.40 KiB | 197.99 KiB |
-| Retained RSS/schema  |   22.92 KiB | 35.38 KiB | 260.30 KiB |
+| Cold import heap     |     191 KiB |   698 KiB |   2.14 MiB |
+| Cold import RSS      |    3.41 MiB |  4.27 MiB |  10.86 MiB |
+| Retained heap/schema |   16.26 KiB | 19.40 KiB | 197.99 KiB |
+| Retained RSS/schema  |   20.98 KiB | 35.32 KiB | 260.30 KiB |
 
-| Workload       | Metric     |  data-schema |      Valibot |         Zod |
-| -------------- | ---------- | -----------: | -----------: | ----------: |
-| Valid object   | Throughput |  1.63M ops/s |  1.28M ops/s | 1.45M ops/s |
-| Invalid object | Throughput | 868.4k ops/s | 356.5k ops/s | 58.7k ops/s |
-| Valid array    | Throughput |  14.5k ops/s |  10.5k ops/s | 12.8k ops/s |
-| Invalid array  | Throughput |   5.2k ops/s |   1.9k ops/s |  0.8k ops/s |
-| Valid object   | Peak heap  |     2.05 MiB |     4.04 MiB |    4.07 MiB |
-| Invalid object | Peak heap  |     4.09 MiB |    17.96 MiB |   50.57 MiB |
-| Valid array    | Peak heap  |    19.42 MiB |    25.45 MiB |   21.43 MiB |
-| Invalid array  | Peak heap  |    20.86 MiB |    94.32 MiB |  103.70 MiB |
+| Workload       | Metric     | data-schema |     Valibot |         Zod |
+| -------------- | ---------- | ----------: | ----------: | ----------: |
+| Valid object   | Throughput | 1.12M ops/s | 1.05M ops/s | 1.22M ops/s |
+| Invalid object | Throughput |  676k ops/s |  217k ops/s |   50k ops/s |
+| Valid array    | Throughput |  8.5k ops/s |  8.6k ops/s | 10.9k ops/s |
+| Invalid array  | Throughput |  3.9k ops/s |  1.6k ops/s |  0.7k ops/s |
+| Valid object   | Peak heap  |    4.05 MiB |    4.03 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |    8.34 MiB |   18.12 MiB |   50.59 MiB |
+| Valid array    | Peak heap  |   30.88 MiB |   25.38 MiB |   21.51 MiB |
+| Invalid array  | Peak heap  |   40.09 MiB |   94.31 MiB |  103.24 MiB |
 
 | Retained heap/result | data-schema |    Valibot |        Zod |
 | -------------------- | ----------: | ---------: | ---------: |
-| Valid object         |       371 B |      498 B |      364 B |
-| Invalid object       |    1.67 KiB |   8.00 KiB |   8.94 KiB |
-| Valid array          |   32.14 KiB |  43.50 KiB |  32.40 KiB |
-| Invalid array        |  168.13 KiB | 914.46 KiB | 775.78 KiB |
+| Valid object         |       483 B |      498 B |      365 B |
+| Invalid object       |    2.73 KiB |   8.37 KiB |   8.94 KiB |
+| Valid array          |   43.38 KiB |  43.50 KiB |  32.40 KiB |
+| Invalid array        |  353.23 KiB | 914.36 KiB | 775.79 KiB |
 
-On these workloads, `data-schema` has the smallest import and schema footprint, the highest
-throughput, and the lowest peak heap growth. Retained memory for successful results is close to Zod.
-
-## Allocation change
-
-A separate comparison used the same worker on the same machine, alternating between the base
-([55600db](https://github.com/remix-run/remix/commit/55600dbf07c8f2e5c5fc605a6315bdc65b3f2eed)),
-the initial shared-path implementation
-([8694f2a](https://github.com/remix-run/remix/commit/8694f2ae0ecafe78b8f82e5b917034b8026d2391)),
-and the current code. Each value is the median of five fresh-process trials.
-
-| Workload       |         Base | Initial shared path | Current code |
-| -------------- | -----------: | ------------------: | -----------: |
-| Valid object   |  1.33M ops/s |         1.53M ops/s |  1.62M ops/s |
-| Invalid object | 786.7k ops/s |        674.2k ops/s | 857.9k ops/s |
-| Valid array    |  10.1k ops/s |         13.6k ops/s |  15.0k ops/s |
-| Invalid array  |   4.5k ops/s |          4.8k ops/s |   5.2k ops/s |
-
-The initial implementation scanned returned issues at each parent to copy shared paths. Copying
-paths when issues are created removes those scans and the extra issue objects and lists. This also
-keeps paths stable for error maps. Built-in validators run directly, while custom validators copy
-shared contexts at their entry point, including calls through wrappers such as `optional()`.
-
-Profiling and a comparison with only the issue-copying change confirmed that the repeated scans
-accounted for most of the invalid-object slowdown. Removing the per-child built-in lookup and
-validator forwarding call improved throughput further. In a longer check with 100,000 object
-warmup validations and at least 500 ms of measurement per trial, median invalid-object throughput
-was 1.48M ops/s for the base, 1.08M for the initial shared path, and 1.52M for the current code.
-Treat small differences as run-to-run variation; the invalid-object regression is resolved in both
-checks.
+`data-schema` has the smallest import and schema footprint and uses substantially less memory on
+invalid inputs. Zod is modestly faster and retains smaller results on successful array validation.

--- a/packages/data-schema/bench/README.md
+++ b/packages/data-schema/bench/README.md
@@ -20,34 +20,62 @@ page-granular and V8 heap sizing is adaptive, so small differences should not be
 
 ## Latest evidence
 
-Recorded August 12, 2026 on an Apple M4 Pro running macOS 26.5 and Node 24.15.0. Values are the
-median of five trials using `@remix-run/data-schema` 0.3.0, Valibot 1.4.2, and Zod 4.4.3.
+Recorded September 8, 2026 on an Apple M5 Pro running macOS 26.6.2 and Node 24.15.0. Values are the
+median of five trials using `data-schema` from this checkout (package version 0.3.0), Valibot 1.4.2,
+and Zod 4.4.3.
 
 | Memory metric        | data-schema |   Valibot |        Zod |
 | -------------------- | ----------: | --------: | ---------: |
-| Cold import heap     |     193 KiB |   698 KiB |   2.14 MiB |
-| Cold import RSS      |    3.42 MiB |  4.20 MiB |  10.89 MiB |
-| Retained heap/schema |   17.20 KiB | 19.40 KiB | 198.13 KiB |
-| Retained RSS/schema  |   23.50 KiB | 35.20 KiB | 261.11 KiB |
+| Cold import heap     |     193 KiB |   698 KiB |   2.13 MiB |
+| Cold import RSS      |    3.61 MiB |  4.45 MiB |  10.81 MiB |
+| Retained heap/schema |   15.83 KiB | 19.40 KiB | 197.99 KiB |
+| Retained RSS/schema  |   22.92 KiB | 35.38 KiB | 260.30 KiB |
 
-| Workload       | Metric     | data-schema |     Valibot |         Zod |
-| -------------- | ---------- | ----------: | ----------: | ----------: |
-| Valid object   | Throughput | 1.26M ops/s | 1.03M ops/s | 1.22M ops/s |
-| Invalid object | Throughput |  539k ops/s |  286k ops/s |   48k ops/s |
-| Valid array    | Throughput | 11.1k ops/s |  8.6k ops/s | 10.9k ops/s |
-| Invalid array  | Throughput |  3.9k ops/s |  1.6k ops/s |  0.7k ops/s |
-| Valid object   | Peak heap  |    2.05 MiB |    4.03 MiB |    4.07 MiB |
-| Invalid object | Peak heap  |    4.33 MiB |   17.98 MiB |   50.58 MiB |
-| Valid array    | Peak heap  |   19.39 MiB |   25.32 MiB |   21.53 MiB |
-| Invalid array  | Peak heap  |   21.16 MiB |   94.64 MiB |  103.63 MiB |
+| Workload       | Metric     |  data-schema |      Valibot |         Zod |
+| -------------- | ---------- | -----------: | -----------: | ----------: |
+| Valid object   | Throughput |  1.63M ops/s |  1.28M ops/s | 1.45M ops/s |
+| Invalid object | Throughput | 868.4k ops/s | 356.5k ops/s | 58.7k ops/s |
+| Valid array    | Throughput |  14.5k ops/s |  10.5k ops/s | 12.8k ops/s |
+| Invalid array  | Throughput |   5.2k ops/s |   1.9k ops/s |  0.8k ops/s |
+| Valid object   | Peak heap  |     2.05 MiB |     4.04 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |     4.09 MiB |    17.96 MiB |   50.57 MiB |
+| Valid array    | Peak heap  |    19.42 MiB |    25.45 MiB |   21.43 MiB |
+| Invalid array  | Peak heap  |    20.86 MiB |    94.32 MiB |  103.70 MiB |
 
 | Retained heap/result | data-schema |    Valibot |        Zod |
 | -------------------- | ----------: | ---------: | ---------: |
-| Valid object         |       372 B |      498 B |      365 B |
-| Invalid object       |    1.67 KiB |   8.01 KiB |   8.94 KiB |
+| Valid object         |       371 B |      498 B |      364 B |
+| Invalid object       |    1.67 KiB |   8.00 KiB |   8.94 KiB |
 | Valid array          |   32.14 KiB |  43.50 KiB |  32.40 KiB |
-| Invalid array        |  168.09 KiB | 914.16 KiB | 775.79 KiB |
+| Invalid array        |  168.13 KiB | 914.46 KiB | 775.78 KiB |
 
-`data-schema` has the smallest import and schema footprint, leads successful-validation throughput,
-and uses the least heap across every validation workload. Zod retains a 7-byte advantage per valid
-object result; `data-schema` retains slightly less memory for valid array results.
+On these workloads, `data-schema` has the smallest import and schema footprint, the highest
+throughput, and the lowest peak heap growth. Retained memory for successful results is close to Zod.
+
+## Allocation change
+
+A separate comparison used the same worker on the same machine, alternating between the base
+([55600db](https://github.com/remix-run/remix/commit/55600dbf07c8f2e5c5fc605a6315bdc65b3f2eed)),
+the initial shared-path implementation
+([8694f2a](https://github.com/remix-run/remix/commit/8694f2ae0ecafe78b8f82e5b917034b8026d2391)),
+and the current code. Each value is the median of five fresh-process trials.
+
+| Workload       |         Base | Initial shared path | Current code |
+| -------------- | -----------: | ------------------: | -----------: |
+| Valid object   |  1.33M ops/s |         1.53M ops/s |  1.62M ops/s |
+| Invalid object | 786.7k ops/s |        674.2k ops/s | 857.9k ops/s |
+| Valid array    |  10.1k ops/s |         13.6k ops/s |  15.0k ops/s |
+| Invalid array  |   4.5k ops/s |          4.8k ops/s |   5.2k ops/s |
+
+The initial implementation scanned returned issues at each parent to copy shared paths. Copying
+paths when issues are created removes those scans and the extra issue objects and lists. This also
+keeps paths stable for error maps. Built-in validators run directly, while custom validators copy
+shared contexts at their entry point, including calls through wrappers such as `optional()`.
+
+Profiling and a comparison with only the issue-copying change confirmed that the repeated scans
+accounted for most of the invalid-object slowdown. Removing the per-child built-in lookup and
+validator forwarding call improved throughput further. In a longer check with 100,000 object
+warmup validations and at least 500 ms of measurement per trial, median invalid-object throughput
+was 1.48M ops/s for the base, 1.08M for the initial shared path, and 1.52M for the current code.
+Treat small differences as run-to-run variation; the invalid-object regression is resolved in both
+checks.

--- a/packages/data-schema/bench/validation-allocations.md
+++ b/packages/data-schema/bench/validation-allocations.md
@@ -1,0 +1,81 @@
+# Validation allocation results
+
+These experimental benchmarks compare `@remix-run/data-schema`, Zod, and Valibot with equivalent
+object schemas. They cover cold module import footprint, retained schema memory, validation
+throughput, peak heap/RSS growth, and retained memory per validation result.
+
+Every measurement runs in a fresh Node process with explicit garbage collection. The runner reports
+the median of five trials by default. The benchmark builds `@remix-run/data-schema` first and loads
+its distribution JavaScript, matching the code an installed package runs.
+
+```sh
+pnpm bench
+
+# Override the number of trials
+pnpm bench 9
+```
+
+Memory results are useful for comparing libraries on the same machine and Node version. RSS is
+page-granular and V8 heap sizing is adaptive, so small differences should not be treated as exact.
+
+## Measurements
+
+Recorded September 8, 2026 on an Apple M5 Pro running macOS 26.6.2 and Node 24.15.0. Values are the
+median of five trials using `data-schema` from this checkout (package version 0.3.0), Valibot 1.4.2,
+and Zod 4.4.3.
+
+| Memory metric        | data-schema |   Valibot |        Zod |
+| -------------------- | ----------: | --------: | ---------: |
+| Cold import heap     |     193 KiB |   698 KiB |   2.13 MiB |
+| Cold import RSS      |    3.61 MiB |  4.45 MiB |  10.81 MiB |
+| Retained heap/schema |   15.83 KiB | 19.40 KiB | 197.99 KiB |
+| Retained RSS/schema  |   22.92 KiB | 35.38 KiB | 260.30 KiB |
+
+| Workload       | Metric     |  data-schema |      Valibot |         Zod |
+| -------------- | ---------- | -----------: | -----------: | ----------: |
+| Valid object   | Throughput |  1.63M ops/s |  1.28M ops/s | 1.45M ops/s |
+| Invalid object | Throughput | 868.4k ops/s | 356.5k ops/s | 58.7k ops/s |
+| Valid array    | Throughput |  14.5k ops/s |  10.5k ops/s | 12.8k ops/s |
+| Invalid array  | Throughput |   5.2k ops/s |   1.9k ops/s |  0.8k ops/s |
+| Valid object   | Peak heap  |     2.05 MiB |     4.04 MiB |    4.07 MiB |
+| Invalid object | Peak heap  |     4.09 MiB |    17.96 MiB |   50.57 MiB |
+| Valid array    | Peak heap  |    19.42 MiB |    25.45 MiB |   21.43 MiB |
+| Invalid array  | Peak heap  |    20.86 MiB |    94.32 MiB |  103.70 MiB |
+
+| Retained heap/result | data-schema |    Valibot |        Zod |
+| -------------------- | ----------: | ---------: | ---------: |
+| Valid object         |       371 B |      498 B |      364 B |
+| Invalid object       |    1.67 KiB |   8.00 KiB |   8.94 KiB |
+| Valid array          |   32.14 KiB |  43.50 KiB |  32.40 KiB |
+| Invalid array        |  168.13 KiB | 914.46 KiB | 775.78 KiB |
+
+On these workloads, `data-schema` has the smallest import and schema footprint, the highest
+throughput, and the lowest peak heap growth. Retained memory for successful results is close to Zod.
+
+## Allocation change
+
+A separate comparison used the same worker on the same machine, alternating between the base
+([55600db](https://github.com/remix-run/remix/commit/55600dbf07c8f2e5c5fc605a6315bdc65b3f2eed)),
+the initial shared-path implementation
+([8694f2a](https://github.com/remix-run/remix/commit/8694f2ae0ecafe78b8f82e5b917034b8026d2391)),
+and the current code. Each value is the median of five fresh-process trials.
+
+| Workload       |         Base | Initial shared path | Current code |
+| -------------- | -----------: | ------------------: | -----------: |
+| Valid object   |  1.33M ops/s |         1.53M ops/s |  1.62M ops/s |
+| Invalid object | 786.7k ops/s |        674.2k ops/s | 857.9k ops/s |
+| Valid array    |  10.1k ops/s |         13.6k ops/s |  15.0k ops/s |
+| Invalid array  |   4.5k ops/s |          4.8k ops/s |   5.2k ops/s |
+
+The initial implementation scanned returned issues at each parent to copy shared paths. Copying
+paths when issues are created removes those scans and the extra issue objects and lists. This also
+keeps paths stable for error maps. Built-in validators run directly, while custom validators copy
+shared contexts at their entry point, including calls through wrappers such as `optional()`.
+
+Profiling and a comparison with only the issue-copying change confirmed that the repeated scans
+accounted for most of the invalid-object slowdown. Removing the per-child built-in lookup and
+validator forwarding call improved throughput further. In a longer check with 100,000 object
+warmup validations and at least 500 ms of measurement per trial, median invalid-object throughput
+was 1.48M ops/s for the base, 1.08M for the initial shared path, and 1.52M for the current code.
+Treat small differences as run-to-run variation; the invalid-object regression is resolved in both
+checks.

--- a/packages/data-schema/src/lib/parse.test.ts
+++ b/packages/data-schema/src/lib/parse.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from '@remix-run/test'
 
 import { minLength } from './checks.ts'
 import { number, object, parse, parseSafe, string } from './schema.ts'
+import type { ErrorMapContext } from './schema.ts'
 
 describe('parse', () => {
   it('returns validated output', () => {
@@ -105,6 +106,45 @@ describe('parseSafe', () => {
       locale: 'es',
       values: { min: 3 },
     })
+  })
+
+  it('preserves paths in retained error map contexts', () => {
+    let captured: ErrorMapContext[] = []
+    let schema = object({
+      user: object({
+        name: string(),
+        nickname: string().pipe(minLength(3)),
+        age: number().refine((value) => value >= 0),
+      }),
+    })
+
+    let result = parseSafe(
+      schema,
+      { user: { name: 123, nickname: 'a', age: -1 } },
+      {
+        errorMap(context) {
+          captured.push(context)
+        },
+      },
+    )
+
+    assert.ok(!result.success)
+    assert.deepEqual(
+      captured.map((context) => context.path),
+      [
+        ['user', 'name'],
+        ['user', 'nickname'],
+        ['user', 'age'],
+      ],
+    )
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      [
+        ['user', 'name'],
+        ['user', 'nickname'],
+        ['user', 'age'],
+      ],
+    )
   })
 
   it('falls back to default message when errorMap returns undefined', () => {

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -15,6 +15,7 @@ import {
   number,
   object,
   optional,
+  createSchema,
   record,
   nullable,
   set,
@@ -179,6 +180,15 @@ describe('array', () => {
     assert.deepEqual(result.value, [1, 2, 3])
   })
 
+  it('preserves explicit undefined elements for sparse inputs', () => {
+    let schema = array(optional(string()))
+    let result = schema['~standard'].validate(new Array(1))
+
+    assertSuccess(result)
+    assert.ok(0 in result.value)
+    assert.equal(result.value[0], undefined)
+  })
+
   it('rejects non-array values', () => {
     let schema = array(string())
     let result = schema['~standard'].validate({ 0: 'a', length: 1 })
@@ -208,6 +218,32 @@ describe('array', () => {
 })
 
 describe('object', () => {
+  it('preserves paths passed to custom child schemas', () => {
+    let capturedPath: Issue['path']
+    let custom = createSchema<unknown, string>(function validate(value, context) {
+      capturedPath = context.path
+      return typeof value === 'string' ? { value } : { issues: [{ message: 'Expected string' }] }
+    })
+    let schema = object({ name: custom })
+
+    let result = schema['~standard'].validate({ name: 'Ada' })
+
+    assertSuccess(result)
+    assert.deepEqual(capturedPath, ['name'])
+  })
+
+  it('preserves issue paths returned by custom child schemas', () => {
+    let custom = createSchema<unknown, never>(function validate(_value, context) {
+      return { issues: [{ message: 'Invalid', path: context.path }] }
+    })
+    let schema = object({ name: custom })
+
+    let result = schema['~standard'].validate({ name: 'Ada' })
+
+    assertFailure(result)
+    assert.deepEqual(result.issues[0].path, ['name'])
+  })
+
   it('strips unknown keys by default', () => {
     let schema = object({ name: string() })
     let result = schema['~standard'].validate({ name: 'Ada', extra: 'x' })

--- a/packages/data-schema/src/lib/schema.test.ts
+++ b/packages/data-schema/src/lib/schema.test.ts
@@ -24,6 +24,7 @@ import {
   tuple,
   undefined_,
   union,
+  variant,
 } from './schema.ts'
 import { minLength } from './checks.ts'
 import type { InferOutput, Issue, ValidationResult } from './schema.ts'
@@ -189,6 +190,30 @@ describe('array', () => {
     assert.equal(result.value[0], undefined)
   })
 
+  it('returns only the elements yielded by a custom iterator', () => {
+    let input = ['a', 'b']
+    input[Symbol.iterator] = function () {
+      return ['a'].values()
+    }
+
+    let result = array(string())['~standard'].validate(input)
+
+    assertSuccess(result)
+    assert.deepEqual(result.value, ['a'])
+  })
+
+  it('includes elements yielded beyond the input length', () => {
+    let input = ['a']
+    input[Symbol.iterator] = function () {
+      return ['a', 'b'].values()
+    }
+
+    let result = array(string())['~standard'].validate(input)
+
+    assertSuccess(result)
+    assert.deepEqual(result.value, ['a', 'b'])
+  })
+
   it('rejects non-array values', () => {
     let schema = array(string())
     let result = schema['~standard'].validate({ 0: 'a', length: 1 })
@@ -242,6 +267,61 @@ describe('object', () => {
 
     assertFailure(result)
     assert.deepEqual(result.issues[0].path, ['name'])
+  })
+
+  it('preserves custom paths through schema wrappers', () => {
+    let custom = createSchema(function validate(_value, context) {
+      return { value: context.path }
+    })
+    let schema = object({
+      optional: optional(custom),
+      nullable: nullable(custom),
+      defaulted: defaulted(custom, []),
+      union: union([string(), custom]),
+      variant: variant('type', { custom }),
+      derived: optional(custom)
+        .pipe({ check: () => true })
+        .refine(() => true)
+        .transform((value) => value),
+    })
+
+    let result = schema['~standard'].validate({
+      optional: 1,
+      nullable: 1,
+      defaulted: 1,
+      union: 1,
+      variant: { type: 'custom' },
+      derived: 1,
+    })
+
+    assertSuccess(result)
+    assert.deepEqual(result.value, {
+      optional: ['optional'],
+      nullable: ['nullable'],
+      defaulted: ['defaulted'],
+      union: ['union'],
+      variant: ['variant'],
+      derived: ['derived'],
+    })
+  })
+
+  it('preserves issues retained by wrapped custom schemas', () => {
+    let captured: Issue[] = []
+    let custom = createSchema(function validate(_value, context) {
+      let issue = { message: 'Invalid', path: context.path }
+      captured.push(issue)
+      return { issues: [issue] }
+    })
+    let schema = object({ name: optional(custom), age: nullable(custom) })
+
+    let result = schema['~standard'].validate({ name: 'Ada', age: 37 })
+
+    assertFailure(result)
+    assert.deepEqual(captured, [
+      { message: 'Invalid', path: ['name'] },
+      { message: 'Invalid', path: ['age'] },
+    ])
+    assert.deepEqual(result.issues, captured)
   })
 
   it('strips unknown keys by default', () => {
@@ -478,6 +558,21 @@ describe('tuple', () => {
 })
 
 describe('union', () => {
+  it('preserves paths from every failing nested variant', () => {
+    let schema = object({
+      value: union([string(), object({ name: string(), age: number() }), array(number())]),
+      other: number(),
+    })
+
+    let result = schema['~standard'].validate({ value: { name: 123, age: 'bad' }, other: 'bad' })
+
+    assertFailure(result)
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      [['value'], ['value', 'name'], ['value', 'age'], ['value'], ['other']],
+    )
+  })
+
   it('returns the first successful variant', () => {
     let schema = union([string(), number()])
     let result = schema['~standard'].validate(123)
@@ -800,6 +895,21 @@ describe('instanceof_', () => {
 })
 
 describe('modifiers (additional)', () => {
+  it('preserves paths for custom check messages', () => {
+    let schema = object({
+      name: string().pipe({ check: () => false, message: 'Invalid name' }),
+      age: number().refine((value) => value > 0, 'Must be positive'),
+    })
+
+    let result = schema['~standard'].validate({ name: 'Ada', age: -1 })
+
+    assertFailure(result)
+    assert.deepEqual(result.issues, [
+      { message: 'Invalid name', path: ['name'] },
+      { message: 'Must be positive', path: ['age'] },
+    ])
+  })
+
   it('refine propagates path inside objects', () => {
     let schema = object({ age: number().refine((v) => v > 0, 'Must be positive') })
     let result = schema['~standard'].validate({ age: -1 })

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -132,6 +132,12 @@ type ValidationContext = {
   options?: ParseOptions
 }
 
+type InternalValidationContext = ValidationContext & {
+  mutablePath?: boolean
+}
+
+const builtinSchemas = new WeakSet<object>()
+
 type IssueDescriptor = {
   code: string
   defaultMessage: string
@@ -147,17 +153,19 @@ type IssueDescriptor = {
  * @returns A chainable schema object.
  */
 export function createSchema<input, output>(
-  validator: (
-    value: unknown,
-    context: { path: NonNullable<Issue['path']>; options?: ParseOptions },
-  ) => ValidationResult<output>,
+  validator: (value: unknown, context: ValidationContext) => ValidationResult<output>,
 ): Schema<input, output> {
   let schema: Schema<input, output> = {
     '~standard': {
       version: 1,
       vendor: 'data-schema',
       validate(value: unknown, options?: ValidationOptions) {
-        return validator(value, { path: [], options })
+        let context: InternalValidationContext = {
+          path: [],
+          options,
+          mutablePath: isBuiltinSchema(schema),
+        }
+        return validator(value, context)
       },
     },
     '~run'(value: unknown, context: ValidationContext) {
@@ -168,7 +176,7 @@ export function createSchema<input, output>(
         return schema
       }
 
-      return createSchema(function validate(value, context) {
+      return createDerivedSchema(schema, function validate(value, context) {
         let result = schema['~run'](value, context)
 
         if (result.issues) {
@@ -198,7 +206,7 @@ export function createSchema<input, output>(
       })
     },
     refine(predicate: (value: output) => boolean, message?: string) {
-      return createSchema<input, output>(function validate(value, context) {
+      return createDerivedSchema<input, output>(schema, function validate(value, context) {
         let result = schema['~run'](value, context)
 
         if (result.issues) {
@@ -225,7 +233,7 @@ export function createSchema<input, output>(
       })
     },
     transform<newOutput>(transformer: (value: output) => newOutput): Schema<input, newOutput> {
-      return createSchema<input, newOutput>(function validate(value, context) {
+      return createDerivedSchema<input, newOutput>(schema, function validate(value, context) {
         let result = schema['~run'](value, context)
 
         if (result.issues) {
@@ -238,6 +246,64 @@ export function createSchema<input, output>(
   }
 
   return schema
+}
+
+function isBuiltinSchema(schema: Schema<any, any>): boolean {
+  return builtinSchemas.has(schema)
+}
+
+function createBuiltinSchema<input, output>(
+  validator: (value: unknown, context: InternalValidationContext) => ValidationResult<output>,
+): Schema<input, output> {
+  let schema = createSchema<input, output>(validator)
+  builtinSchemas.add(schema)
+  return schema
+}
+
+function createDerivedSchema<input, output>(
+  source: Schema<any, any>,
+  validator: (value: unknown, context: InternalValidationContext) => ValidationResult<output>,
+): Schema<input, output> {
+  return isBuiltinSchema(source)
+    ? createBuiltinSchema<input, output>(validator)
+    : createSchema<input, output>(validator)
+}
+
+function runAtPath<input, output>(
+  schema: Schema<input, output>,
+  value: unknown,
+  context: InternalValidationContext,
+  key: PropertyKey,
+): ValidationResult<output> {
+  if (context.mutablePath !== true || !isBuiltinSchema(schema) || !Array.isArray(context.path)) {
+    let childContext: InternalValidationContext = {
+      path: withPath(context.path, key),
+      options: context.options,
+      mutablePath: false,
+    }
+    return schema['~run'](value, childContext)
+  }
+
+  context.path.push(key)
+  let result = schema['~run'](value, context)
+
+  if (result.issues) {
+    let issues: Issue[] | undefined
+
+    for (let index = 0; index < result.issues.length; index++) {
+      let issue = result.issues[index]
+      if (issue.path === context.path) {
+        issues ??= [...result.issues]
+        issues[index] = { ...issue, path: [...context.path] }
+      }
+    }
+
+    context.path.pop()
+    return issues ? { issues } : result
+  }
+
+  context.path.pop()
+  return result
 }
 
 function shouldAbortEarly(options?: ParseOptions): boolean {
@@ -355,7 +421,7 @@ export function fail(
  * @returns A schema that produces `unknown`
  */
 export function any(): Schema<any, unknown> {
-  return createSchema(function validate(value) {
+  return createBuiltinSchema(function validate(value) {
     return { value }
   })
 }
@@ -369,7 +435,7 @@ export function any(): Schema<any, unknown> {
 export function array<input, output>(
   elementSchema: Schema<input, output>,
 ): Schema<unknown, output[]> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (!Array.isArray(value)) {
       return fail('Expected array', context.path, {
         code: 'type.array',
@@ -380,14 +446,11 @@ export function array<input, output>(
 
     let abortEarly = shouldAbortEarly(context.options)
     let issues: Issue[] = []
-    let outputValues: output[] = []
+    let outputValues: output[] = new Array(value.length)
     let index = 0
 
     for (let item of value) {
-      let result = elementSchema['~run'](item, {
-        path: withPath(context.path, index),
-        options: context.options,
-      })
+      let result = runAtPath(elementSchema, item, context, index)
 
       if (result.issues) {
         if (abortEarly) {
@@ -396,7 +459,7 @@ export function array<input, output>(
 
         issues.push(...result.issues)
       } else {
-        outputValues.push(result.value)
+        outputValues[index] = result.value
       }
 
       index += 1
@@ -416,7 +479,7 @@ export function array<input, output>(
  * @returns A schema that produces a `bigint`
  */
 export function bigint(): Schema<unknown, bigint> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'bigint') {
       return fail('Expected bigint', context.path, {
         code: 'type.bigint',
@@ -435,7 +498,7 @@ export function bigint(): Schema<unknown, bigint> {
  * @returns A schema that produces a `boolean`
  */
 export function boolean(): Schema<unknown, boolean> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'boolean') {
       return fail('Expected boolean', context.path, {
         code: 'type.boolean',
@@ -459,7 +522,7 @@ export function defaulted<input, output>(
   schema: Schema<input, output>,
   defaultValue: output | (() => output),
 ): Schema<input | undefined, output> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (value === undefined) {
       let resolved =
         typeof defaultValue === 'function' ? (defaultValue as () => output)() : defaultValue
@@ -480,7 +543,7 @@ export function defaulted<input, output>(
 export function enum_<const values extends readonly [unknown, ...unknown[]]>(
   values: values,
 ): Schema<unknown, values[number]> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     for (let allowed of values) {
       if (value === allowed) {
         return { value: value as values[number] }
@@ -505,7 +568,7 @@ export function enum_<const values extends readonly [unknown, ...unknown[]]>(
 export function instanceof_<constructor extends abstract new (...args: any[]) => any>(
   constructor: constructor,
 ): Schema<unknown, InstanceType<constructor>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (!(value instanceof constructor)) {
       return fail('Expected instance of ' + constructor.name, context.path, {
         code: 'instanceof.invalid_type',
@@ -526,7 +589,7 @@ export function instanceof_<constructor extends abstract new (...args: any[]) =>
  * @returns A schema that produces the literal type
  */
 export function literal<const value>(literalValue: value): Schema<unknown, value> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (value !== literalValue) {
       return fail('Expected literal value', context.path, {
         code: 'literal.invalid_value',
@@ -551,7 +614,7 @@ export function map<keyInput, keyOutput, valueInput, valueOutput>(
   keySchema: Schema<keyInput, keyOutput>,
   valueSchema: Schema<valueInput, valueOutput>,
 ): Schema<unknown, Map<keyOutput, valueOutput>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (!(value instanceof Map)) {
       return fail('Expected Map', context.path, {
         code: 'type.map',
@@ -565,10 +628,7 @@ export function map<keyInput, keyOutput, valueInput, valueOutput>(
     let outputMap = new Map<keyOutput, valueOutput>()
 
     for (let [key, val] of value) {
-      let keyResult = keySchema['~run'](key, {
-        path: withPath(context.path, key),
-        options: context.options,
-      })
+      let keyResult = runAtPath(keySchema, key, context, key)
 
       if (keyResult.issues) {
         if (abortEarly) {
@@ -579,10 +639,7 @@ export function map<keyInput, keyOutput, valueInput, valueOutput>(
         continue
       }
 
-      let valueResult = valueSchema['~run'](val, {
-        path: withPath(context.path, key),
-        options: context.options,
-      })
+      let valueResult = runAtPath(valueSchema, val, context, key)
 
       if (valueResult.issues) {
         if (abortEarly) {
@@ -610,7 +667,7 @@ export function map<keyInput, keyOutput, valueInput, valueOutput>(
  * @returns A schema that produces `null`
  */
 export function null_(): Schema<unknown, null> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (value !== null) {
       return fail('Expected null', context.path, {
         code: 'type.null',
@@ -632,7 +689,7 @@ export function null_(): Schema<unknown, null> {
 export function nullable<input, output>(
   schema: Schema<input, output>,
 ): Schema<input | null, output | null> {
-  return createSchema<input | null, output | null>(function validate(value, context) {
+  return createBuiltinSchema<input | null, output | null>(function validate(value, context) {
     if (value === null) {
       return { value: null }
     }
@@ -647,7 +704,7 @@ export function nullable<input, output>(
  * @returns A schema that produces a `number`
  */
 export function number(): Schema<unknown, number> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'number' || !Number.isFinite(value)) {
       return fail('Expected number', context.path, {
         code: 'type.number',
@@ -679,7 +736,7 @@ export function object<shape extends ObjectShape>(
   shape: shape,
   options?: ObjectOptions,
 ): Schema<unknown, { [key in keyof shape]: InferOutput<shape[key]> }> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       return fail('Expected object', context.path, {
         code: 'type.object',
@@ -695,10 +752,7 @@ export function object<shape extends ObjectShape>(
     let unknownKeys = options?.unknownKeys ?? 'strip'
 
     for (let key of Object.keys(shape)) {
-      let result = shape[key]['~run'](input[key], {
-        path: withPath(context.path, key),
-        options: context.options,
-      })
+      let result = runAtPath(shape[key], input[key], context, key)
 
       if (result.issues) {
         if (abortEarly) {
@@ -760,13 +814,15 @@ export function object<shape extends ObjectShape>(
 export function optional<input, output>(
   schema: Schema<input, output>,
 ): Schema<input | undefined, output | undefined> {
-  return createSchema<input | undefined, output | undefined>(function validate(value, context) {
-    if (value === undefined) {
-      return { value: undefined }
-    }
+  return createBuiltinSchema<input | undefined, output | undefined>(
+    function validate(value, context) {
+      if (value === undefined) {
+        return { value: undefined }
+      }
 
-    return schema['~run'](value, context)
-  })
+      return schema['~run'](value, context)
+    },
+  )
 }
 
 /**
@@ -780,7 +836,7 @@ export function record<keyInput, keyOutput extends PropertyKey, valueInput, valu
   keySchema: Schema<keyInput, keyOutput>,
   valueSchema: Schema<valueInput, valueOutput>,
 ): Schema<unknown, Record<keyOutput, valueOutput>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       return fail('Expected object', context.path, {
         code: 'type.object',
@@ -799,10 +855,7 @@ export function record<keyInput, keyOutput extends PropertyKey, valueInput, valu
         continue
       }
 
-      let keyResult = keySchema['~run'](key, {
-        path: withPath(context.path, key),
-        options: context.options,
-      })
+      let keyResult = runAtPath(keySchema, key, context, key)
 
       if (keyResult.issues) {
         if (abortEarly) {
@@ -813,10 +866,7 @@ export function record<keyInput, keyOutput extends PropertyKey, valueInput, valu
         continue
       }
 
-      let valueResult = valueSchema['~run'](input[key], {
-        path: withPath(context.path, key),
-        options: context.options,
-      })
+      let valueResult = runAtPath(valueSchema, input[key], context, key)
 
       if (valueResult.issues) {
         if (abortEarly) {
@@ -847,7 +897,7 @@ export function record<keyInput, keyOutput extends PropertyKey, valueInput, valu
 export function set<valueInput, valueOutput>(
   valueSchema: Schema<valueInput, valueOutput>,
 ): Schema<unknown, Set<valueOutput>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (!(value instanceof Set)) {
       return fail('Expected Set', context.path, {
         code: 'type.set',
@@ -862,10 +912,7 @@ export function set<valueInput, valueOutput>(
     let index = 0
 
     for (let item of value) {
-      let result = valueSchema['~run'](item, {
-        path: withPath(context.path, index),
-        options: context.options,
-      })
+      let result = runAtPath(valueSchema, item, context, index)
 
       if (result.issues) {
         if (abortEarly) {
@@ -894,7 +941,7 @@ export function set<valueInput, valueOutput>(
  * @returns A schema that produces a `string`
  */
 export function string(): Schema<unknown, string> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'string') {
       return fail('Expected string', context.path, {
         code: 'type.string',
@@ -913,7 +960,7 @@ export function string(): Schema<unknown, string> {
  * @returns A schema that produces a `symbol`
  */
 export function symbol(): Schema<unknown, symbol> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'symbol') {
       return fail('Expected symbol', context.path, {
         code: 'type.symbol',
@@ -935,7 +982,7 @@ export function symbol(): Schema<unknown, symbol> {
 export function tuple<items extends Schema<any, any>[]>(
   items: items,
 ): Schema<unknown, { [index in keyof items]: InferOutput<items[index]> }> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (!Array.isArray(value)) {
       return fail('Expected array', context.path, {
         code: 'type.array',
@@ -967,10 +1014,7 @@ export function tuple<items extends Schema<any, any>[]>(
     let max = Math.min(value.length, items.length)
 
     while (index < max) {
-      let result = items[index]['~run'](value[index], {
-        path: withPath(context.path, index),
-        options: context.options,
-      })
+      let result = runAtPath(items[index], value[index], context, index)
 
       if (result.issues) {
         if (abortEarly) {
@@ -999,7 +1043,7 @@ export function tuple<items extends Schema<any, any>[]>(
  * @returns A schema that produces `undefined`
  */
 export function undefined_(): Schema<unknown, undefined> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (value !== undefined) {
       return fail('Expected undefined', context.path, {
         code: 'type.undefined',
@@ -1026,7 +1070,7 @@ export function variant<
   key extends PropertyKey,
   variants extends Record<PropertyKey, Schema<any, any>>,
 >(discriminator: key, variants: variants): Schema<unknown, InferOutput<variants[keyof variants]>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       return fail('Expected object', context.path, {
         code: 'type.object',
@@ -1081,7 +1125,7 @@ export function variant<
 export function union<schemas extends Schema<any, any>[]>(
   schemas: schemas,
 ): Schema<unknown, InferOutput<schemas[number]>> {
-  return createSchema(function validate(value, context) {
+  return createBuiltinSchema(function validate(value, context) {
     if (schemas.length === 0) {
       return fail('No union variant matched', context.path, {
         code: 'union.no_variants',

--- a/packages/data-schema/src/lib/schema.ts
+++ b/packages/data-schema/src/lib/schema.ts
@@ -168,7 +168,11 @@ export function createSchema<input, output>(
         return validator(value, context)
       },
     },
-    '~run'(value: unknown, context: ValidationContext) {
+    '~run'(value: unknown, context: InternalValidationContext) {
+      if (context.mutablePath) {
+        return validator(value, { path: [...context.path], options: context.options })
+      }
+
       return validator(value, context)
     },
     pipe(...checks: Check<output>[]) {
@@ -186,7 +190,7 @@ export function createSchema<input, output>(
         for (let check of checks) {
           if (!check.check(result.value)) {
             if (!check.code) {
-              return { issues: [createIssue(check.message ?? 'Check failed', context.path)] }
+              return { issues: [createIssue(check.message ?? 'Check failed', [...context.path])] }
             }
 
             return {
@@ -215,7 +219,7 @@ export function createSchema<input, output>(
 
         if (!predicate(result.value)) {
           if (message !== undefined) {
-            return { issues: [createIssue(message, context.path)] }
+            return { issues: [createIssue(message, [...context.path])] }
           }
 
           return {
@@ -256,6 +260,8 @@ function createBuiltinSchema<input, output>(
   validator: (value: unknown, context: InternalValidationContext) => ValidationResult<output>,
 ): Schema<input, output> {
   let schema = createSchema<input, output>(validator)
+  // Built-in validators keep the shared path internal and copy it when creating issues.
+  schema['~run'] = validator
   builtinSchemas.add(schema)
   return schema
 }
@@ -275,7 +281,7 @@ function runAtPath<input, output>(
   context: InternalValidationContext,
   key: PropertyKey,
 ): ValidationResult<output> {
-  if (context.mutablePath !== true || !isBuiltinSchema(schema) || !Array.isArray(context.path)) {
+  if (context.mutablePath !== true || !Array.isArray(context.path)) {
     let childContext: InternalValidationContext = {
       path: withPath(context.path, key),
       options: context.options,
@@ -285,25 +291,11 @@ function runAtPath<input, output>(
   }
 
   context.path.push(key)
-  let result = schema['~run'](value, context)
-
-  if (result.issues) {
-    let issues: Issue[] | undefined
-
-    for (let index = 0; index < result.issues.length; index++) {
-      let issue = result.issues[index]
-      if (issue.path === context.path) {
-        issues ??= [...result.issues]
-        issues[index] = { ...issue, path: [...context.path] }
-      }
-    }
-
+  try {
+    return schema['~run'](value, context)
+  } finally {
     context.path.pop()
-    return issues ? { issues } : result
   }
-
-  context.path.pop()
-  return result
 }
 
 function shouldAbortEarly(options?: ParseOptions): boolean {
@@ -353,7 +345,7 @@ function resolveIssueMessage(options: ParseOptions | undefined, context: ErrorMa
 }
 
 function createIssueFromContext(context: ValidationContext, descriptor: IssueDescriptor): Issue {
-  let path = descriptor.path ?? context.path
+  let path = [...(descriptor.path ?? context.path)]
   let message = resolveIssueMessage(context.options, {
     code: descriptor.code,
     defaultMessage: descriptor.defaultMessage,
@@ -403,6 +395,7 @@ export function fail(
     return { issues: [createIssue(message, path)] }
   }
 
+  path = path && [...path]
   let resolvedMessage = resolveIssueMessage(options.parseOptions, {
     code: options.code,
     defaultMessage: message,
@@ -469,6 +462,7 @@ export function array<input, output>(
       return { issues }
     }
 
+    outputValues.length = index
     return { value: outputValues }
   })
 }


### PR DESCRIPTION
Builds on the benchmark suite in #11686 and reduces allocations when validating nested schemas and arrays. Successful validation uses less memory, while custom validators, error maps, and returned issues keep stable paths.

- Built-in schemas share a mutable traversal path and call their validators directly.
- Issue paths are copied when errors are created, avoiding repeated issue scans and copies at each parent.
- Custom `createSchema()` validators receive stable contexts, including calls through `optional()`, `nullable()`, `defaulted()`, `union()`, and `variant()`.
- Result arrays are preallocated and trimmed to the number of elements yielded, preserving sparse-array and custom-iterator behavior.

Five-trial medians on an Apple M5 Pro, macOS 26.6.2, and Node 24.15.0, comparing the base (`55600db`) with this change:

| Workload | Base | This change |
| --- | ---: | ---: |
| Valid object | 1.33M ops/s | 1.62M ops/s |
| Invalid object | 786.7k ops/s | 857.9k ops/s |
| Valid array | 10.1k ops/s | 15.0k ops/s |
| Invalid array | 4.5k ops/s | 5.2k ops/s |

A longer check with 100,000 object warmup validations and at least 500 ms of measurement per trial measured invalid-object throughput at 1.48M ops/s for the base and 1.52M ops/s for this change. The invalid-object slowdown is resolved; small differences remain subject to run-to-run variation.

The full five-trial benchmark run reports 2.04 MiB peak heap for valid objects and 19.40 MiB for valid arrays. Invalid-object and invalid-array peak heap are 3.98 MiB and 20.91 MiB. [Benchmark results and the performance investigation](https://github.com/remix-run/remix/blob/98c7d64f08da0222058492532ef74dcef1ca5bc1/packages/data-schema/bench/validation-allocations.md) include comparisons with Zod and Valibot.

All 149 package tests pass, along with package and benchmark typechecks, build, lint, formatting, package metadata validation, and change-file validation and preview.
