### PR TITLE
Skip blocked static middleware publish

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -198,7 +198,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.15`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.15)
+  - [`static-middleware@0.4.13`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.13)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,20 +2,6 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
-## v0.4.15
-
-### Patch Changes
-
-- Republish the pending patch release as v0.4.15 because npm rejected v0.4.14.
-
-## v0.4.14
-
-### Patch Changes
-
-- Bumped `@remix-run/*` dependencies:
-  - [`fetch-router@0.21.0`](https://github.com/remix-run/remix/releases/tag/fetch-router@0.21.0)
-  - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
-
 ## v0.4.13
 
 ### Patch Changes

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/static-middleware",
-  "version": "0.4.15",
+  "version": "0.4.13",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Npm rejects every new `@remix-run/static-middleware` version with `403 Forbidden`, including `0.4.14` and `0.4.15`, from both GitHub OIDC and an authenticated maintainer publish. This keeps beta.6 installable by leaving static-middleware at the already-published `0.4.13`.

- Removes the unshipped `0.4.14` and `0.4.15` changelog entries
- Keeps the package version at `0.4.13`, so the publish workflow skips the blocked package
- Points the beta.6 dependency release link to the published `0.4.13`

The pending static-middleware release contains no runtime or public API change; its diff is dependency/tooling churn. Related recovery attempt: [#11697](https://github.com/remix-run/remix/pull/11697).
