### PR TITLE
Recover static middleware release as 0.4.15

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -198,7 +198,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.14`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.14)
+  - [`static-middleware@0.4.15`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.15)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
+## v0.4.15
+
+### Patch Changes
+
+- Republish the pending patch release as v0.4.15 because npm rejected v0.4.14.
+
 ## v0.4.14
 
 ### Patch Changes

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/static-middleware",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Npm consistently rejects `@remix-run/static-middleware@0.4.14` with `403 Forbidden`, including from GitHub OIDC and an authenticated maintainer publish. This advances only that pending package release to `0.4.15` so the beta.6 release can complete.

- Records the skipped `0.4.14` publication in the package changelog
- Keeps Remix at `3.0.0-beta.6`
- Updates the beta.6 dependency release link to `static-middleware@0.4.15`

Related publish runs: [initial failure](https://github.com/remix-run/remix/actions/runs/31755956635) and [independent reproduction](https://github.com/remix-run/remix/actions/runs/31755993489).
