### PR TITLE
Support object shorthand in logical predicates

### DIFF
--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -331,13 +331,13 @@ describe('sqlite sql-compiler', () => {
     it('compile logical or', async () => {
       await db
         .query(accounts)
-        .where(or(eq(accounts.status, 'enabled'), eq(accounts.status, 'disabled')))
+        .where(or({ status: 'enabled' }, { email: 'admin@example.com' }))
         .all()
 
       let compiled = compileSqliteOperation(statements[0])
       assert.deepEqual(compiled, {
-        text: 'select * from "accounts" where (("accounts"."status" = ?) or ("accounts"."status" = ?))',
-        values: ['enabled', 'disabled'],
+        text: 'select * from "accounts" where ((("status" = ?)) or (("email" = ?)))',
+        values: ['enabled', 'admin@example.com'],
       })
     })
 

--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -331,6 +331,19 @@ describe('sqlite sql-compiler', () => {
     it('compile logical or', async () => {
       await db
         .query(accounts)
+        .where(or(eq(accounts.status, 'enabled'), eq(accounts.status, 'disabled')))
+        .all()
+
+      let compiled = compileSqliteOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from "accounts" where (("accounts"."status" = ?) or ("accounts"."status" = ?))',
+        values: ['enabled', 'disabled'],
+      })
+    })
+
+    it('compile logical or with object filters', async () => {
+      await db
+        .query(accounts)
         .where(or({ status: 'enabled' }, { email: 'admin@example.com' }))
         .all()
 

--- a/packages/data-table/.changes/patch.object-logical-predicates.md
+++ b/packages/data-table/.changes/patch.object-logical-predicates.md
@@ -1,0 +1,1 @@
+Allow `and()` and `or()` to compose object shorthand filters, matching the documented `where: or({ status: 'pending' }, { status: 'processing' })` usage.

--- a/packages/data-table/src/lib/operators.test.ts
+++ b/packages/data-table/src/lib/operators.test.ts
@@ -2,6 +2,7 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { column } from './column.ts'
+import type { Predicate } from './operators.ts'
 import {
   and,
   between,
@@ -218,6 +219,36 @@ describe('logical predicates', () => {
     let normalized = normalizeWhereInput(input)
 
     assert.equal(normalized, input)
+  })
+
+  it('normalizes object filters in logical predicates', () => {
+    let input = 'user@example.com'
+    let predicate = or({ username: input }, { email: input })
+    let typedPredicate: Predicate<'username' | 'email'> = predicate
+
+    assert.deepEqual(typedPredicate, {
+      type: 'logical',
+      operator: 'or',
+      predicates: [
+        {
+          type: 'logical',
+          operator: 'and',
+          predicates: [eq('username', input)],
+        },
+        {
+          type: 'logical',
+          operator: 'and',
+          predicates: [eq('email', input)],
+        },
+      ],
+    })
+  })
+
+  it('combines object filters with normalized predicates', () => {
+    let predicate = and({ active: true }, or({ role: 'admin' }, eq('owner_id', 1)))
+    let typedPredicate: Predicate<'active' | 'role' | 'owner_id'> = predicate
+
+    assert.deepEqual(getPredicateColumns(typedPredicate), ['active', 'role', 'owner_id'])
   })
 
   it('filters falsy values when combining logical predicates', () => {

--- a/packages/data-table/src/lib/operators.ts
+++ b/packages/data-table/src/lib/operators.ts
@@ -66,6 +66,9 @@ export type WhereObject<column extends string = string> = Partial<Record<column,
  */
 export type WhereInput<column extends string = string> = Predicate<column> | WhereObject<column>
 
+type WhereInputColumn<input extends WhereInput> =
+  input extends Predicate<infer column> ? column : keyof input & string
+
 /**
  * Builds an equality predicate.
  */
@@ -293,23 +296,33 @@ export function notNull<column extends string | ColumnReferenceLike>(
 }
 
 /**
- * Combines predicates with logical `AND`.
- * @param predicates Child predicates.
+ * Combines where inputs with logical `AND`.
+ * @param inputs Child predicates or object shorthand filters.
  * @returns A logical `and` predicate.
  */
-export function and<column extends string>(...predicates: Predicate<column>[]): Predicate<column> {
-  let filtered = predicates.filter(Boolean)
-  return { type: 'logical', operator: 'and', predicates: filtered }
+export function and<inputs extends WhereInput[]>(
+  ...inputs: inputs
+): Predicate<WhereInputColumn<inputs[number]>> {
+  type column = WhereInputColumn<inputs[number]>
+  let predicates = inputs
+    .filter(Boolean)
+    .map((input) => normalizeWhereInput(input) as Predicate<column>)
+  return { type: 'logical', operator: 'and', predicates }
 }
 
 /**
- * Combines predicates with logical `OR`.
- * @param predicates Child predicates.
+ * Combines where inputs with logical `OR`.
+ * @param inputs Child predicates or object shorthand filters.
  * @returns A logical `or` predicate.
  */
-export function or<column extends string>(...predicates: Predicate<column>[]): Predicate<column> {
-  let filtered = predicates.filter(Boolean)
-  return { type: 'logical', operator: 'or', predicates: filtered }
+export function or<inputs extends WhereInput[]>(
+  ...inputs: inputs
+): Predicate<WhereInputColumn<inputs[number]>> {
+  type column = WhereInputColumn<inputs[number]>
+  let predicates = inputs
+    .filter(Boolean)
+    .map((input) => normalizeWhereInput(input) as Predicate<column>)
+  return { type: 'logical', operator: 'or', predicates }
 }
 
 /**


### PR DESCRIPTION
The [documented object shorthand](https://github.com/remix-run/remix/blob/79b575b8a4ceea724fc27ea68bc251121aa40524/packages/data-table/README.md#crud-helpers) fails when it is nested inside `or()` or `and()`:

```ts
where: or({ username: input }, { email: input })
```

In simple terms, `where` understands these objects, but the logical helpers only understood predicates built with helpers such as `eq()`.

- The [CRUD documentation promises object shorthand inside `or()`](https://github.com/remix-run/remix/blob/79b575b8a4ceea724fc27ea68bc251121aa40524/packages/data-table/README.md#L145-L166).
- The [logical helper signatures only accepted `Predicate[]`](https://github.com/remix-run/remix/blob/79b575b8a4ceea724fc27ea68bc251121aa40524/packages/data-table/src/lib/operators.ts#L295-L313), while object shorthand was only normalized later at the outer [`where()` boundary](https://github.com/remix-run/remix/blob/79b575b8a4ceea724fc27ea68bc251121aa40524/packages/data-table/src/lib/query.ts#L335-L347).
- Reported by [`@rossipedia` in Discord](https://discord.com/channels/770287896669978684/1425953782415495308/1538292133318893698).

This updates `and()` and `or()` to accept the same object-or-predicate input used by `where()` and normalize each child with the existing object shorthand logic. It also preserves precise column inference when objects and explicit predicates are mixed.
