### PR TITLE
Avoid npm WAF trigger in static middleware README

### DIFF
--- a/packages/static-files-middleware/README.md
+++ b/packages/static-files-middleware/README.md
@@ -75,7 +75,7 @@ let router = createRouter({
 
 ## Security
 
-- Prevents path traversal attacks (e.g., `../../../etc/passwd`)
+- Prevents path traversal attacks
 - Only serves files with GET and HEAD requests
 - Respects the configured root directory boundary
 


### PR DESCRIPTION
Publishing `@remix-run/static-files-middleware@0.1.0` was blocked by Cloudflare before npm’s registry handled the request. The package README included a literal path-traversal payload, which triggered the WAF when npm embedded the README in the publish body.

This keeps the security guarantee documented without including the exploit-shaped string.

- Leaves the package API and runtime artifacts unchanged
- Matches the README in the successfully published `0.1.0` tarball
- Prevents future publishes from hitting the same Cloudflare rule
