### PR TITLE
Support RequestInit redirects in fetch router

### DIFF
--- a/demos/assets/server.ts
+++ b/demos/assets/server.ts
@@ -7,7 +7,7 @@ import { assetServer } from './app/utils/assets.ts'
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/bookstore/app/actions/account/controller.test.ts
+++ b/demos/bookstore/app/actions/account/controller.test.ts
@@ -12,7 +12,7 @@ const router = await createTestRouter()
 
 describe('account handlers', () => {
   it('GET /account redirects to login when not authenticated', async () => {
-    let response = await router.fetch('https://remix.run/account')
+    let response = await router.fetch('https://remix.run/account', { redirect: 'manual' })
 
     assert.equal(response.status, 302)
     assert.equal(response.headers.get('Location'), '/login?returnTo=%2Faccount')

--- a/demos/bookstore/app/actions/admin/books/controller.test.ts
+++ b/demos/bookstore/app/actions/admin/books/controller.test.ts
@@ -27,7 +27,7 @@ describe('admin books handlers', () => {
         inStock: 'true',
       }),
     })
-    let response = await router.fetch(createRequest)
+    let response = await router.fetch(createRequest, { redirect: 'manual' })
 
     assert.equal(response.status, 302)
     assert.ok(response.headers.get('Location')?.includes('/admin/books'))

--- a/demos/bookstore/app/actions/admin/controller.test.ts
+++ b/demos/bookstore/app/actions/admin/controller.test.ts
@@ -7,7 +7,7 @@ const router = await createTestRouter()
 
 describe('admin handlers', () => {
   it('GET /admin redirects when not authenticated', async () => {
-    let response = await router.fetch('https://remix.run/admin')
+    let response = await router.fetch('https://remix.run/admin', { redirect: 'manual' })
 
     assert.equal(response.status, 302)
     assert.equal(response.headers.get('Location'), '/login?returnTo=%2Fadmin')

--- a/demos/bookstore/app/actions/checkout/controller.test.ts
+++ b/demos/bookstore/app/actions/checkout/controller.test.ts
@@ -13,7 +13,7 @@ const router = await createTestRouter()
 
 describe('checkout handlers', () => {
   it('GET /checkout redirects when not authenticated', async () => {
-    let response = await router.fetch('https://remix.run/checkout')
+    let response = await router.fetch('https://remix.run/checkout', { redirect: 'manual' })
 
     assert.equal(response.status, 302)
     assert.equal(response.headers.get('Location'), '/login?returnTo=%2Fcheckout')
@@ -45,7 +45,7 @@ describe('checkout handlers', () => {
         zip: '12345',
       }),
     })
-    let checkoutResponse = await router.fetch(checkoutRequest)
+    let checkoutResponse = await router.fetch(checkoutRequest, { redirect: 'manual' })
     let confirmationUrl = checkoutResponse.headers.get('Location')
     sessionCookie = getSessionCookie(checkoutResponse) ?? sessionCookie
 

--- a/demos/bookstore/app/actions/controller.test.ts
+++ b/demos/bookstore/app/actions/controller.test.ts
@@ -83,7 +83,7 @@ describe('root controller', () => {
       body: formBody,
     })
 
-    let createResponse = await router.fetch(createRequest)
+    let createResponse = await router.fetch(createRequest, { redirect: 'manual' })
     assert.equal(createResponse.status, 302)
     assert.ok(createResponse.headers.get('Location')?.includes('/admin/books'))
 

--- a/demos/bookstore/server.ts
+++ b/demos/bookstore/server.ts
@@ -14,7 +14,7 @@ const router = createBookstoreRouter()
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/frame-navigation/app/app.test.e2e.ts
+++ b/demos/frame-navigation/app/app.test.e2e.ts
@@ -16,7 +16,7 @@ declare global {
 
 describe('frame navigation', () => {
   it('redirects unauthenticated requests to sign in', async (t) => {
-    let page = await t.serve(await createTestServer(router.fetch))
+    let page = await t.serve(await createAppTestServer())
 
     await page.goto(routes.main.index.href())
     await waitForNavigationRuntime(page)
@@ -26,7 +26,7 @@ describe('frame navigation', () => {
   })
 
   it('signs in without reloading the document', async (t) => {
-    let page = await t.serve(await createTestServer(router.fetch))
+    let page = await t.serve(await createAppTestServer())
     await page.goto(routes.main.index.href())
     await waitForNavigationRuntime(page)
     let documentMarker = await markDocument(page)
@@ -39,7 +39,7 @@ describe('frame navigation', () => {
   })
 
   it('navigates without reloading the document and supports back navigation', async (t) => {
-    let server = await createTestServer(router.fetch)
+    let server = await createAppTestServer()
     let page = await t.serve(server)
     await setAuthCookie(page, server.baseUrl)
     await page.goto(routes.main.index.href())
@@ -60,7 +60,7 @@ describe('frame navigation', () => {
   })
 
   it('replaces history when filtering courses', async (t) => {
-    let server = await createTestServer(router.fetch)
+    let server = await createAppTestServer()
     let page = await t.serve(server)
     await setAuthCookie(page, server.baseUrl)
     await page.goto(routes.main.index.href())
@@ -86,7 +86,7 @@ describe('frame navigation', () => {
   })
 
   it('submits a form and follows its redirect without reloading the document', async (t) => {
-    let server = await createTestServer(router.fetch)
+    let server = await createAppTestServer()
     let page = await t.serve(server)
     await setAuthCookie(page, server.baseUrl)
     await page.goto(routes.main.index.href())
@@ -119,7 +119,7 @@ describe('frame navigation', () => {
   })
 
   it('follows a frame redirect without reloading the document', async (t) => {
-    let server = await createTestServer(router.fetch)
+    let server = await createAppTestServer()
     let page = await t.serve(server)
     await setAuthCookie(page, server.baseUrl)
     await page.goto(routes.main.index.href())
@@ -135,7 +135,7 @@ describe('frame navigation', () => {
   })
 
   it('reloads the document when a subframe redirects to sign in', async (t) => {
-    let server = await createTestServer(router.fetch)
+    let server = await createAppTestServer()
     let page = await t.serve(server)
     await setAuthCookie(page, server.baseUrl)
     await page.goto(routes.settings.overview.href())
@@ -150,6 +150,10 @@ describe('frame navigation', () => {
     await assertDocumentReplaced(page, documentMarker)
   })
 })
+
+function createAppTestServer() {
+  return createTestServer((request) => router.fetch(request, { redirect: 'manual' }))
+}
 
 async function setAuthCookie(page: Page, baseUrl: string): Promise<void> {
   let cookie = new SetCookie(await authCookie.serialize('1'))

--- a/demos/frame-navigation/app/middleware/render.tsx
+++ b/demos/frame-navigation/app/middleware/render.tsx
@@ -61,38 +61,18 @@ async function resolveFrame(
   let cookie = request.headers.get('Cookie')
   if (cookie) headers.set('Cookie', cookie)
 
-  let res = await followFrameRedirects(router, request, url, headers)
+  let res = await router.fetch(
+    new Request(url, {
+      method: 'GET',
+      headers,
+      signal: request.signal,
+    }),
+  )
   if (!res.ok) {
     return `<pre>Frame error: ${res.status} ${res.statusText}</pre>`
   }
 
   return res.text()
-}
-
-async function followFrameRedirects(router: Router, request: Request, url: URL, headers: Headers) {
-  let currentUrl = url
-  let redirectsRemaining = 10
-
-  while (true) {
-    let res = await router.fetch(
-      new Request(currentUrl, {
-        method: 'GET',
-        headers,
-        signal: request.signal,
-      }),
-    )
-
-    let location = res.headers.get('Location')
-    if (!location || res.status < 300 || res.status >= 400) {
-      return res
-    }
-
-    if (redirectsRemaining-- <= 0) {
-      throw new Error('Too many frame redirects')
-    }
-
-    currentUrl = new URL(location, currentUrl)
-  }
 }
 
 function titleCaseFileName(fileUrl: string): string {

--- a/demos/frame-navigation/server.ts
+++ b/demos/frame-navigation/server.ts
@@ -6,7 +6,7 @@ import { router } from './app/router.ts'
 const server = http.createServer(
   createRequestListener(async (request: Request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/frames/server.ts
+++ b/demos/frames/server.ts
@@ -6,7 +6,7 @@ import { router } from './app/router.ts'
 const server = http.createServer(
   createRequestListener(async (request: Request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/social-auth/app/router.test.ts
+++ b/demos/social-auth/app/router.test.ts
@@ -38,6 +38,7 @@ describe('social-auth router', () => {
     let loginResponse = await router.fetch('https://social-auth.test/auth/login', {
       method: 'POST',
       body: new URLSearchParams({ email: 'user@example.com', password: 'password123' }),
+      redirect: 'manual',
     })
 
     assert.equal(loginResponse.status, 302)
@@ -62,6 +63,7 @@ describe('social-auth router', () => {
     let loginResponse = await router.fetch('https://social-auth.test/auth/login', {
       method: 'POST',
       body: new URLSearchParams({ email: 'user@example.com', password: 'wrong-password' }),
+      redirect: 'manual',
     })
 
     assert.equal(loginResponse.status, 302)
@@ -138,6 +140,7 @@ describe('social-auth router', () => {
           `https://social-auth.test/auth/google/callback?code=test-google-code&state=${encodeURIComponent(state)}`,
           loginSessionCookie,
         ),
+        { redirect: 'manual' },
       )
 
       assert.equal(callbackResponse.status, 302)
@@ -181,6 +184,7 @@ describe('social-auth router', () => {
         email: 'new-user@example.com',
         password: 'password123',
       }),
+      redirect: 'manual',
     })
 
     assert.equal(response.status, 302)
@@ -230,6 +234,7 @@ describe('social-auth router', () => {
     let loginResponse = await router.fetch('https://social-auth.test/auth/login', {
       method: 'POST',
       body: new URLSearchParams({ email: 'user@example.com', password: 'newpassword123' }),
+      redirect: 'manual',
     })
 
     assert.equal(loginResponse.status, 302)
@@ -241,6 +246,7 @@ describe('social-auth router', () => {
     let loginResponse = await router.fetch('https://social-auth.test/auth/login', {
       method: 'POST',
       body: new URLSearchParams({ email: 'user@example.com', password: 'password123' }),
+      redirect: 'manual',
     })
 
     let sessionCookie = getSessionCookie(loginResponse)
@@ -250,6 +256,7 @@ describe('social-auth router', () => {
       requestWithSession('https://social-auth.test/auth/logout', sessionCookie, {
         method: 'POST',
       }),
+      { redirect: 'manual' },
     )
 
     assert.equal(logoutResponse.status, 302)
@@ -257,6 +264,7 @@ describe('social-auth router', () => {
 
     let accountResponse = await router.fetch(
       requestWithSession('https://social-auth.test/account', sessionCookie),
+      { redirect: 'manual' },
     )
 
     assert.equal(accountResponse.status, 302)

--- a/demos/social-auth/server.ts
+++ b/demos/social-auth/server.ts
@@ -18,7 +18,7 @@ const router = createSocialAuthRouter()
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/sse/server.ts
+++ b/demos/sse/server.ts
@@ -6,7 +6,7 @@ import { router } from './app/router.ts'
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/demos/timeboxer/app/actions/auth/controller.test.ts
+++ b/demos/timeboxer/app/actions/auth/controller.test.ts
@@ -3,11 +3,17 @@ import { describe, it } from 'remix/test'
 
 process.env.SESSION_SECRET = 'test-session-secret'
 
-const { router } = await import('../../router.ts')
+const { router: appRouter } = await import('../../router.ts')
 const { routes } = await import('../../routes.ts')
 const { db, getMigrations, seed } = await import('../../db.ts')
 await db.reset({ migrations: await getMigrations(), seed })
 const { users } = await import('../../data/schema.ts')
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 describe('auth endpoints', () => {
   it('validates signup credentials', async () => {

--- a/demos/timeboxer/app/actions/schedules/authorization.test.ts
+++ b/demos/timeboxer/app/actions/schedules/authorization.test.ts
@@ -4,10 +4,16 @@ import { describe, it } from 'remix/test'
 process.env.SESSION_SECRET = 'test-session-secret'
 
 const { db, getMigrations, seed } = await import('../../db.ts')
-const { router } = await import('../../router.ts')
+const { router: appRouter } = await import('../../router.ts')
 const { routes } = await import('../../routes.ts')
 
 await db.reset({ migrations: await getMigrations(), seed })
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 describe('schedule authorization', () => {
   it('does not expose another user active schedule', async () => {

--- a/demos/timeboxer/app/actions/schedules/controller.test.ts
+++ b/demos/timeboxer/app/actions/schedules/controller.test.ts
@@ -4,11 +4,17 @@ import { describe, it } from 'remix/test'
 
 process.env.SESSION_SECRET = 'test-session-secret'
 
-const { router } = await import('../../router.ts')
+const { router: appRouter } = await import('../../router.ts')
 const { routes } = await import('../../routes.ts')
 const { db, getMigrations, seed } = await import('../../db.ts')
 await db.reset({ migrations: await getMigrations(), seed })
 const { schedules } = await import('../../data/schema.ts')
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 describe('schedule endpoints', () => {
   it('requires authentication', async () => {

--- a/demos/timeboxer/app/actions/schedules/validation.test.ts
+++ b/demos/timeboxer/app/actions/schedules/validation.test.ts
@@ -4,10 +4,16 @@ import { describe, it } from 'remix/test'
 process.env.SESSION_SECRET = 'test-session-secret'
 
 const { db, getMigrations, seed } = await import('../../db.ts')
-const { router } = await import('../../router.ts')
+const { router: appRouter } = await import('../../router.ts')
 const { routes } = await import('../../routes.ts')
 
 await db.reset({ migrations: await getMigrations(), seed })
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 describe('schedule input validation', () => {
   it('rejects invalid JSON request bodies', async () => {

--- a/demos/timeboxer/app/router.security.test.ts
+++ b/demos/timeboxer/app/router.security.test.ts
@@ -4,10 +4,16 @@ import { describe, it } from 'remix/test'
 process.env.SESSION_SECRET = 'test-session-secret'
 
 const { db, getMigrations, seed } = await import('./db.ts')
-const { router } = await import('./router.ts')
+const { router: appRouter } = await import('./router.ts')
 const { routes } = await import('./routes.ts')
 
 await db.reset({ migrations: await getMigrations(), seed })
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 describe('security middleware', () => {
   it('rejects auth mutations with missing or invalid CSRF tokens', async () => {

--- a/demos/timeboxer/server.ts
+++ b/demos/timeboxer/server.ts
@@ -10,7 +10,7 @@ await db.migrate(await getMigrations())
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/demos/unpkg/app/router.test.ts
+++ b/demos/unpkg/app/router.test.ts
@@ -7,7 +7,13 @@ import {
   addFetchHandler,
   createNpmRegistryMock,
 } from '../test/mock-fetch.ts'
-import { router } from './router.ts'
+import { router as appRouter } from './router.ts'
+
+const router = {
+  fetch(request: Request) {
+    return appRouter.fetch(request, { redirect: 'manual' })
+  },
+}
 
 before(() => {
   installFetchMock()

--- a/demos/unpkg/server.ts
+++ b/demos/unpkg/server.ts
@@ -6,7 +6,7 @@ import { router } from './app/router.ts'
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/docs/shared/server.ts
+++ b/docs/shared/server.ts
@@ -24,7 +24,7 @@ export function startDocsServer<context extends RequestContext<any, any>>(
   let { assetServer, devRefresh, label, port = readPort() } = options
   let requestListener = createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)

--- a/packages/auth/src/lib/oauth-flow.integration.test.ts
+++ b/packages/auth/src/lib/oauth-flow.integration.test.ts
@@ -101,7 +101,9 @@ describe('OAuth flow integration', () => {
     assert.equal(providerAuthorizeResponse.status, 302)
     assert.equal(typeof callbackURL, 'string')
 
-    let callbackResponse = await router.fetch(createRequest(callbackURL!, loginResponse))
+    let callbackResponse = await router.fetch(createRequest(callbackURL!, loginResponse), {
+      redirect: 'manual',
+    })
 
     assert.equal(callbackResponse.status, 302)
     assert.equal(callbackResponse.headers.get('Location'), '/dashboard')

--- a/packages/fetch-router/.changes/minor.fetch-redirects.md
+++ b/packages/fetch-router/.changes/minor.fetch-redirects.md
@@ -1,0 +1,1 @@
+`Router.fetch()` now supports the `RequestInit.redirect` option. Same-origin redirect responses are followed by default; use `manual` to return the redirect response or `error` to reject it. In `follow` mode, cross-origin redirect responses are returned for the network client to handle.

--- a/packages/fetch-router/README.md
+++ b/packages/fetch-router/README.md
@@ -9,6 +9,7 @@ A minimal, composable router built on the [web Fetch API](https://developer.mozi
 - **Typed Request Context**: Carry request-scoped context through routers, controllers, and actions
 - **Declarative Route Maps**: Define your route structure upfront with type-safe route names and request methods
 - **Flexible Middleware**: Use router, controller, and action middleware for each request boundary
+- **Redirect Handling**: Follow same-origin redirects or return them for another network boundary
 - **Easy Testing**: Use standard `fetch()` to test your routes - no special test harness required
 
 ## Installation
@@ -869,6 +870,18 @@ type AppContext = MiddlewareContext<typeof middleware>
 
 - use the `methodOverride()` middleware to override the request method
 - use a hidden `<input name="_method" value="...">` to override the request method
+
+#### Redirects
+
+`router.fetch()` follows same-origin redirects by default. Set the standard `RequestInit.redirect` option to `manual` to receive the redirect response unchanged, or to `error` to reject when a route redirects.
+
+Use `manual` at an HTTP server boundary so the client receives the redirect and decides whether to follow it:
+
+```ts
+let response = await router.fetch(request, { redirect: 'manual' })
+```
+
+Because `router.fetch()` dispatches requests in-process, `follow` returns cross-origin redirect responses for the network client to handle. Unlike browser `fetch()`, `manual` returns the original redirect response, including its status and `Location` header.
 
 ### Response Helpers
 

--- a/packages/fetch-router/demos/bun/index.ts
+++ b/packages/fetch-router/demos/bun/index.ts
@@ -6,7 +6,7 @@ Bun.serve({
   port: PORT,
   async fetch(request) {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/demos/cf-workers/worker.ts
+++ b/packages/fetch-router/demos/cf-workers/worker.ts
@@ -3,7 +3,7 @@ import { router } from './app/router.ts'
 export default {
   async fetch(request): Promise<Response> {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/demos/node/server.ts
+++ b/packages/fetch-router/demos/node/server.ts
@@ -8,7 +8,7 @@ const PORT = 44100
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/packages/fetch-router/src/lib/router.test.ts
+++ b/packages/fetch-router/src/lib/router.test.ts
@@ -143,6 +143,140 @@ describe('router.fetch()', () => {
     assert.deepEqual(requestLog, ['admin@remix.run'])
   })
 
+  it('follows redirects by default', async () => {
+    let router = createRouter()
+
+    router.get('/one', () => new Response(null, { status: 301, headers: { Location: 'two' } }))
+    router.get('/two', () => new Response(null, { status: 302, headers: { Location: '/three' } }))
+    router.get('/three', () => new Response(null, { status: 307, headers: { Location: '/four' } }))
+    router.get('/four', () => new Response(null, { status: 308, headers: { Location: '/home' } }))
+    router.get('/home', () => new Response('Home'))
+
+    let response = await router.fetch('https://remix.run/one')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Home')
+  })
+
+  it('returns redirect responses when redirect is manual', async () => {
+    let router = createRouter()
+    router.get('/old', () => new Response(null, { status: 302, headers: { Location: '/new' } }))
+    router.get('/new', () => new Response('New'))
+
+    let response = await router.fetch('https://remix.run/old', { redirect: 'manual' })
+
+    assert.equal(response.status, 302)
+    assert.equal(response.headers.get('Location'), '/new')
+  })
+
+  it('rejects redirect responses when redirect is error', async () => {
+    let router = createRouter()
+    router.get('/old', () => new Response(null, { status: 302, headers: { Location: '/new' } }))
+
+    await assert.rejects(router.fetch('https://remix.run/old', { redirect: 'error' }), TypeError)
+  })
+
+  it('rewrites POST requests to GET after 303 redirects', async () => {
+    let router = createRouter()
+
+    router.post(
+      '/submit',
+      () => new Response(null, { status: 303, headers: { Location: '/done' } }),
+    )
+    router.get('/done', ({ headers, method }) => {
+      assert.equal(method, 'GET')
+      assert.equal(headers.get('Content-Type'), null)
+      return new Response('Done')
+    })
+
+    let response = await router.fetch('https://remix.run/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'submission',
+    })
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Done')
+  })
+
+  it('rewrites POST requests to GET after 302 redirects', async () => {
+    let router = createRouter()
+
+    router.post(
+      '/submit',
+      () => new Response(null, { status: 302, headers: { Location: '/done' } }),
+    )
+    router.get('/done', ({ method }) => new Response(method))
+
+    let response = await router.fetch('https://remix.run/submit', {
+      method: 'POST',
+      body: 'submission',
+    })
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'GET')
+  })
+
+  it('preserves the method and body after 307 redirects', async () => {
+    let router = createRouter()
+
+    router.post('/submit', async ({ request }) => {
+      assert.equal(await request.text(), 'submission')
+      return new Response(null, { status: 307, headers: { Location: '/done' } })
+    })
+    router.post('/done', async ({ method, request }) => {
+      assert.equal(method, 'POST')
+      return new Response(await request.text())
+    })
+
+    let response = await router.fetch('https://remix.run/submit', {
+      method: 'POST',
+      body: 'submission',
+    })
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'submission')
+  })
+
+  it('returns cross-origin redirect responses', async () => {
+    let router = createRouter()
+    let destinationCalled = false
+
+    router.get(
+      '/old',
+      () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://example.com/new' },
+        }),
+    )
+    router.get('/new', () => {
+      destinationCalled = true
+      return new Response('New')
+    })
+
+    let response = await router.fetch('https://remix.run/old')
+
+    assert.equal(response.status, 302)
+    assert.equal(response.headers.get('Location'), 'https://example.com/new')
+    assert.equal(destinationCalled, false)
+  })
+
+  it('rejects after 20 redirects', async () => {
+    let router = createRouter()
+
+    router.get(
+      '/:count',
+      ({ params }) =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: `/${Number(params.count) + 1}` },
+        }),
+    )
+
+    await assert.rejects(router.fetch('https://remix.run/0'), /Too many redirects/)
+  })
+
   it('runs router middleware even when there are no routes', async () => {
     let requestLog: string[] = []
     let router = createRouter({

--- a/packages/fetch-router/src/lib/router.ts
+++ b/packages/fetch-router/src/lib/router.ts
@@ -26,6 +26,9 @@ import {
 
 type AnyContext = RequestContext<any, any>
 
+const redirectStatusCodes = new Set([301, 302, 303, 307, 308])
+const maxRedirectCount = 20
+
 type RouteTarget<
   pattern extends string = string,
   method extends RequestMethod | 'ANY' = RequestMethod | 'ANY',
@@ -236,6 +239,10 @@ export interface Router<context extends AnyContext = RequestContext> extends Rou
   /**
    * Fetch a response from the router.
    *
+   * Same-origin redirect responses are followed by default. Cross-origin redirects are returned
+   * unchanged. Set the `redirect` request option to `manual` to return any redirect response or
+   * `error` to reject it instead.
+   *
    * @param input The request input to fetch
    * @param init The request init options
    * @returns The response from the route that matched the request
@@ -302,6 +309,52 @@ function createRequestContext(input: string | URL | Request, init?: RequestInit)
   return new RequestContext(request)
 }
 
+function isRedirectResponse(response: Response): boolean {
+  return redirectStatusCodes.has(response.status)
+}
+
+function shouldRewriteRedirectMethod(request: Request, response: Response): boolean {
+  return (
+    ((response.status === 301 || response.status === 302) && request.method === 'POST') ||
+    (response.status === 303 && request.method !== 'GET' && request.method !== 'HEAD')
+  )
+}
+
+function resolveRedirectURL(request: Request, location: string): URL {
+  return new URL(location, request.url)
+}
+
+function cloneRequest(request: Request): Request {
+  // Some runtimes add host metadata generics to the clone return type, but it remains a Request.
+  return request.clone() as Request
+}
+
+function createRedirectRequest(request: Request, url: URL, response: Response): Request {
+  if (!shouldRewriteRedirectMethod(request, response)) {
+    return new Request(url, request)
+  }
+
+  let headers = new Headers(request.headers)
+  headers.delete('Content-Encoding')
+  headers.delete('Content-Language')
+  headers.delete('Content-Location')
+  headers.delete('Content-Type')
+
+  return new Request(url, {
+    cache: request.cache,
+    credentials: request.credentials,
+    headers,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    method: 'GET',
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  })
+}
+
 function getRoutePattern(target: RouteTarget): RoutePattern {
   if (target instanceof Route) {
     return target.pattern
@@ -351,6 +404,46 @@ export function createRouter<
     }
 
     return dispatch()
+  }
+
+  async function fetchRouter(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+    let context = createRequestContext(input, init)
+
+    for (let redirectCount = 0; ; redirectCount++) {
+      let request = context.request
+      let requestForRedirect =
+        request.redirect === 'follow' && request.body != null ? cloneRequest(request) : request
+      context.router = router
+
+      let response = await dispatchRouter(context)
+      if (!isRedirectResponse(response)) {
+        return response
+      }
+
+      if (request.redirect === 'manual') {
+        return response
+      }
+
+      if (request.redirect === 'error') {
+        throw new TypeError('Redirect encountered while redirect mode is set to `error`')
+      }
+
+      let location = response.headers.get('Location')
+      if (location == null) {
+        return response
+      }
+
+      let url = resolveRedirectURL(request, location)
+      if (url.origin !== new URL(request.url).origin) {
+        return response
+      }
+
+      if (redirectCount === maxRedirectCount) {
+        throw new TypeError('Too many redirects')
+      }
+
+      context = createRequestContext(createRedirectRequest(requestForRedirect, url, response))
+    }
   }
 
   async function dispatchMatches(context: RequestContext): Promise<Response> {
@@ -519,10 +612,7 @@ export function createRouter<
   let router: Router<RouterContext> = {
     ...rootBuilder,
     fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
-      let context = createRequestContext(input, init)
-      context.router = router
-
-      return dispatchRouter(context)
+      return fetchRouter(input, init)
     },
   }
 

--- a/packages/node-fetch-server/src/lib/test-server.ts
+++ b/packages/node-fetch-server/src/lib/test-server.ts
@@ -23,8 +23,8 @@ export interface TestServer {
  * returned {@link TestServer} with `t.serve()` from `@remix-run/test` to
  * drive it from a Playwright `Page`.
  *
- * @param handler - A fetch-style `(request) => Response | Promise<Response>`
- *   (e.g. `router.fetch` from `@remix-run/fetch-router`)
+ * @param handler A fetch-style `(request) => Response | Promise<Response>` handler, such as
+ * `(request) => router.fetch(request, { redirect: 'manual' })` from `@remix-run/fetch-router`.
  * @returns A promise that resolves to the running {@link TestServer}.
  */
 export function createTestServer(

--- a/packages/ui/bench/server.ts
+++ b/packages/ui/bench/server.ts
@@ -79,7 +79,7 @@ router.get(routes.index, () => {
 
 let server = http.createServer(
   createRequestListener(async (request) => {
-    return await router.fetch(request)
+    return await router.fetch(request, { redirect: 'manual' })
   }),
 )
 

--- a/packages/ui/demo/server.ts
+++ b/packages/ui/demo/server.ts
@@ -6,7 +6,7 @@ import { router } from './config/router.tsx'
 const server = http.createServer(
   createRequestListener(async (request: Request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })

--- a/template/server.ts
+++ b/template/server.ts
@@ -11,7 +11,7 @@ const hmrProxyPort = process.env.HMR_PROXY_PORT
 const server = http.createServer(
   createRequestListener(async (request) => {
     try {
-      return await router.fetch(request)
+      return await router.fetch(request, { redirect: 'manual' })
     } catch (error) {
       if (!(request.signal.aborted && error === request.signal.reason)) {
         console.error(error)


### PR DESCRIPTION
`Router.fetch()` accepts the standard `RequestInit.redirect` option, making in-process route calls handle redirects consistently without turning the router into a cross-origin network client.

- Follows same-origin redirects by default, including relative `Location` values and the 20-redirect limit
- Applies Fetch method semantics: 301/302 POST and 303 requests become GET, while 307/308 preserve the method and body
- Supports `manual` for the original 3xx response and `error` for rejecting redirects
- Returns cross-origin redirects in `follow` mode so an HTTP client can handle them
- Uses `redirect: 'manual'` at HTTP server boundaries so application redirects still reach browsers

```ts
let response = await router.fetch('https://app.example.com/old')

let redirect = await router.fetch('https://app.example.com/old', {
  redirect: 'manual',
})

await router.fetch('https://app.example.com/old', {
  redirect: 'error',
})
```

Unlike browser `fetch()`, manual mode returns the original redirect response rather than an opaque-redirect filtered response because dispatch stays in-process.
