### PR TITLE
Replace blocked static middleware package

### DIFF
--- a/packages/remix/.changes/patch.static-files-dependency.md
+++ b/packages/remix/.changes/patch.static-files-dependency.md
@@ -1,0 +1,1 @@
+Fixed fresh Remix projects failing type checking when `staticFiles()` and other router middleware were used together. `remix/middleware/static` now uses the same router dependency as `remix/router`, preventing incompatible `RequestContext` types from being installed.

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -208,7 +208,7 @@ This is the changelog for [`remix`](https://github.com/remix-run/remix/tree/main
   - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
   - [`route-pattern@0.24.0`](https://github.com/remix-run/remix/releases/tag/route-pattern@0.24.0)
   - [`session-middleware@0.4.0`](https://github.com/remix-run/remix/releases/tag/session-middleware@0.4.0)
-  - [`static-middleware@0.4.14`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.14)
+  - [`static-middleware@0.4.13`](https://github.com/remix-run/remix/releases/tag/static-middleware@0.4.13)
   - [`test@0.6.0`](https://github.com/remix-run/remix/releases/tag/test@0.6.0)
   - [`ui@0.5.0`](https://github.com/remix-run/remix/releases/tag/ui@0.5.0)
   - [`ui-hmr@0.1.0`](https://github.com/remix-run/remix/releases/tag/ui-hmr@0.1.0)

--- a/packages/remix/manifest.json
+++ b/packages/remix/manifest.json
@@ -55,7 +55,7 @@
   "remix/middleware/method-override": "@remix-run/method-override-middleware",
   "remix/middleware/render": "@remix-run/render-middleware",
   "remix/middleware/session": "@remix-run/session-middleware",
-  "remix/middleware/static": "@remix-run/static-middleware",
+  "remix/middleware/static": "@remix-run/static-files",
   "remix/mime": "@remix-run/mime",
   "remix/multipart-parser": "@remix-run/multipart-parser",
   "remix/multipart-parser/node": "@remix-run/multipart-parser/node",

--- a/packages/remix/manifest.test.ts
+++ b/packages/remix/manifest.test.ts
@@ -51,7 +51,8 @@ const allRemixRunPackages: string[] = fs
   .flatMap((d) => {
     let pkgJsonPath = path.join(packagesDir, d.name, 'package.json')
     if (!fs.existsSync(pkgJsonPath)) return []
-    let { name } = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+    let { name, private: isPrivate } = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+    if (isPrivate === true) return []
     return name?.startsWith('@remix-run/') ? [name as string] : []
   })
 
@@ -122,7 +123,7 @@ describe('manifest', () => {
     }
   })
 
-  it('every @remix-run/* workspace package is referenced in the manifest', () => {
+  it('every public @remix-run/* workspace package is referenced in the manifest', () => {
     for (let pkgName of allRemixRunPackages) {
       // @remix-run/cli is intentionally excluded from the manifest — it is handled
       // separately by the generate-remix script via the CLI_PACKAGE_NAME constant.

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -79,7 +79,7 @@
     "./middleware/method-override": "./src/method-override-middleware.ts",
     "./middleware/render": "./src/render-middleware.ts",
     "./middleware/session": "./src/session-middleware.ts",
-    "./middleware/static": "./src/static-middleware.ts",
+    "./middleware/static": "./src/static-files.ts",
     "./mime": "./src/mime.ts",
     "./multipart-parser": "./src/multipart-parser.ts",
     "./multipart-parser/node": "./src/multipart-parser/node.ts",
@@ -373,8 +373,8 @@
         "default": "./dist/session-middleware.js"
       },
       "./middleware/static": {
-        "types": "./dist/static-middleware.d.ts",
-        "default": "./dist/static-middleware.js"
+        "types": "./dist/static-files.d.ts",
+        "default": "./dist/static-files.js"
       },
       "./mime": {
         "types": "./dist/mime.d.ts",
@@ -676,7 +676,6 @@
     "@remix-run/session-middleware": "workspace:^",
     "@remix-run/session-storage-memcache": "workspace:^",
     "@remix-run/session-storage-redis": "workspace:^",
-    "@remix-run/static-middleware": "workspace:^",
     "@remix-run/tar-parser": "workspace:^",
     "@remix-run/assert": "workspace:^",
     "@remix-run/cli": "workspace:^",
@@ -684,7 +683,8 @@
     "@remix-run/terminal": "workspace:^",
     "@remix-run/render-middleware": "workspace:^",
     "@remix-run/node-hmr": "workspace:^",
-    "@remix-run/ui-hmr": "workspace:^"
+    "@remix-run/ui-hmr": "workspace:^",
+    "@remix-run/static-files": "workspace:^"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node ../../scripts/copy-package-type-only-exports.ts .",

--- a/packages/remix/src/static-files.ts
+++ b/packages/remix/src/static-files.ts
@@ -1,2 +1,2 @@
 // IMPORTANT: This file is auto-generated, please do not edit manually.
-export * from '@remix-run/static-middleware'
+export * from '@remix-run/static-files'

--- a/packages/static-files/.changes/minor.initial-release.md
+++ b/packages/static-files/.changes/minor.initial-release.md
@@ -1,0 +1,1 @@
+Initial release of the static file-serving middleware that powers `remix/middleware/static`. Application code should continue importing `staticFiles` from `remix/middleware/static`.

--- a/packages/static-files/CHANGELOG.md
+++ b/packages/static-files/CHANGELOG.md
@@ -1,0 +1,5 @@
+# `static-files` CHANGELOG
+
+This is the changelog for [`static-files`](https://github.com/remix-run/remix/tree/main/packages/static-files). It follows [semantic versioning](https://semver.org/).
+
+## Unreleased

--- a/packages/static-files/LICENSE
+++ b/packages/static-files/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/static-files/README.md
+++ b/packages/static-files/README.md
@@ -1,0 +1,89 @@
+# static-files
+
+Static file serving middleware for Remix. Serves static files from a directory with support for ETags, range requests, and conditional requests.
+
+## Features
+
+- [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) support (weak and strong)
+- [Range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) support (HTTP 206 Partial Content)
+- [Conditional request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) support (If-None-Match, If-Modified-Since)
+- Path traversal protection
+- Automatic fallback to next middleware/handler if file not found
+
+## Installation
+
+```sh
+npm i remix
+```
+
+## Usage
+
+Static middleware is useful for serving static files from a directory.
+
+```ts
+import { createRouter } from 'remix/router'
+import { staticFiles } from 'remix/middleware/static'
+
+let router = createRouter({
+  middleware: [staticFiles('./public')],
+})
+
+router.get('/', () => new Response('Home'))
+```
+
+### With Cache Control
+
+Internally, the `staticFiles()` middleware uses the [`createFileResponse()` helper from `remix/response`](https://github.com/remix-run/remix/tree/main/packages/response/README.md#file-responses) to send files with full HTTP semantics. This means it also accepts the same options as the `createFileResponse()` helper.
+
+```ts
+let router = createRouter({
+  middleware: [
+    staticFiles('./public', {
+      cacheControl: 'public, max-age=31536000, immutable', // 1 year
+    }),
+  ],
+})
+```
+
+### Filter Files
+
+```ts
+let router = createRouter({
+  middleware: [
+    staticFiles('./public', {
+      filter(path) {
+        // Don't serve hidden files
+        return !path.startsWith('.')
+      },
+    }),
+  ],
+})
+```
+
+### Multiple Directories
+
+```ts
+let router = createRouter({
+  middleware: [
+    staticFiles('./public'),
+    staticFiles('./assets', {
+      cacheControl: 'public, max-age=31536000',
+    }),
+  ],
+})
+```
+
+## Security
+
+- Prevents path traversal attacks (e.g., `../../../etc/passwd`)
+- Only serves files with GET and HEAD requests
+- Respects the configured root directory boundary
+
+## Related Packages
+
+- [`fetch-router`](https://github.com/remix-run/remix/tree/main/packages/fetch-router) - Router for the web Fetch API
+- [`lazy-file`](https://github.com/remix-run/remix/tree/main/packages/lazy-file) - Used internally for streaming file contents
+
+## License
+
+See [LICENSE](https://github.com/remix-run/remix/blob/main/LICENSE)

--- a/packages/static-files/package.json
+++ b/packages/static-files/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "@remix-run/static-middleware",
-  "version": "0.4.13",
-  "private": true,
+  "name": "@remix-run/static-files",
+  "version": "0.0.0",
   "description": "Middleware for serving static files from the filesystem",
   "author": "Michael Jackson <mjijackson@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/remix-run/remix.git",
-    "directory": "packages/static-middleware"
+    "directory": "packages/static-files"
   },
-  "homepage": "https://github.com/remix-run/remix/tree/main/packages/static-middleware#readme",
+  "homepage": "https://github.com/remix-run/remix/tree/main/packages/static-files#readme",
   "files": [
     "LICENSE",
     "README.md",
@@ -33,25 +32,30 @@
     }
   },
   "devDependencies": {
-    "@remix-run/assert": "workspace:*",
-    "@remix-run/fetch-router": "workspace:*",
-    "@remix-run/form-data-middleware": "workspace:*",
-    "@remix-run/fs": "workspace:*",
-    "@remix-run/html-template": "workspace:*",
-    "@remix-run/method-override-middleware": "workspace:*",
-    "@remix-run/mime": "workspace:*",
-    "@remix-run/response": "workspace:*",
-    "@remix-run/test": "workspace:*",
+    "@remix-run/assert": "workspace:^",
+    "@remix-run/fetch-router": "workspace:^",
+    "@remix-run/form-data-middleware": "workspace:^",
+    "@remix-run/method-override-middleware": "workspace:^",
+    "@remix-run/mime": "workspace:^",
+    "@remix-run/response": "workspace:^",
+    "@remix-run/test": "workspace:^",
     "@types/node": "catalog:",
-    "typescript": "catalog:"
+    "@typescript/native-preview": "catalog:"
+  },
+  "dependencies": {
+    "@remix-run/fetch-router": "workspace:^",
+    "@remix-run/fs": "workspace:^",
+    "@remix-run/html-template": "workspace:^",
+    "@remix-run/mime": "workspace:^",
+    "@remix-run/response": "workspace:^"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsgo -p tsconfig.build.json",
     "clean": "git clean -fdX",
     "prepublishOnly": "pnpm run build",
     "test": "remix test",
     "test:bun": "bun x --bun remix test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "keywords": [
     "fetch",

--- a/packages/static-files/src/index.ts
+++ b/packages/static-files/src/index.ts
@@ -1,0 +1,1 @@
+export { type StaticFilesOptions, staticFiles } from './lib/static.ts'

--- a/packages/static-files/src/lib/directory-listing.ts
+++ b/packages/static-files/src/lib/directory-listing.ts
@@ -1,0 +1,315 @@
+import * as path from 'node:path'
+import * as fsp from 'node:fs/promises'
+import { html } from '@remix-run/html-template'
+import { createHtmlResponse } from '@remix-run/response/html'
+import { detectMimeType } from '@remix-run/mime'
+
+interface DirectoryEntry {
+  name: string
+  isDirectory: boolean
+  size: number
+  type: string
+}
+
+export async function generateDirectoryListing(
+  dirPath: string,
+  pathname: string,
+): Promise<Response> {
+  let entries: DirectoryEntry[] = []
+
+  try {
+    let dirents = await fsp.readdir(dirPath, { withFileTypes: true })
+
+    for (let dirent of dirents) {
+      let fullPath = path.join(dirPath, dirent.name)
+      let isDirectory = dirent.isDirectory()
+      let size = 0
+      let type = ''
+
+      if (isDirectory) {
+        size = await calculateDirectorySize(fullPath)
+      } else {
+        try {
+          let stats = await fsp.stat(fullPath)
+          size = stats.size
+          let mimeType = detectMimeType(dirent.name)
+          type = mimeType || 'application/octet-stream'
+        } catch {
+          // Unable to stat file, use defaults
+        }
+      }
+
+      entries.push({
+        name: dirent.name,
+        isDirectory,
+        size,
+        type,
+      })
+    }
+  } catch {
+    return new Response('Error reading directory', { status: 500 })
+  }
+
+  // Sort: directories first, then alphabetically
+  entries.sort((a, b) => {
+    if (a.isDirectory && !b.isDirectory) return -1
+    if (!a.isDirectory && b.isDirectory) return 1
+    return a.name.localeCompare(b.name, undefined, { numeric: true })
+  })
+
+  // Build table rows
+  let tableRows = []
+
+  let folderIcon = html.raw`<svg
+    class="icon"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+  >
+    <path d="M2 3.5h4.5l1.5 1.5h6v8h-12z" />
+  </svg>`
+  let fileIcon = html.raw`<svg
+    class="icon"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+  >
+    <path d="M3 2h7l3 3v9H3z" />
+    <path d="M10 2v3h3" />
+  </svg>`
+
+  // Add parent directory link if not at root
+  if (pathname !== '/' && pathname !== '') {
+    let parentPath = pathname.replace(/\/$/, '').split('/').slice(0, -1).join('/') || '/'
+    tableRows.push(html`
+      <tr class="file-row">
+        <td class="name-cell">
+          <a href="${parentPath}">${folderIcon} ..</a>
+        </td>
+        <td class="size-cell"></td>
+        <td class="type-cell"></td>
+      </tr>
+    `)
+  }
+
+  for (let entry of entries) {
+    let icon = entry.isDirectory ? folderIcon : fileIcon
+    let href = pathname.endsWith('/') ? pathname + entry.name : pathname + '/' + entry.name
+    let sizeDisplay = formatFileSize(entry.size)
+    let typeDisplay = entry.isDirectory ? 'Folder' : entry.type
+
+    tableRows.push(html`
+      <tr class="file-row">
+        <td class="name-cell">
+          <a href="${href}">${icon} ${entry.name}</a>
+        </td>
+        <td class="size-cell">${sizeDisplay}</td>
+        <td class="type-cell">${typeDisplay}</td>
+      </tr>
+    `)
+  }
+
+  return createHtmlResponse(html`
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Index of ${pathname}</title>
+        <style>
+          * {
+            box-sizing: border-box;
+          }
+          body {
+            font-family:
+              -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+              'Open Sans', 'Helvetica Neue', sans-serif;
+            margin: 0;
+            padding: 2rem 1rem;
+            background: #fff;
+            color: #333;
+            font-size: 14px;
+          }
+          .container {
+            max-width: 1200px;
+            margin: 0 auto;
+          }
+          h1 {
+            margin: 0 0 1rem 0;
+            padding: 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #333;
+          }
+          .icon {
+            width: 14px;
+            height: 14px;
+            display: inline-block;
+            vertical-align: text-top;
+            margin-right: 0.5rem;
+            color: #666;
+          }
+          table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid #e0e0e0;
+          }
+          thead tr {
+            background: #fafafa;
+          }
+          th {
+            padding: 0.5rem 1rem;
+            text-align: left;
+            font-weight: 600;
+            font-size: 0.8125rem;
+            color: #666;
+            border-bottom: 1px solid #e0e0e0;
+          }
+          td {
+            border-bottom: 1px solid #f0f0f0;
+          }
+          tr:last-child td {
+            border-bottom: none;
+          }
+          .file-row {
+            position: relative;
+          }
+          .file-row:hover {
+            background: #fafafa;
+          }
+          .name-cell {
+            width: 50%;
+            padding: 0;
+          }
+          .name-cell a {
+            display: block;
+            padding: 0.375rem 1rem;
+            color: #0066cc;
+            text-decoration: none;
+          }
+          .name-cell a::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+          }
+          .file-row:hover .name-cell a {
+            text-decoration: underline;
+          }
+          .size-cell {
+            width: 25%;
+            padding: 0.375rem 1rem;
+            text-align: left;
+            color: #666;
+            font-variant-numeric: tabular-nums;
+          }
+          .type-cell {
+            width: 25%;
+            padding: 0.375rem 1rem;
+            color: #666;
+            white-space: nowrap;
+          }
+          @media (max-width: 768px) {
+            body {
+              padding: 1rem 0.5rem;
+            }
+            h1 {
+              font-size: 1.125rem;
+              margin-bottom: 0.75rem;
+            }
+            thead {
+              display: none;
+            }
+            .name-cell a,
+            .size-cell,
+            .type-cell {
+              padding: 0.375rem 0.75rem;
+            }
+            .type-cell {
+              display: none;
+            }
+            .name-cell {
+              width: 60%;
+            }
+            .size-cell {
+              width: 40%;
+              text-align: right;
+            }
+          }
+          @media (max-width: 480px) {
+            body {
+              font-size: 13px;
+            }
+            .name-cell a,
+            .size-cell,
+            .type-cell {
+              padding: 0.375rem 0.5rem;
+            }
+            h1 {
+              font-size: 1rem;
+            }
+            .icon {
+              width: 12px;
+              height: 12px;
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <h1>Index of ${pathname}</h1>
+          <table>
+            <thead>
+              <tr>
+                <th class="name">Name</th>
+                <th class="size">Size</th>
+                <th class="type">Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${tableRows}
+            </tbody>
+          </table>
+        </div>
+      </body>
+    </html>
+  `)
+}
+
+async function calculateDirectorySize(dirPath: string): Promise<number> {
+  let totalSize = 0
+
+  try {
+    let dirents = await fsp.readdir(dirPath, { withFileTypes: true })
+
+    for (let dirent of dirents) {
+      let fullPath = path.join(dirPath, dirent.name)
+
+      try {
+        if (dirent.isDirectory()) {
+          totalSize += await calculateDirectorySize(fullPath)
+        } else if (dirent.isFile()) {
+          let stats = await fsp.stat(fullPath)
+          totalSize += stats.size
+        }
+      } catch {
+        // Skip files/folders we can't access
+      }
+    }
+  } catch {
+    // If we can't read the directory, return 0
+  }
+
+  return totalSize
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  let units = ['B', 'kB', 'MB', 'GB', 'TB']
+  let i = Math.floor(Math.log(bytes) / Math.log(1024))
+  let size = bytes / Math.pow(1024, i)
+  return size.toFixed(i === 0 ? 0 : 1) + ' ' + units[i]
+}

--- a/packages/static-files/src/lib/static.test.ts
+++ b/packages/static-files/src/lib/static.test.ts
@@ -1,0 +1,754 @@
+import * as assert from '@remix-run/assert'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, beforeEach, afterEach } from '@remix-run/test'
+
+import { createRouter } from '@remix-run/fetch-router'
+import { formData } from '@remix-run/form-data-middleware'
+import { methodOverride } from '@remix-run/method-override-middleware'
+
+import { staticFiles } from './static.ts'
+
+describe('staticFiles middleware', () => {
+  let tmpDir: string
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-files-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function createTestFile(filename: string, content: string, date?: Date) {
+    let filePath = path.join(tmpDir, filename)
+    let dir = path.dirname(filePath)
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+
+    fs.writeFileSync(filePath, content)
+
+    if (date) {
+      fs.utimesSync(filePath, date, date)
+    }
+
+    return filePath
+  }
+
+  describe('basic functionality', () => {
+    it('serves a file', async () => {
+      createTestFile('test.txt', 'Hello, World!')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/test.txt')
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'Hello, World!')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
+    })
+
+    it('serves a file with HEAD request', async () => {
+      createTestFile('test.txt', 'Hello, World!')
+
+      let router = createRouter()
+      router.head('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/test.txt', { method: 'HEAD' })
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
+    })
+
+    it('serves files from nested directories', async () => {
+      createTestFile('dir/subdir/file.txt', 'Nested file')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/dir/subdir/file.txt')
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'Nested file')
+    })
+
+    it('falls through to handler for non-existent file', async () => {
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Custom Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/nonexistent.txt')
+
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Custom Fallback Handler')
+    })
+
+    it('falls through to handler when requesting a directory', async () => {
+      let dirPath = path.join(tmpDir, 'subdir')
+      fs.mkdirSync(dirPath)
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir')
+
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Fallback Handler')
+    })
+  })
+
+  it('supports etag by default', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    let etag = response.headers.get('ETag')
+    assert.ok(etag)
+    assert.equal(etag, 'W/"13-1735689600000"')
+
+    let response2 = await router.fetch('https://remix.run/test.txt', {
+      headers: { 'If-None-Match': etag },
+    })
+    assert.equal(response2.status, 304)
+    assert.equal(await response2.text(), '')
+  })
+
+  it('does not send etag if etag is disabled', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir, { etag: false })],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('ETag'), null)
+  })
+
+  it('supports last-modified by default', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('Last-Modified'), lastModified.toUTCString())
+  })
+
+  it('does not send last-modified if lastModified is disabled', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir, { lastModified: false })],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('Last-Modified'), null)
+  })
+
+  it('does not support accept-ranges by default for compressible files', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('Accept-Ranges'), null)
+
+    let response2 = await router.fetch('https://remix.run/test.txt', {
+      headers: { Range: 'bytes=0-4' },
+    })
+    assert.equal(response2.status, 200)
+    assert.equal(await response2.text(), 'Hello, World!')
+  })
+
+  it('supports range requests when acceptRanges is explicitly enabled', async () => {
+    let lastModified = new Date('2025-01-01')
+    createTestFile('test.txt', 'Hello, World!', lastModified)
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir, { acceptRanges: true })],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('Accept-Ranges'), 'bytes')
+
+    let response2 = await router.fetch('https://remix.run/test.txt', {
+      headers: { Range: 'bytes=0-4' },
+    })
+    assert.equal(response2.status, 206)
+    assert.equal(await response2.text(), 'Hello')
+    assert.equal(response2.headers.get('Content-Range'), 'bytes 0-4/13')
+    assert.equal(response2.headers.get('Content-Length'), '5')
+    assert.equal(response2.headers.get('Accept-Ranges'), 'bytes')
+  })
+
+  it('supports range requests with acceptRanges function', async () => {
+    createTestFile('test.txt', 'Hello, World!')
+    createTestFile('video.dat', 'fake video data')
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [
+        staticFiles(tmpDir, {
+          acceptRanges: (file) => file.type.startsWith('video/'),
+        }),
+      ],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    // test.txt should not have ranges (text/plain doesn't match video/* filter)
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Hello, World!')
+    assert.equal(response.headers.get('Accept-Ranges'), null)
+
+    let response2 = await router.fetch('https://remix.run/test.txt', {
+      headers: { Range: 'bytes=0-4' },
+    })
+    assert.equal(response2.status, 200)
+    assert.equal(await response2.text(), 'Hello, World!')
+  })
+
+  it('supports cache-control', async () => {
+    createTestFile('test.txt', 'Hello, World!')
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir, { cacheControl: 'public, max-age=3600' })],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/test.txt')
+    assert.equal(response.headers.get('Cache-Control'), 'public, max-age=3600')
+  })
+
+  it('works with multiple static middleware instances', async () => {
+    createTestFile('assets/style.css', 'body {}')
+    createTestFile('images/logo.png', 'PNG data')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response1 = await router.fetch('https://remix.run/assets/style.css')
+    assert.equal(response1.status, 200)
+    assert.equal(await response1.text(), 'body {}')
+
+    let response2 = await router.fetch('https://remix.run/images/logo.png')
+    assert.equal(response2.status, 200)
+    assert.equal(await response2.text(), 'PNG data')
+  })
+
+  it('works as fallback middleware', async () => {
+    createTestFile('index.html', '<h1>Fallback Handler</h1>')
+
+    let router = createRouter()
+    router.get('/api/users', () => new Response('Users API'))
+    router.get('*path', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response1 = await router.fetch('https://remix.run/api/users')
+    assert.equal(await response1.text(), 'Users API')
+
+    let response2 = await router.fetch('https://remix.run/index.html')
+    assert.equal(await response2.text(), '<h1>Fallback Handler</h1>')
+  })
+
+  for (let method of ['POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'] as const) {
+    it(`ignores ${method} requests`, async () => {
+      createTestFile('test.txt', 'Hello, World!')
+
+      let router = createRouter()
+      router.route(method, '/*path', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/test.txt', { method })
+
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Fallback Handler')
+    })
+  }
+
+  it('prevents path traversal with .. in pathname', async () => {
+    createTestFile('secret.txt', 'Secret content')
+
+    let publicDirName = 'public'
+    createTestFile(`${publicDirName}/allowed.txt`, 'Allowed content')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(path.join(tmpDir, publicDirName))],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let allowedResponse = await router.fetch('https://remix.run/allowed.txt')
+    assert.equal(allowedResponse.status, 200)
+    assert.equal(await allowedResponse.text(), 'Allowed content')
+
+    let traversalResponse = await router.fetch('https://remix.run/../secret.txt')
+    assert.equal(traversalResponse.status, 404)
+  })
+
+  it('does not support absolute paths in the URL', async () => {
+    let parentDir = path.dirname(tmpDir)
+    let secretFileName = 'secret-outside-root.txt'
+    let secretPath = path.join(parentDir, secretFileName)
+    fs.writeFileSync(secretPath, 'Secret content')
+
+    let router = createRouter()
+    router.get('*path', {
+      middleware: [staticFiles(tmpDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    try {
+      let response = await router.fetch(`https://remix.run/${secretPath}`)
+      assert.equal(response.status, 404)
+    } finally {
+      fs.unlinkSync(secretPath)
+    }
+  })
+
+  it('serves symlinked files inside the root using the requested path metadata', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    fs.writeFileSync(path.join(publicDir, 'asset.txt'), 'console.log("safe")')
+    fs.symlinkSync(path.join(publicDir, 'asset.txt'), path.join(publicDir, 'asset.js'))
+    let files: Array<{ name: string; type: string }> = []
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [
+        staticFiles(publicDir, {
+          acceptRanges(file) {
+            files.push({ name: file.name, type: file.type })
+            return false
+          },
+        }),
+      ],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/asset.js')
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'console.log("safe")')
+    assert.equal(response.headers.get('Content-Type'), 'text/javascript; charset=utf-8')
+    assert.deepEqual(files, [{ name: 'asset.js', type: 'text/javascript' }])
+  })
+
+  it('does not serve symlinked files outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('secret.txt', 'Secret content')
+    fs.symlinkSync(path.join(tmpDir, 'secret.txt'), path.join(publicDir, 'leak.txt'))
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/leak.txt')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
+  it('does not serve files from symlinked directories outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('private/secret.txt', 'Secret content')
+    fs.symlinkSync(path.join(tmpDir, 'private'), path.join(publicDir, 'private'), 'dir')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/private/secret.txt')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
+  it('does not serve index files from symlinked directories outside the root', async () => {
+    let publicDir = path.join(tmpDir, 'public')
+    fs.mkdirSync(publicDir)
+    createTestFile('private/index.html', 'Secret index')
+    fs.symlinkSync(path.join(tmpDir, 'private'), path.join(publicDir, 'private'), 'dir')
+
+    let router = createRouter()
+    router.get('/*', {
+      middleware: [staticFiles(publicDir)],
+      handler() {
+        return new Response('Fallback Handler', { status: 404 })
+      },
+    })
+
+    let response = await router.fetch('https://remix.run/private')
+
+    assert.equal(response.status, 404)
+    assert.equal(await response.text(), 'Fallback Handler')
+  })
+
+  describe('filter option', () => {
+    it('filters files based on custom filter function', async () => {
+      createTestFile('index.html', '<h1>Home</h1>')
+      createTestFile('secret.txt', 'Secret')
+      createTestFile('public.txt', 'Public')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [
+          staticFiles(tmpDir, {
+            filter: (path) => !path.includes('secret'),
+          }),
+        ],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let secretResponse = await router.fetch('https://remix.run/secret.txt')
+      assert.equal(secretResponse.status, 404)
+      assert.equal(await secretResponse.text(), 'Fallback Handler')
+
+      let publicResponse = await router.fetch('https://remix.run/public.txt')
+      assert.equal(publicResponse.status, 200)
+      assert.equal(await publicResponse.text(), 'Public')
+    })
+  })
+
+  describe('index option', () => {
+    it('serves default index.html when requesting a directory', async () => {
+      createTestFile('subdir/index.html', '<h1>Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Index Page</h1>')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
+    })
+
+    it('serves default index.html when requesting a directory without trailing slash', async () => {
+      createTestFile('subdir/index.html', '<h1>Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Index Page</h1>')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
+    })
+
+    it('serves default index.htm when index.html does not exist', async () => {
+      createTestFile('subdir/index.htm', '<h1>HTM Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>HTM Index Page</h1>')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
+    })
+
+    it('prefers index.html over index.htm when both exist', async () => {
+      createTestFile('subdir/index.html', '<h1>HTML Index</h1>')
+      createTestFile('subdir/index.htm', '<h1>HTM Index</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>HTML Index</h1>')
+    })
+
+    it('falls through when directory has no index file', async () => {
+      let dirPath = path.join(tmpDir, 'subdir')
+      fs.mkdirSync(dirPath)
+      createTestFile('subdir/other.txt', 'Not an index file')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Fallback Handler')
+    })
+
+    it('serves custom index file when specified', async () => {
+      createTestFile('subdir/default.html', '<h1>Custom Default Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir, { index: ['default.html'] })],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Custom Default Page</h1>')
+    })
+
+    it('tries custom index files in order', async () => {
+      createTestFile('subdir/home.html', '<h1>Home Page</h1>')
+      createTestFile('subdir/default.html', '<h1>Default Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir, { index: ['index.html', 'home.html', 'default.html'] })],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Home Page</h1>')
+    })
+
+    it('serves root directory index file', async () => {
+      createTestFile('index.html', '<h1>Root Index</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Root Index</h1>')
+    })
+
+    it('supports empty index array to disable index file serving', async () => {
+      createTestFile('subdir/index.html', '<h1>Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir, { index: [] })],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Fallback Handler')
+    })
+
+    it('supports index: false to disable index file serving', async () => {
+      createTestFile('subdir/index.html', '<h1>Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir, { index: false })],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 404)
+      assert.equal(await response.text(), 'Fallback Handler')
+    })
+
+    it('supports index: true to use default index files', async () => {
+      createTestFile('subdir/index.html', '<h1>Index Page</h1>')
+
+      let router = createRouter()
+      router.get('/*', {
+        middleware: [staticFiles(tmpDir, { index: true })],
+        handler() {
+          return new Response('Fallback Handler', { status: 404 })
+        },
+      })
+
+      let response = await router.fetch('https://remix.run/subdir/')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), '<h1>Index Page</h1>')
+    })
+  })
+
+  describe('works with method-override middleware', () => {
+    it('ignores overridden POST requests', async () => {
+      createTestFile('test.txt', 'Hello, World!')
+
+      let router = createRouter({
+        middleware: [formData(), methodOverride()],
+      })
+      router.post('/*path', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('POST handler called', { status: 200 })
+        },
+      })
+
+      let formDataPayload = new FormData()
+      formDataPayload.append('_method', 'POST')
+      formDataPayload.append('name', 'test')
+
+      let response = await router.fetch('https://remix.run/test.txt', {
+        method: 'POST',
+        body: formDataPayload,
+      })
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'POST handler called')
+    })
+
+    it('serves files with overridden GET requests', async () => {
+      createTestFile('test.txt', 'Hello, World!')
+
+      let router = createRouter({
+        middleware: [formData(), methodOverride()],
+      })
+      router.get('/*path', {
+        middleware: [staticFiles(tmpDir)],
+        handler() {
+          return new Response('GET handler fallback', { status: 404 })
+        },
+      })
+
+      let formDataPayload = new FormData()
+      formDataPayload.append('_method', 'GET')
+
+      let response = await router.fetch('https://remix.run/test.txt', {
+        method: 'POST',
+        body: formDataPayload,
+      })
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'Hello, World!')
+      assert.equal(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
+    })
+  })
+})

--- a/packages/static-files/src/lib/static.ts
+++ b/packages/static-files/src/lib/static.ts
@@ -1,0 +1,210 @@
+import * as path from 'node:path'
+import * as fsp from 'node:fs/promises'
+import { openLazyFile } from '@remix-run/fs'
+import type { Middleware } from '@remix-run/fetch-router'
+import { detectMimeType } from '@remix-run/mime'
+import { createFileResponse as sendFile, type FileResponseOptions } from '@remix-run/response/file'
+
+import { generateDirectoryListing } from './directory-listing.ts'
+
+interface StaticFileMatch {
+  realPath: string
+  requestedPath: string
+}
+
+/**
+ * Function that determines if HTTP Range requests should be supported for a given file.
+ *
+ * @param file The File object being served
+ * @returns true if range requests should be supported
+ */
+export type AcceptRangesFunction = (file: File) => boolean
+
+/**
+ * Options for the {@link staticFiles} middleware in addition to {@link FileResponseOptions}.
+ */
+export interface StaticFilesOptions extends Omit<FileResponseOptions, 'acceptRanges'> {
+  /**
+   * Filter function to determine which files should be served.
+   *
+   * @param path The relative path being requested
+   * @returns Whether to serve the file
+   */
+  filter?: (path: string) => boolean
+
+  /**
+   * Whether to support HTTP Range requests for partial content.
+   *
+   * Can be a boolean or a function that receives the file.
+   * When enabled, includes Accept-Ranges header and handles Range requests
+   * with 206 Partial Content responses.
+   *
+   * Defaults to enabling ranges only for non-compressible MIME types,
+   * as defined by `isCompressibleMimeType()` from `@remix-run/mime`.
+   *
+   * Note: Range requests and compression are mutually exclusive. When
+   * `Accept-Ranges: bytes` is present in the response headers, the compression
+   * middleware will not compress the response. This is why the default behavior
+   * enables ranges only for non-compressible types.
+   *
+   * @example
+   * // Force range request support for all files
+   * acceptRanges: true
+   *
+   * @example
+   * // Enable ranges for videos only
+   * acceptRanges: (file) => file.type.startsWith('video/')
+   */
+  acceptRanges?: boolean | AcceptRangesFunction
+
+  /**
+   * Files to try and serve as the index file when the request path targets a directory.
+   *
+   * - `true`: Use default index files `['index.html', 'index.htm']`
+   * - `false`: Disable index file serving
+   * - `string[]`: Custom list of index files to try in order
+   *
+   * @default true
+   */
+  index?: boolean | string[]
+  /**
+   * Whether to return an HTML page listing the files in a directory when the request path
+   * targets a directory. If both this and `index` are set, `index` takes precedence.
+   *
+   * @default false
+   */
+  listFiles?: boolean
+}
+
+/**
+ * Creates a middleware that serves static files from the filesystem.
+ *
+ * Uses the URL pathname to resolve files, removing the leading slash to make it a relative path.
+ * The middleware always falls through to the handler if the file is not found or an error occurs.
+ *
+ * @param root The root directory to serve files from (absolute or relative to cwd)
+ * @param options Configuration for file responses
+ * @returns The static files middleware
+ */
+export function staticFiles(root: string, options: StaticFilesOptions = {}): Middleware {
+  // Ensure root is an absolute path
+  root = path.resolve(root)
+
+  let { acceptRanges, filter, index: indexOption, listFiles, ...fileOptions } = options
+
+  // Normalize index option
+  let index: string[]
+  if (indexOption === false) {
+    index = []
+  } else if (indexOption === true || indexOption === undefined) {
+    index = ['index.html', 'index.htm']
+  } else {
+    index = indexOption
+  }
+
+  return async (context, next) => {
+    if (context.method !== 'GET' && context.method !== 'HEAD') {
+      return next()
+    }
+
+    let relativePath = context.url.pathname.replace(/^\/+/, '')
+
+    if (filter && !filter(relativePath)) {
+      return next()
+    }
+
+    let rootRealPath: string
+    try {
+      rootRealPath = await fsp.realpath(root)
+    } catch {
+      return next()
+    }
+
+    let targetPath = path.join(root, relativePath)
+    let containedTargetPath = await resolveContainedPath(rootRealPath, targetPath)
+    if (containedTargetPath == null) {
+      return next()
+    }
+
+    let file: StaticFileMatch | undefined
+
+    try {
+      let stats = await fsp.stat(containedTargetPath)
+
+      if (stats.isFile()) {
+        file = {
+          realPath: containedTargetPath,
+          requestedPath: targetPath,
+        }
+      } else if (stats.isDirectory()) {
+        // Try each index file in turn
+        for (let indexFile of index) {
+          let indexPath = path.join(targetPath, indexFile)
+          let containedIndexPath = await resolveContainedPath(rootRealPath, indexPath)
+          if (containedIndexPath == null) {
+            continue
+          }
+
+          try {
+            let indexStats = await fsp.stat(containedIndexPath)
+            if (indexStats.isFile()) {
+              file = {
+                realPath: containedIndexPath,
+                requestedPath: indexPath,
+              }
+              break
+            }
+          } catch {
+            // Index file doesn't exist, continue to next
+          }
+        }
+
+        // If no index file found and listFiles is enabled, show directory listing
+        if (!file && listFiles) {
+          return generateDirectoryListing(containedTargetPath, context.url.pathname)
+        }
+      }
+    } catch {
+      // Path doesn't exist or isn't accessible, fall through
+    }
+
+    if (file) {
+      let fileName = path.relative(root, file.requestedPath)
+      let lazyFile = openLazyFile(file.realPath, {
+        name: fileName,
+        type: detectMimeType(file.requestedPath) ?? '',
+      })
+
+      let finalFileOptions: FileResponseOptions = { ...fileOptions }
+
+      // If acceptRanges is a function, evaluate it with the lazyFile
+      // Otherwise, pass it directly to sendFile
+      if (typeof acceptRanges === 'function') {
+        finalFileOptions.acceptRanges = acceptRanges(lazyFile)
+      } else if (acceptRanges !== undefined) {
+        finalFileOptions.acceptRanges = acceptRanges
+      }
+
+      return sendFile(lazyFile, context.request, finalFileOptions)
+    }
+
+    return next()
+  }
+}
+
+async function resolveContainedPath(
+  rootRealPath: string,
+  targetPath: string,
+): Promise<string | null> {
+  try {
+    let realPath = await fsp.realpath(targetPath)
+    return isContainedPath(rootRealPath, realPath) ? realPath : null
+  } catch {
+    return null
+  }
+}
+
+function isContainedPath(rootPath: string, targetPath: string): boolean {
+  let relativePath = path.relative(rootPath, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}

--- a/packages/static-files/tsconfig.build.json
+++ b/packages/static-files/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/static-files/tsconfig.json
+++ b/packages/static-files/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "types": ["node"],
+    "strict": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/packages/static-middleware/CHANGELOG.md
+++ b/packages/static-middleware/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 This is the changelog for [`static-middleware`](https://github.com/remix-run/remix/tree/main/packages/static-middleware). It follows [semantic versioning](https://semver.org/).
 
-## v0.4.14
-
-### Patch Changes
-
-- Bumped `@remix-run/*` dependencies:
-  - [`fetch-router@0.21.0`](https://github.com/remix-run/remix/releases/tag/fetch-router@0.21.0)
-  - [`response@0.3.8`](https://github.com/remix-run/remix/releases/tag/response@0.3.8)
-
 ## v0.4.13
 
 ### Patch Changes

--- a/packages/ui/bench/package.json
+++ b/packages/ui/bench/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/node-fetch-server": "workspace:*",
-    "@remix-run/static-middleware": "workspace:*",
+    "@remix-run/static-files": "workspace:*",
     "remix": "workspace:*"
   },
   "devDependencies": {

--- a/packages/ui/bench/server.ts
+++ b/packages/ui/bench/server.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path'
 import { createRouter } from '@remix-run/fetch-router'
 import { route } from '@remix-run/fetch-router/routes'
 import { createRequestListener } from '@remix-run/node-fetch-server'
-import { staticFiles } from '@remix-run/static-middleware'
+import { staticFiles } from '@remix-run/static-files'
 
 let frameworksDir = path.resolve(import.meta.dirname, 'frameworks')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@types/node':
       specifier: ^24.6.0
       version: 24.10.4
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260707.2
+      version: 7.0.0-dev.20260707.2
     github-slugger:
       specifier: 2.0.0
       version: 2.0.0
@@ -1585,9 +1588,9 @@ importers:
       '@remix-run/session-storage-redis':
         specifier: workspace:^
         version: link:../session-storage-redis
-      '@remix-run/static-middleware':
+      '@remix-run/static-files':
         specifier: workspace:^
-        version: link:../static-middleware
+        version: link:../static-files
       '@remix-run/tar-parser':
         specifier: workspace:^
         version: link:../tar-parser
@@ -1800,7 +1803,7 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
-  packages/static-middleware:
+  packages/static-files:
     dependencies:
       '@remix-run/fetch-router':
         specifier: workspace:^
@@ -1819,14 +1822,50 @@ importers:
         version: link:../response
     devDependencies:
       '@remix-run/assert':
+        specifier: workspace:^
+        version: link:../assert
+      '@remix-run/form-data-middleware':
+        specifier: workspace:^
+        version: link:../form-data-middleware
+      '@remix-run/method-override-middleware':
+        specifier: workspace:^
+        version: link:../method-override-middleware
+      '@remix-run/test':
+        specifier: workspace:^
+        version: link:../test
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260707.2
+
+  packages/static-middleware:
+    devDependencies:
+      '@remix-run/assert':
         specifier: workspace:*
         version: link:../assert
+      '@remix-run/fetch-router':
+        specifier: workspace:*
+        version: link:../fetch-router
       '@remix-run/form-data-middleware':
         specifier: workspace:*
         version: link:../form-data-middleware
+      '@remix-run/fs':
+        specifier: workspace:*
+        version: link:../fs
+      '@remix-run/html-template':
+        specifier: workspace:*
+        version: link:../html-template
       '@remix-run/method-override-middleware':
         specifier: workspace:*
         version: link:../method-override-middleware
+      '@remix-run/mime':
+        specifier: workspace:*
+        version: link:../mime
+      '@remix-run/response':
+        specifier: workspace:*
+        version: link:../response
       '@remix-run/test':
         specifier: workspace:*
         version: link:../test
@@ -2063,9 +2102,9 @@ importers:
       '@remix-run/node-fetch-server':
         specifier: workspace:*
         version: link:../../node-fetch-server
-      '@remix-run/static-middleware':
+      '@remix-run/static-files':
         specifier: workspace:*
-        version: link:../../static-middleware
+        version: link:../../static-files
       remix:
         specifier: workspace:*
         version: link:../../remix
@@ -4419,6 +4458,53 @@ packages:
 
   '@typescript/analyze-trace@0.10.1':
     resolution: {integrity: sha512-RnlSOPh14QbopGCApgkSx5UBgGda5MX1cHqp2fsqfiDyCwGL/m1jaeB9fzu7didVS81LQqGZZuxFBcg8YU8EVw==}
+    hasBin: true
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -7813,6 +7899,37 @@ snapshots:
       split2: 3.2.2
       treeify: 1.1.0
       yargs: 16.2.0
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ allowBuilds:
 catalog:
   '@types/hast': 3.0.5
   '@types/node': ^24.6.0
+  '@typescript/native-preview': 7.0.0-dev.20260707.2
   github-slugger: 2.0.0
   oxfmt: ^0.51.0
   pagefind: 1.5.2

--- a/scripts/generate-remix.ts
+++ b/scripts/generate-remix.ts
@@ -123,6 +123,7 @@ async function scanPackages(): Promise<RemixRunPackage[]> {
     if (!isFile(packageJsonPath)) continue
 
     let packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
+    if (packageJson.private === true) continue
     let packageName = packageJson.name as string
     if (!packageName.startsWith('@remix-run/')) continue
 


### PR DESCRIPTION
The `3.0.0-beta.7` publish is blocked because npm refuses updates to `@remix-run/static-middleware`. Its last published version depends on `@remix-run/fetch-router@^0.20.1`, so fresh pnpm installs get an incompatible router copy alongside Remix's `0.21.x` dependency and fail type checking.

This replaces the internal package while preserving the public API:

- adds `@remix-run/static-files` with the existing implementation and test coverage
- keeps `remix/middleware/static` and `staticFiles()` unchanged for applications
- retires `@remix-run/static-middleware` as a private workspace package and excludes private packages from umbrella generation
- rolls the blocked package metadata and changelog back to the last version actually published to npm
- adds focused change files for `static-files@0.1.0` and the Remix prerelease fix

```ts
import { staticFiles } from 'remix/middleware/static'
```

This recovers the release started in #11704 after the package-specific publish failure investigated in #11709.
