### PR TITLE
Bump static middleware back to 0.4.14

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -198,7 +198,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.15`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.15)
+  - [`static-middleware@0.4.14`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.14)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -198,7 +198,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.13`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.13)
+  - [`static-middleware@0.4.15`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.15)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
+## v0.4.15
+
+### Patch Changes
+
+- Republish the pending patch release as v0.4.15 because npm rejected v0.4.14.
+
+## v0.4.14
+
+### Patch Changes
+
+- Bumped `@remix-run/*` dependencies:
+  - [`fetch-router@0.21.0`](https://github.com/remix-run/remix/releases/tag/fetch-router@0.21.0)
+  - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
+
 ## v0.4.13
 
 ### Patch Changes

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
-## v0.4.15
-
-### Patch Changes
-
-- Republish the pending patch release as v0.4.15 because npm rejected v0.4.14.
-
 ## v0.4.14
 
 ### Patch Changes

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/static-middleware",
-  "version": "0.4.13",
+  "version": "0.4.15",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/static-middleware",
-  "version": "0.4.15",
+  "version": "0.4.14",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Revert the changes to static-middleware so we can re-try publishing it as 0.4.14 to fix issues with beta.6. More info in https://github.com/remix-run/remix/pull/11697 and https://github.com/remix-run/remix/pull/11698.

Output from a local dry run publish script run:

```sh
> node scripts/publish.ts --dry-run
🔍 DRY RUN MODE - No packages will be published

Packages in prerelease mode:
  • remix (beta)

Publishing in two phases: other packages as "latest", then prerelease packages as "next"

Publishing packages to npm...

Would run:
  $ pnpm publish --recursive --filter "./packages/*" --filter "!remix" --access public --no-git-checks --report-summary
  $ pnpm publish --filter remix --tag next --access public --no-git-checks --report-summary

Checking npm for unpublished versions...

1 package would be published:

  • @remix-run/static-middleware@0.4.14

GitHub Release Preview
════════════════════════════════════════════════════════════

📦 static-middleware v0.4.14
   Tag: static-middleware@0.4.14

   Release notes:

   ### Patch Changes
   
   - Bumped `@remix-run/*` dependencies:
     - [`fetch-router@0.21.0`](https://github.com/remix-run/remix/releases/tag/fetch-router@0.21.0)
     - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)

────────────────────────────────────────────────────────────

🔍 Dry run complete. No packages published, no git tags or GitHub releases created.
```