### PR TITLE
Keep Remix as the latest GitHub release

### DIFF
--- a/scripts/utils/github.test.ts
+++ b/scripts/utils/github.test.ts
@@ -52,10 +52,11 @@ describe('createRelease', () => {
       await createRelease('remix', '3.0.0-beta.6', { request: githubRequest })
 
       assert.equal(releaseOptions?.prerelease, true)
+      assert.equal(releaseOptions?.make_latest, 'false')
     })
   })
 
-  it('does not mark stable versions as GitHub prereleases', async () => {
+  it('does not make stable subpackage releases the latest GitHub release', async () => {
     await withGitHubToken(async () => {
       let releaseOptions: Record<string, unknown> | undefined
       let githubRequest: GitHubRequest = async (route, options) => {
@@ -78,6 +79,34 @@ describe('createRelease', () => {
       await createRelease('@remix-run/test', '0.4.2', { request: githubRequest })
 
       assert.equal(releaseOptions?.prerelease, false)
+      assert.equal(releaseOptions?.make_latest, 'false')
+    })
+  })
+
+  it('makes stable Remix versions the latest GitHub release', async () => {
+    await withGitHubToken(async () => {
+      let releaseOptions: Record<string, unknown> | undefined
+      let githubRequest: GitHubRequest = async (route, options) => {
+        if (route === 'GET /repos/{owner}/{repo}/releases/tags/{tag}') {
+          throw createHttpError(404, 'Not Found')
+        }
+
+        if (route === 'POST /repos/{owner}/{repo}/releases') {
+          releaseOptions = options
+          return {
+            data: {
+              html_url: 'https://github.com/remix-run/remix/releases/tag/remix%403.0.0',
+            },
+          }
+        }
+
+        throw new Error(`Unexpected route: ${route}`)
+      }
+
+      await createRelease('remix', '3.0.0', { request: githubRequest })
+
+      assert.equal(releaseOptions?.prerelease, false)
+      assert.equal(releaseOptions?.make_latest, 'true')
     })
   })
 

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -193,6 +193,7 @@ export async function createRelease(
 
   let tagName = getGitTag(packageName, version)
   let releaseName = `${getPackageShortName(packageName)} v${version}`
+  let isPrerelease = prerelease(version) !== null
   let changes = getChangelogEntry({ packageName, version })
   let body = requestedBody ?? changes?.body ?? 'No changelog entry found for this version.'
 
@@ -235,7 +236,8 @@ export async function createRelease(
         tag_name: tagName,
         name: releaseName,
         body,
-        prerelease: prerelease(version) !== null,
+        prerelease: isPrerelease,
+        make_latest: packageName === 'remix' && !isPrerelease ? 'true' : 'false',
       })
 
       return { status: 'created', url: getReleaseInfo(response.data, tagName).url }


### PR DESCRIPTION
GitHub automatically treats the newest stable release as the repository's latest release, which lets routine subpackage publishes replace Remix in the repository sidebar.

- Mark stable `remix` releases as the latest GitHub release
- Explicitly prevent subpackage releases from taking the latest-release slot
- Keep Remix prereleases excluded because GitHub does not allow prereleases to be latest

The current repository state has also been corrected by marking `remix@2.17.5` as latest.
