### PR TITLE
Use npm 12 for trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,6 +53,9 @@ jobs:
       - name: Install Node.js
         uses: ./.github/actions/setup-node-pnpm-cache
 
+      - name: Install npm
+        run: npm install --global npm@12.0.2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -85,6 +88,7 @@ jobs:
         run: node ./scripts/publish.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_LOGLEVEL: verbose
 
       - name: Output tag
         id: get_tag


### PR DESCRIPTION
The release workflow currently uses npm 11.17.0 bundled with Node 24.19.0. Newly configured trusted publishers now include explicit allowed actions, and repeated release attempts are failing with an opaque 403 even though the saved repository, workflow, and publish permission are correct.

This updates the publish job to npm 12.0.2, which includes the current trusted-publisher permission model, and enables verbose npm logging for the publish step so any remaining token-exchange failure is actionable.

- Keeps pnpm unchanged for workspace installation and builds
- Changes only the npm client used to publish package tarballs
- Adds registry diagnostics to the failed [beta.9 publish run](https://github.com/remix-run/remix/actions/runs/32070704728)
