### PR TITLE
Preserve unpublished entries in release notes

### DIFF
--- a/packages/remix/.changes/minor.ui.default-frame-resolver.md
+++ b/packages/remix/.changes/minor.ui.default-frame-resolver.md
@@ -1,0 +1,10 @@
+`run()` from `remix/ui` now fetches frame HTML by default, so apps no longer need a custom `resolveFrame` just to enable frame reloads and same-origin link and form navigation:
+
+```diff
+ let app = run({
+   loadModule,
+-  resolveFrame: (src, options) => fetch(src, { signal: options?.signal }),
+ })
+```
+
+Keep a custom resolver when the app needs custom request headers, body encoding, response handling, or error UI. Add `rmx-document` to a link or form to leave that navigation to the browser (see #11693).

--- a/packages/static-files-middleware/src/lib/static.test.ts
+++ b/packages/static-files-middleware/src/lib/static.test.ts
@@ -375,7 +375,7 @@ describe('staticFiles middleware', () => {
 
   it('does not support absolute paths in the URL', async () => {
     let parentDir = path.dirname(tmpDir)
-    let secretFileName = 'secret-outside-root.txt'
+    let secretFileName = `${path.basename(tmpDir)}-secret-outside-root.txt`
     let secretPath = path.join(parentDir, secretFileName)
     fs.writeFileSync(secretPath, 'Secret content')
 

--- a/packages/static-middleware/src/lib/static.test.ts
+++ b/packages/static-middleware/src/lib/static.test.ts
@@ -375,7 +375,7 @@ describe('staticFiles middleware', () => {
 
   it('does not support absolute paths in the URL', async () => {
     let parentDir = path.dirname(tmpDir)
-    let secretFileName = 'secret-outside-root.txt'
+    let secretFileName = `${path.basename(tmpDir)}-secret-outside-root.txt`
     let secretPath = path.join(parentDir, secretFileName)
     fs.writeFileSync(secretPath, 'Secret content')
 

--- a/packages/ui/.changes/minor.default-frame-resolver.md
+++ b/packages/ui/.changes/minor.default-frame-resolver.md
@@ -1,5 +1,15 @@
-`run()` now uses a default browser frame resolver when `resolveFrame` is omitted
+`run()` now uses a default browser frame resolver when `resolveFrame` is omitted. Apps that supplied a resolver only to fetch frame HTML can remove it:
 
-- Therefore, all `run()` calls will enable frame reloads and frame driven navigations via the Navigation API
-- The default resolver rejects non-OK responses; applications can provide their own `resolveFrame` to render error UI from non-OK responses or customize other behavior
-- The `rmx-document` attribute can be used to opt out of navigation interception
+```diff
+ let app = run({
+   loadModule,
+-  resolveFrame(src, options) {
+-    return fetch(src, {
+-      headers: { Accept: 'text/html' },
+-      signal: options?.signal,
+-    })
+-  },
+ })
+```
+
+All `run()` calls now enable frame reloads and same-origin link and form navigation through the Navigation API. The default resolver submits the requested method, encoding, and form data, and rejects non-OK responses. Keep a custom `resolveFrame` when the app needs custom request headers, body encoding, response handling, or error UI. Add `rmx-document` to a link or form to leave that navigation to the browser (see #11693).

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -31,7 +31,7 @@ import {
 } from './utils/git.ts'
 import { createRelease, releaseExists } from './utils/github.ts'
 import { getRootDir, logAndExec } from './utils/process.ts'
-import { readChangesConfig, getChangelogEntry } from './utils/changes.ts'
+import { readChangesConfig, getChangelogEntries } from './utils/changes.ts'
 import {
   getAllPackageDirNames,
   getPackageFile,
@@ -42,7 +42,7 @@ import {
   getPackagePath,
 } from './utils/packages.ts'
 import { readJson, fileExists } from './utils/fs.ts'
-import { createPublishPlan, isPackageVersionPublished } from './utils/publish.ts'
+import { createPublishPlan, getReleaseNotes, isPackageVersionPublished } from './utils/publish.ts'
 
 const rootDir = getRootDir()
 
@@ -345,7 +345,22 @@ interface ChangelogWarning {
  * Preview GitHub releases for packages that would be published.
  * Returns warnings for packages with missing changelog entries.
  */
-function previewGitHubReleases(packages: PublishedPackage[]): { warnings: ChangelogWarning[] } {
+async function getReleaseBody(pkg: PublishedPackage): Promise<string | null> {
+  let entries = getChangelogEntries({ packageName: pkg.packageName })
+  if (entries === null) {
+    return null
+  }
+
+  return getReleaseNotes({
+    entries,
+    targetVersion: pkg.version,
+    isVersionPublished: (version) => isPackageVersionPublished(pkg.packageName, version),
+  })
+}
+
+async function previewGitHubReleases(
+  packages: PublishedPackage[],
+): Promise<{ warnings: ChangelogWarning[] }> {
   let warnings: ChangelogWarning[] = []
 
   console.log('GitHub Release Preview')
@@ -355,10 +370,10 @@ function previewGitHubReleases(packages: PublishedPackage[]): { warnings: Change
   for (let pkg of packages) {
     let tagName = getGitTag(pkg.packageName, pkg.version)
     let releaseName = `${getPackageShortName(pkg.packageName)} v${pkg.version}`
-    let changes = getChangelogEntry({ packageName: pkg.packageName, version: pkg.version })
-    let body = changes?.body ?? 'No changelog entry found for this version.'
+    let releaseBody = await getReleaseBody(pkg)
+    let body = releaseBody ?? 'No changelog entry found for this version.'
 
-    if (changes === null) {
+    if (releaseBody === null) {
       warnings.push({ packageName: pkg.packageName, version: pkg.version })
     }
 
@@ -500,7 +515,7 @@ async function main() {
     }
     console.log()
 
-    let { warnings } = previewGitHubReleases(unpublished)
+    let { warnings } = await previewGitHubReleases(unpublished)
 
     if (warnings.length > 0) {
       console.log('⚠️  WARNINGS')
@@ -607,7 +622,12 @@ async function main() {
   let failedReleases: Array<{ pkg: PublishedPackage; error: string }> = []
 
   for (let pkg of packagesNeedingTagsOrReleases) {
-    let result = await createRelease(pkg.packageName, pkg.version)
+    let releaseBody = await getReleaseBody(pkg)
+    let result = await createRelease(
+      pkg.packageName,
+      pkg.version,
+      releaseBody === null ? {} : { body: releaseBody },
+    )
     if (result.status === 'created') {
       console.log(`  ✓ ${pkg.packageName} v${pkg.version}`)
     } else if (result.status === 'skipped') {

--- a/scripts/utils/changes.test.ts
+++ b/scripts/utils/changes.test.ts
@@ -4,7 +4,12 @@ import * as path from 'node:path'
 import assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import type { PackageRelease } from './changes.ts'
-import { generateChangelogContent, getNextVersion, parsePackageChanges } from './changes.ts'
+import {
+  generateChangelogContent,
+  getNextVersion,
+  parseChangelog,
+  parsePackageChanges,
+} from './changes.ts'
 
 function makeRelease(overrides: Partial<PackageRelease> = {}): PackageRelease {
   return {
@@ -59,6 +64,40 @@ describe('parsePackageChanges', () => {
       assert.equal(result.changes.length, 0)
       assert.equal(result.changesConfig, null)
     })
+  })
+})
+
+describe('parseChangelog', () => {
+  it('returns version entries in document order', () => {
+    let entries = parseChangelog(`# package changelog
+
+## v3.0.0-beta.9
+
+### Pre-release Changes
+
+- New behavior
+
+## v3.0.0-beta.8 (2026-08-17)
+
+### Pre-release Changes
+
+- Earlier behavior
+
+## Unreleased
+`)
+
+    assert.deepEqual(entries, [
+      {
+        version: '3.0.0-beta.9',
+        date: undefined,
+        body: '### Pre-release Changes\n\n- New behavior',
+      },
+      {
+        version: '3.0.0-beta.8',
+        date: new Date('2026-08-17'),
+        body: '### Pre-release Changes\n\n- Earlier behavior',
+      },
+    ])
   })
 })
 

--- a/scripts/utils/changes.ts
+++ b/scripts/utils/changes.ts
@@ -812,42 +812,61 @@ export function generateCommitMessage(releases: PackageRelease[]): string {
 // CHANGELOG.md parsing utilities (for reading already-released changes)
 // =============================================================================
 
-interface ChangelogEntry {
+export interface ChangelogEntry {
   version: string
   date?: Date
   body: string
 }
 
-type AllChangelogEntries = Record<string, ChangelogEntry>
+/**
+ * Parses changelog content and returns its version entries in document order.
+ */
+export function parseChangelog(changelog: string): ChangelogEntry[] {
+  let headingParser = /^## ([^\n]+)$/gm
+  let versionParser =
+    /^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)(?: \(([^)]+)\))?$/
+  let entries: ChangelogEntry[] = []
+
+  let match
+  while ((match = headingParser.exec(changelog))) {
+    let heading = match[1]
+    let lastIndex = headingParser.lastIndex
+    let nextMatch = headingParser.exec(changelog)
+    let body = changelog.slice(lastIndex, nextMatch ? nextMatch.index : undefined).trim()
+    headingParser.lastIndex = lastIndex
+
+    let versionMatch = versionParser.exec(heading)
+    if (versionMatch === null) {
+      continue
+    }
+
+    let [_, version, dateString] = versionMatch
+    let date = dateString ? new Date(dateString) : undefined
+    entries.push({ version, date, body })
+  }
+
+  return entries
+}
 
 /**
- * Parses a package's CHANGELOG.md and returns all version entries
+ * Gets every version entry from a package's CHANGELOG.md in document order.
  */
-function parseChangelog(packageDirName: string): AllChangelogEntries | null {
-  let changelogPath = getPackageFile(packageDirName, 'CHANGELOG.md')
+export function getChangelogEntries({
+  packageName,
+}: {
+  packageName: string
+}): ChangelogEntry[] | null {
+  let dirName = packageNameToDirectoryName(packageName)
+  if (dirName === null) {
+    return null
+  }
 
+  let changelogPath = getPackageFile(dirName, 'CHANGELOG.md')
   if (!fileExists(changelogPath)) {
     return null
   }
 
-  let changelog = readFile(changelogPath)
-  let parser = /^## ([a-z\d.-]+)(?: \(([^)]+)\))?$/gim
-
-  let result: AllChangelogEntries = {}
-
-  let match
-  while ((match = parser.exec(changelog))) {
-    let [_, versionString, dateString] = match
-    let lastIndex = parser.lastIndex
-    let version = versionString.startsWith('v') ? versionString.slice(1) : versionString
-    let date = dateString ? new Date(dateString) : undefined
-    let nextMatch = parser.exec(changelog)
-    let body = changelog.slice(lastIndex, nextMatch ? nextMatch.index : undefined).trim()
-    result[version] = { version, date, body }
-    parser.lastIndex = lastIndex
-  }
-
-  return result
+  return parseChangelog(readFile(changelogPath))
 }
 
 /**
@@ -861,15 +880,5 @@ export function getChangelogEntry({
   packageName: string
   version: string
 }): ChangelogEntry | null {
-  let dirName = packageNameToDirectoryName(packageName)
-  if (dirName === null) {
-    return null
-  }
-
-  let allEntries = parseChangelog(dirName)
-  if (allEntries !== null) {
-    return allEntries[version] ?? null
-  }
-
-  return null
+  return getChangelogEntries({ packageName })?.find((entry) => entry.version === version) ?? null
 }

--- a/scripts/utils/github.test.ts
+++ b/scripts/utils/github.test.ts
@@ -81,6 +81,31 @@ describe('createRelease', () => {
     })
   })
 
+  it('uses release notes supplied by the publisher', async () => {
+    await withGitHubToken(async () => {
+      let releaseOptions: Record<string, unknown> | undefined
+      let githubRequest: GitHubRequest = async (route, options) => {
+        if (route === 'GET /repos/{owner}/{repo}/releases/tags/{tag}') {
+          throw createHttpError(404, 'Not Found')
+        }
+
+        if (route === 'POST /repos/{owner}/{repo}/releases') {
+          releaseOptions = options
+          return { data: {} }
+        }
+
+        throw new Error(`Unexpected route: ${route}`)
+      }
+
+      await createRelease('remix', '3.0.0-beta.9', {
+        body: 'Changes since beta.6',
+        request: githubRequest,
+      })
+
+      assert.equal(releaseOptions?.body, 'Changes since beta.6')
+    })
+  })
+
   it('treats a failed create response as success when the release exists afterward', async () => {
     await withGitHubToken(async () => {
       let calls: MockCall[] = []

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -178,11 +178,13 @@ export async function createRelease(
   packageName: string,
   version: string,
   options: {
+    body?: string
     preview?: boolean
     request?: GitHubRequest
   } & RetryOptions = {},
 ): Promise<CreateReleaseResult> {
   let {
+    body: requestedBody,
     preview = false,
     request: githubRequest = defaultRequest,
     maxAttempts,
@@ -192,7 +194,7 @@ export async function createRelease(
   let tagName = getGitTag(packageName, version)
   let releaseName = `${getPackageShortName(packageName)} v${version}`
   let changes = getChangelogEntry({ packageName, version })
-  let body = changes?.body ?? 'No changelog entry found for this version.'
+  let body = requestedBody ?? changes?.body ?? 'No changelog entry found for this version.'
 
   if (preview) {
     console.log(`  Tag:  ${tagName}`)

--- a/scripts/utils/publish.test.ts
+++ b/scripts/utils/publish.test.ts
@@ -2,6 +2,7 @@ import assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 import {
   createPublishPlan,
+  getReleaseNotes,
   isPackageVersionPublished,
   type PublishCandidate,
   type RegistryRequest,
@@ -32,6 +33,62 @@ function createRegistryRequest(
     urls,
   }
 }
+
+describe('getReleaseNotes', () => {
+  it('combines skipped changelog entries since the previous published version', async () => {
+    let publishedVersions = new Set(['3.0.0-beta.6'])
+    let notes = await getReleaseNotes({
+      entries: [
+        { version: '3.0.0-beta.9', body: 'Beta 9 changes' },
+        { version: '3.0.0-beta.8', body: 'Beta 8 changes' },
+        { version: '3.0.0-beta.7', body: 'Beta 7 changes' },
+        { version: '3.0.0-beta.6', body: 'Beta 6 changes' },
+      ],
+      targetVersion: '3.0.0-beta.9',
+      isVersionPublished: async (version) => publishedVersions.has(version),
+    })
+
+    assert.equal(
+      notes,
+      `This release includes all changes since v3.0.0-beta.6.
+
+## v3.0.0-beta.7
+
+Beta 7 changes
+
+## v3.0.0-beta.8
+
+Beta 8 changes
+
+## v3.0.0-beta.9
+
+Beta 9 changes`,
+    )
+  })
+
+  it('uses the target changelog entry when the previous version was published', async () => {
+    let notes = await getReleaseNotes({
+      entries: [
+        { version: '0.7.0', body: 'Current changes' },
+        { version: '0.6.0', body: 'Previous changes' },
+      ],
+      targetVersion: '0.7.0',
+      isVersionPublished: async () => true,
+    })
+
+    assert.equal(notes, 'Current changes')
+  })
+
+  it('returns null when the target changelog entry is missing', async () => {
+    let notes = await getReleaseNotes({
+      entries: [],
+      targetVersion: '1.0.0',
+      isVersionPublished: async () => false,
+    })
+
+    assert.equal(notes, null)
+  })
+})
 
 describe('isPackageVersionPublished', () => {
   it('checks scoped packages using the npm registry API', async () => {

--- a/scripts/utils/publish.ts
+++ b/scripts/utils/publish.ts
@@ -1,3 +1,5 @@
+import type { ChangelogEntry } from './changes.ts'
+
 export interface PublishCandidate {
   packageName: string
   version: string
@@ -18,6 +20,12 @@ interface CreatePublishPlanOptions {
   prereleaseDirNames: Set<string>
   getDirectoryName(packageName: string): string | null
   getDependencies(packageName: string): string[]
+}
+
+interface GetReleaseNotesOptions {
+  entries: ChangelogEntry[]
+  targetVersion: string
+  isVersionPublished(version: string): Promise<boolean>
 }
 
 export async function isPackageVersionPublished(
@@ -43,6 +51,43 @@ export async function isPackageVersionPublished(
   }
 
   return true
+}
+
+export async function getReleaseNotes({
+  entries,
+  targetVersion,
+  isVersionPublished,
+}: GetReleaseNotesOptions): Promise<string | null> {
+  let targetIndex = entries.findIndex((entry) => entry.version === targetVersion)
+  if (targetIndex === -1) {
+    return null
+  }
+
+  let includedEntries = [entries[targetIndex]]
+  let previousPublishedVersion: string | null = null
+
+  for (let entry of entries.slice(targetIndex + 1)) {
+    if (await isVersionPublished(entry.version)) {
+      previousPublishedVersion = entry.version
+      break
+    }
+    includedEntries.push(entry)
+  }
+
+  if (includedEntries.length === 1) {
+    return includedEntries[0].body
+  }
+
+  let introduction =
+    previousPublishedVersion === null
+      ? 'This release includes all previously unpublished changelog entries.'
+      : `This release includes all changes since v${previousPublishedVersion}.`
+  let versionSections = includedEntries
+    .reverse()
+    .map((entry) => `## v${entry.version}\n\n${entry.body}`)
+    .join('\n\n')
+
+  return `${introduction}\n\n${versionSections}`
 }
 
 export function createPublishPlan({


### PR DESCRIPTION
The npm publishing failure left `remix@3.0.0-beta.7` and `beta.8` unpublished. Publishing the next version would therefore compare against an unpublished changelog entry instead of the `beta.6` version users actually have.

- Combines consecutive unpublished changelog entries in GitHub release notes, stopping at the first version found on npm.
- Keeps package change files separate while presenting one chronological “changes since” release story.
- Expands the pending default frame resolver notes with a concrete migration example for both `@remix-run/ui` and `remix/ui` consumers.
- Ignores non-version changelog headings such as `Unreleased`.
- Isolates the old and replacement static middleware test fixtures so their parallel test runs cannot delete each other's temporary file.

For this recovery release, the Remix GitHub release will include the `beta.7`, `beta.8`, and new `beta.9` entries as changes since `beta.6`.
