### PR TITLE
Publish static middleware 0.4.14

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -198,7 +198,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.13`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.13)
+  - [`static-middleware@0.4.14`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.14)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
+## v0.4.14
+
+### Patch Changes
+
+- Bumped `@remix-run/*` dependencies:
+  - [`fetch-router@0.21.0`](https://github.com/remix-run/remix/releases/tag/fetch-router@0.21.0)
+  - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
+
 ## v0.4.13
 
 ### Patch Changes

--- a/packages/static-middleware/package.json
+++ b/packages/static-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/static-middleware",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Publish `@remix-run/static-middleware@0.4.14` now that its npm trusted publisher can be configured. This aligns its `@remix-run/fetch-router` dependency with the version used by `remix@3.0.0-beta.6`.

Fresh beta.6 projects currently install two copies of `fetch-router`, making their private-field-bearing `RequestContext` types incompatible. Once `0.4.14` is available, the existing `remix` dependency range will select it and fresh installs will deduplicate on `fetch-router@0.21.0`.

- Restores the narrowly scoped release state from #11700
- Publishes only `@remix-run/static-middleware@0.4.14`
- Updates the beta.6 changelog dependency link to the published version

Previous registry recovery context: #11697 and #11698.
