### PR TITLE
Use npm CLI for trusted publishing

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,8 +1,8 @@
 /**
  * Publishes packages to npm and creates tags/releases for what was published.
  *
- * This script uses pnpm publish with --report-summary, reads the summary file,
- * and creates Git tags + GitHub releases. When one or more packages are in
+ * This script uses npm publish for trusted publishing authentication, then
+ * creates Git tags + GitHub releases. When one or more packages are in
  * prerelease mode (have .changes/config.json with prereleaseChannel), it publishes
  * in two phases: all other packages as "latest", then prerelease packages with
  * the "next" tag.
@@ -20,6 +20,7 @@
  */
 import * as cp from 'node:child_process'
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
 
 import {
@@ -37,8 +38,11 @@ import {
   getGitTag,
   packageNameToDirectoryName,
   getPackageShortName,
+  getPackageDependencies,
+  getPackagePath,
 } from './utils/packages.ts'
 import { readJson, fileExists } from './utils/fs.ts'
+import { createPublishPlan, isPackageVersionPublished } from './utils/publish.ts'
 
 const rootDir = getRootDir()
 
@@ -50,13 +54,6 @@ interface PublishedPackage {
   packageName: string
   version: string
   tag: string
-}
-
-interface PublishSummary {
-  publishedPackages: Array<{
-    name: string
-    version: string
-  }>
 }
 
 interface LocalPackage {
@@ -73,28 +70,6 @@ interface PrereleasePackage {
 interface TagPlan {
   pkg: PublishedPackage
   targetCommit: string
-}
-
-/**
- * Read published packages from pnpm's publish summary file.
- * See https://pnpm.io/cli/publish#--report-summary
- */
-function readPublishSummary(): PublishedPackage[] {
-  let summaryPath = path.join(rootDir, 'pnpm-publish-summary.json')
-
-  if (!fs.existsSync(summaryPath)) {
-    throw new Error(
-      `pnpm-publish-summary.json not found. This is unexpected after a successful publish.`,
-    )
-  }
-
-  let summary: PublishSummary = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'))
-
-  return summary.publishedPackages.map((pkg) => ({
-    packageName: pkg.name,
-    version: pkg.version,
-    tag: getGitTag(pkg.name, pkg.version),
-  }))
 }
 
 /**
@@ -155,22 +130,6 @@ function getPrereleasePackages(): PrereleasePackage[] {
 }
 
 /**
- * Check if a specific version of a package is published on npm.
- */
-async function isVersionPublished(packageName: string, version: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    cp.exec(
-      `npm view ${packageName}@${version} version`,
-      { encoding: 'utf-8' },
-      (_error, stdout) => {
-        // If we get output that matches the version, it exists
-        resolve(stdout.trim() === version)
-      },
-    )
-  })
-}
-
-/**
  * Get all packages that have versions not yet published to npm.
  */
 async function getUnpublishedPackages(): Promise<PublishedPackage[]> {
@@ -180,7 +139,7 @@ async function getUnpublishedPackages(): Promise<PublishedPackage[]> {
   let npmResults = await Promise.all(
     localPackages.map(async (pkg) => ({
       pkg,
-      isPublished: await isVersionPublished(pkg.npmName, pkg.localVersion),
+      isPublished: await isPackageVersionPublished(pkg.npmName, pkg.localVersion),
     })),
   )
 
@@ -209,7 +168,7 @@ async function getPublishedPackagesMissingTags(): Promise<PublishedPackage[]> {
   let npmResults = await Promise.all(
     localPackages.map(async (pkg) => ({
       pkg,
-      isPublished: await isVersionPublished(pkg.npmName, pkg.localVersion),
+      isPublished: await isPackageVersionPublished(pkg.npmName, pkg.localVersion),
     })),
   )
 
@@ -242,7 +201,7 @@ async function getPublishedPackagesMissingReleases(): Promise<PublishedPackage[]
   let npmResults = await Promise.all(
     localPackages.map(async (pkg) => ({
       pkg,
-      isPublished: await isVersionPublished(pkg.npmName, pkg.localVersion),
+      isPublished: await isPackageVersionPublished(pkg.npmName, pkg.localVersion),
     })),
   )
 
@@ -456,54 +415,69 @@ async function main() {
   // Publish packages to npm
   console.log('Publishing packages to npm...\n')
 
+  let unpublished = await getUnpublishedPackages()
+  let publishPlan = createPublishPlan({
+    packages: unpublished,
+    prereleaseDirNames: new Set(prereleasePackages.map((pkg) => pkg.dirName)),
+    getDirectoryName: packageNameToDirectoryName,
+    getDependencies: getPackageDependencies,
+  })
   let published: PublishedPackage[] = []
 
-  if (prereleasePackages.length > 0) {
-    let publishCommands = [
-      [
-        'pnpm publish --recursive',
-        '--filter "./packages/*"',
-        ...prereleasePackages.map((pkg) => `--filter "!${pkg.dirName}"`),
-        '--access public',
-        '--no-git-checks',
-        '--report-summary',
-      ].join(' '),
-      ...prereleasePackages.map((pkg) =>
-        [
-          `pnpm publish --filter ${pkg.dirName}`,
-          '--tag next',
-          '--access public',
-          '--no-git-checks',
-          '--report-summary',
-        ].join(' '),
-      ),
-    ]
+  if (dryRun && publishPlan.length > 0) {
+    console.log('Would run:')
+  }
+
+  for (let plan of publishPlan) {
+    let packageDir = getPackagePath(plan.dirName)
+    let relativePackageDir = path.relative(rootDir, packageDir)
 
     if (dryRun) {
-      console.log('Would run:')
-      for (let publishCommand of publishCommands) {
-        console.log(`  $ ${publishCommand}`)
-      }
-      console.log()
-    } else {
-      for (let publishCommand of publishCommands) {
-        logAndExec(publishCommand)
-        published.push(...readPublishSummary())
-      }
+      console.log(
+        `  $ (cd ${relativePackageDir} && pnpm run --if-present prepublishOnly && pnpm pack)`,
+      )
+      console.log(`  $ npm publish <package tarball> --access public --tag ${plan.npmTag}`)
+      continue
     }
-  } else {
-    // Single-phase publish: everything as latest
-    let publishCommand =
-      'pnpm publish --recursive --filter "./packages/*" --access public --no-git-checks --report-summary'
 
-    if (dryRun) {
-      console.log('Would run:')
-      console.log(`  $ ${publishCommand}`)
-      console.log()
-    } else {
-      logAndExec(publishCommand)
-      published.push(...readPublishSummary())
+    console.log(`$ (cd ${relativePackageDir} && pnpm run --if-present prepublishOnly)`)
+    cp.execFileSync('pnpm', ['run', '--if-present', 'prepublishOnly'], {
+      cwd: packageDir,
+      stdio: 'inherit',
+    })
+
+    let packDir = fs.mkdtempSync(path.join(os.tmpdir(), `remix-publish-${plan.dirName}-`))
+    try {
+      console.log(`$ (cd ${relativePackageDir} && pnpm pack)`)
+      cp.execFileSync('pnpm', ['pack', '--pack-destination', packDir], {
+        cwd: packageDir,
+        stdio: 'inherit',
+      })
+
+      let tarballs = fs.readdirSync(packDir).filter((file) => file.endsWith('.tgz'))
+      if (tarballs.length !== 1) {
+        throw new Error(
+          `Expected pnpm pack to create one tarball for ${plan.packageName}, found ${tarballs.length}.`,
+        )
+      }
+
+      let tarballPath = path.join(packDir, tarballs[0])
+      console.log(
+        `$ npm publish ${path.basename(tarballPath)} --access public --tag ${plan.npmTag}`,
+      )
+      cp.execFileSync('npm', ['publish', tarballPath, '--access', 'public', '--tag', plan.npmTag], {
+        cwd: packageDir,
+        stdio: 'inherit',
+      })
+    } finally {
+      fs.rmSync(packDir, { recursive: true, force: true })
     }
+
+    published.push(plan)
+  }
+
+  if (dryRun && publishPlan.length > 0) {
+    console.log()
   }
 
   // In dry run mode, query npm to determine what would be published
@@ -511,8 +485,6 @@ async function main() {
   // the contents of the "Release" PR / `pnpm changes:version` output.
   if (dryRun) {
     console.log('Checking npm for unpublished versions...\n')
-
-    let unpublished = await getUnpublishedPackages()
 
     if (unpublished.length === 0) {
       console.log('All package versions are already published to npm.')

--- a/scripts/utils/publish.test.ts
+++ b/scripts/utils/publish.test.ts
@@ -1,0 +1,124 @@
+import assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+import {
+  createPublishPlan,
+  isPackageVersionPublished,
+  type PublishCandidate,
+  type RegistryRequest,
+} from './publish.ts'
+
+function makePackage(packageName: string): PublishCandidate {
+  return {
+    packageName,
+    version: '1.0.0',
+    tag: `${packageName}@1.0.0`,
+  }
+}
+
+function createRegistryRequest(
+  status: number,
+  statusText = '',
+): {
+  request: RegistryRequest
+  urls: URL[]
+} {
+  let urls: URL[] = []
+
+  return {
+    request(url) {
+      urls.push(url)
+      return Promise.resolve(new Response(null, { status, statusText }))
+    },
+    urls,
+  }
+}
+
+describe('isPackageVersionPublished', () => {
+  it('checks scoped packages using the npm registry API', async () => {
+    let { request, urls } = createRegistryRequest(200)
+
+    assert.equal(
+      await isPackageVersionPublished('@remix-run/static-files-middleware', '0.1.0', request),
+      true,
+    )
+    assert.deepEqual(urls.map(String), [
+      'https://registry.npmjs.org/%40remix-run%2Fstatic-files-middleware/0.1.0',
+    ])
+  })
+
+  it('returns false when the package version is not found', async () => {
+    let { request } = createRegistryRequest(404, 'Not Found')
+
+    assert.equal(await isPackageVersionPublished('remix', '3.0.0-beta.8', request), false)
+  })
+
+  it('fails when the registry cannot answer the request', async () => {
+    let { request } = createRegistryRequest(503, 'Service Unavailable')
+
+    await assert.rejects(
+      isPackageVersionPublished('remix', '3.0.0-beta.8', request),
+      /Could not check remix@3\.0\.0-beta\.8 on npm: 503 Service Unavailable/,
+    )
+  })
+})
+
+describe('createPublishPlan', () => {
+  it('publishes dependencies first and prerelease packages after latest packages', () => {
+    let plan = createPublishPlan({
+      packages: [makePackage('remix'), makePackage('@remix-run/app'), makePackage('@remix-run/db')],
+      prereleaseDirNames: new Set(['remix']),
+      getDirectoryName(packageName) {
+        if (packageName === 'remix') return 'remix'
+        return packageName.slice('@remix-run/'.length)
+      },
+      getDependencies(packageName) {
+        if (packageName === '@remix-run/app') return ['@remix-run/db']
+        return []
+      },
+    })
+
+    assert.deepEqual(
+      plan.map((pkg) => [pkg.packageName, pkg.npmTag]),
+      [
+        ['@remix-run/db', 'latest'],
+        ['@remix-run/app', 'latest'],
+        ['remix', 'next'],
+      ],
+    )
+  })
+
+  it('only plans the unpublished packages provided by the caller', () => {
+    let plan = createPublishPlan({
+      packages: [makePackage('@remix-run/unpublished')],
+      prereleaseDirNames: new Set(),
+      getDirectoryName() {
+        return 'unpublished'
+      },
+      getDependencies() {
+        return ['@remix-run/already-published']
+      },
+    })
+
+    assert.deepEqual(
+      plan.map((pkg) => pkg.packageName),
+      ['@remix-run/unpublished'],
+    )
+  })
+
+  it('fails when a package cannot be mapped to a workspace directory', () => {
+    assert.throws(
+      () =>
+        createPublishPlan({
+          packages: [makePackage('@remix-run/unknown')],
+          prereleaseDirNames: new Set(),
+          getDirectoryName() {
+            return null
+          },
+          getDependencies() {
+            return []
+          },
+        }),
+      /Could not map package "@remix-run\/unknown" to a workspace directory/,
+    )
+  })
+})

--- a/scripts/utils/publish.ts
+++ b/scripts/utils/publish.ts
@@ -1,0 +1,105 @@
+export interface PublishCandidate {
+  packageName: string
+  version: string
+  tag: string
+}
+
+export interface PublishPlan extends PublishCandidate {
+  dirName: string
+  npmTag: 'latest' | 'next'
+}
+
+export interface RegistryRequest {
+  (url: URL, init: RequestInit): Promise<Response>
+}
+
+interface CreatePublishPlanOptions {
+  packages: PublishCandidate[]
+  prereleaseDirNames: Set<string>
+  getDirectoryName(packageName: string): string | null
+  getDependencies(packageName: string): string[]
+}
+
+export async function isPackageVersionPublished(
+  packageName: string,
+  version: string,
+  request: RegistryRequest = fetch,
+): Promise<boolean> {
+  let packagePath = encodeURIComponent(packageName)
+  let versionPath = encodeURIComponent(version)
+  let url = new URL(`/${packagePath}/${versionPath}`, 'https://registry.npmjs.org')
+  let response = await request(url, {
+    headers: { Accept: 'application/json' },
+  })
+
+  if (response.status === 404) {
+    return false
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not check ${packageName}@${version} on npm: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  return true
+}
+
+export function createPublishPlan({
+  packages,
+  prereleaseDirNames,
+  getDirectoryName,
+  getDependencies,
+}: CreatePublishPlanOptions): PublishPlan[] {
+  let packagesByName = new Map(packages.map((pkg) => [pkg.packageName, pkg]))
+  let plansByName = new Map<string, PublishPlan>()
+
+  for (let pkg of packages) {
+    let dirName = getDirectoryName(pkg.packageName)
+    if (dirName === null) {
+      throw new Error(`Could not map package "${pkg.packageName}" to a workspace directory.`)
+    }
+
+    plansByName.set(pkg.packageName, {
+      ...pkg,
+      dirName,
+      npmTag: prereleaseDirNames.has(dirName) ? 'next' : 'latest',
+    })
+  }
+
+  let sorted: PublishPlan[] = []
+  let visited = new Set<string>()
+  let visiting = new Set<string>()
+
+  function visit(packageName: string, npmTag: PublishPlan['npmTag']) {
+    if (visited.has(packageName)) {
+      return
+    }
+    if (visiting.has(packageName)) {
+      throw new Error(`Detected a dependency cycle while planning publication of ${packageName}.`)
+    }
+
+    let plan = plansByName.get(packageName)
+    if (plan === undefined || plan.npmTag !== npmTag) {
+      return
+    }
+
+    visiting.add(packageName)
+    for (let dependency of getDependencies(packageName)) {
+      if (packagesByName.has(dependency)) {
+        visit(dependency, npmTag)
+      }
+    }
+    visiting.delete(packageName)
+    visited.add(packageName)
+    sorted.push(plan)
+  }
+
+  for (let npmTag of ['latest', 'next'] as const) {
+    for (let pkg of packages) {
+      visit(pkg.packageName, npmTag)
+    }
+  }
+
+  return sorted
+}


### PR DESCRIPTION
pnpm currently fails npm trusted publishing with `ENEEDAUTH` even when the GitHub Actions OIDC publisher is configured correctly. This moves the authenticated upload to npm's CLI while preserving pnpm's workspace-aware package preparation.

- Builds each unpublished package, then uses `pnpm pack` so `workspace:^` ranges and `publishConfig` are rendered correctly in the tarball.
- Uploads the prepared tarball with `npm publish`, which supports the configured trusted publisher.
- Preserves dependency-first ordering, stable-before-prerelease ordering, npm dist-tags, and partial-release recovery.
- Checks published versions through the npm registry API, keeping local release previews independent of the installed npm wrapper.

This works around [pnpm#9812](https://github.com/pnpm/pnpm/issues/9812) and [pnpm#11566](https://github.com/pnpm/pnpm/issues/11566) without changing pnpm during the active release.
