### PR TITLE
feat(cli): add `remix db rollback`

### DIFF
--- a/packages/cli/.changes/minor.add-db-rollback.md
+++ b/packages/cli/.changes/minor.add-db-rollback.md
@@ -1,0 +1,8 @@
+Add `remix db rollback`, which reverts applied migrations by running their `down.sql`
+
+`Database.migrate()` already accepted `direction`, `to`, `step`, and `dryRun`, but the CLI never
+passed them, so a migration's `down.sql` was unreachable from `remix db` — `--to` only bounds
+forward progress. `rollback` reverts newest first, bounded by `--step <count>` (default `1`) or
+`--to <migration>`, which reverts back through that migration inclusive. `--dry-run` reports what
+would be reverted without running it. It also takes `--migrations`, `--journal-table`, and
+`--connection-env`.

--- a/packages/cli/.changes/minor.add-db-rollback.md
+++ b/packages/cli/.changes/minor.add-db-rollback.md
@@ -1,8 +1,3 @@
 Add `remix db rollback`, which reverts applied migrations by running their `down.sql`
 
-`Database.migrate()` already accepted `direction`, `to`, `step`, and `dryRun`, but the CLI never
-passed them, so a migration's `down.sql` was unreachable from `remix db` — `--to` only bounds
-forward progress. `rollback` reverts newest first, bounded by `--step <count>` (default `1`) or
-`--to <migration>`, which reverts back through that migration inclusive. `--dry-run` reports what
-would be reverted without running it. It also takes `--migrations`, `--journal-table`, and
-`--connection-env`.
+`Database.migrate()` already accepted `direction`, `to`, `step`, and `dryRun`, but the CLI never passed them, so a migration's `down.sql` was unreachable from `remix db` — `--to` only bounds forward progress. `rollback` reverts newest first, bounded by `--step <count>` (default `1`) or `--to <migration>`, which reverts back through that migration inclusive. `--dry-run` reports what would be reverted without running it. It also takes `--migrations`, `--journal-table`, and `--connection-env` (see #11723).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,7 @@ remix completion bash >> ~/.bashrc
 remix doctor
 remix doctor --fix
 remix db migrate
+remix db rollback
 remix db status
 remix db reset --force
 remix routes
@@ -70,6 +71,7 @@ await runRemix(['completion', 'bash'])
 await runRemix(['doctor'])
 await runRemix(['doctor', '--fix'])
 await runRemix(['db', 'migrate'])
+await runRemix(['db', 'rollback'])
 await runRemix(['db', 'status'])
 await runRemix(['db', 'reset', '--force'])
 await runRemix(['routes'])
@@ -80,6 +82,8 @@ await runRemix(['version'])
 ```
 
 Destructive database commands (`remix db wipe` and `remix db reset`) refuse to run without `--force`.
+
+`remix db rollback` reverts the most recent migration by default. Use `--step <count>` or `--to <migration>` to select a bound, and use `--dry-run` to report what would be reverted without changing the database.
 
 `runRemix()` returns the CLI exit code as a promise.
 
@@ -162,8 +166,9 @@ disable configured strict mode for one run.
 a string or an object naming an environment variable with an optional default. `db.seed` names a
 SQL file that `remix db seed` and `remix db reset` run against the database. Database flags such as
 `--migrations`, `--seed`, `--journal-table`, and `--connection-env` override the corresponding
-config for one invocation. When no global `--config` is provided, database commands find the
-nearest `remix.json` by walking up from the working directory.
+config for one invocation. Rollbacks also accept `--step`, `--to`, and `--dry-run`. When no global
+`--config` is provided, database commands find the nearest `remix.json` by walking up from the
+working directory.
 
 Use the global `--config` option to select another JSONC file. The option itself is resolved from the
 CLI working directory and may appear before or after the command:

--- a/packages/cli/src/lib/commands/completion.test.ts
+++ b/packages/cli/src/lib/commands/completion.test.ts
@@ -110,6 +110,7 @@ describe('completion command', () => {
         'mode:values',
         'migrate',
         'reset',
+        'rollback',
         'seed',
         'status',
         'wipe',

--- a/packages/cli/src/lib/commands/db.test.ts
+++ b/packages/cli/src/lib/commands/db.test.ts
@@ -21,7 +21,10 @@ describe('db command', () => {
     assert.match(result.stdout, /--journal-table <name>/)
     assert.match(result.stdout, /--migrations <path>/)
     assert.match(result.stdout, /--seed <path>/)
+    assert.match(result.stdout, /--step <count>/)
     assert.match(result.stdout, /--to <migration>/)
+    assert.match(result.stdout, /--dry-run/)
+    assert.match(result.stdout, /remix db rollback/)
   })
 
   it('refuses destructive database commands without --force', async () => {
@@ -234,6 +237,114 @@ describe('db command', () => {
     }
   })
 
+  it('rolls back the most recent migration, newest first', async () => {
+    let projectDir = await createDatabaseProject({ reversible: true })
+
+    try {
+      await captureOutput(() => runRemix(['db', 'migrate'], { cwd: projectDir }))
+
+      let rollback = await captureOutput(() => runRemix(['db', 'rollback'], { cwd: projectDir }))
+      assert.equal(rollback.exitCode, 0, rollback.stderr)
+      assert.match(rollback.stdout, /reverted 20260715130000_create_second/)
+      assert.equal(readTableNames(projectDir).includes('second_table'), false)
+      assert.ok(readTableNames(projectDir).includes('first_table'))
+
+      let status = await captureOutput(() => runRemix(['db', 'status'], { cwd: projectDir }))
+      assert.match(status.stdout, /20260715120000 create_first applied/)
+      assert.match(status.stdout, /20260715130000 create_second pending/)
+
+      let remaining = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--step', '1'], { cwd: projectDir }),
+      )
+      assert.equal(remaining.exitCode, 0, remaining.stderr)
+      assert.match(remaining.stdout, /reverted 20260715120000_create_first/)
+
+      let empty = await captureOutput(() => runRemix(['db', 'rollback'], { cwd: projectDir }))
+      assert.equal(empty.exitCode, 0, empty.stderr)
+      assert.match(empty.stdout, /no migrations to revert/)
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('bounds a rollback with --step, --to, and --dry-run', async () => {
+    let projectDir = await createDatabaseProject({ reversible: true })
+
+    try {
+      await captureOutput(() => runRemix(['db', 'migrate'], { cwd: projectDir }))
+
+      let dryRun = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--dry-run'], { cwd: projectDir }),
+      )
+      assert.equal(dryRun.exitCode, 0, dryRun.stderr)
+      assert.match(dryRun.stdout, /would revert 20260715130000_create_second/)
+      // A dry run reports without reverting, so the table is still there.
+      assert.ok(readTableNames(projectDir).includes('second_table'))
+
+      // --to is inclusive: it reverts back through the named migration.
+      let toFirst = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--to', '20260715120000'], { cwd: projectDir }),
+      )
+      assert.equal(toFirst.exitCode, 0, toFirst.stderr)
+      assert.match(toFirst.stdout, /reverted 20260715130000_create_second/)
+      assert.match(toFirst.stdout, /reverted 20260715120000_create_first/)
+      assert.equal(readTableNames(projectDir).includes('first_table'), false)
+
+      let both = await captureOutput(() =>
+        runRemix(['db', 'migrate'], { cwd: projectDir }).then(() =>
+          runRemix(['db', 'rollback', '--step', '2'], { cwd: projectDir }),
+        ),
+      )
+      assert.equal(both.exitCode, 0, both.stderr)
+      assert.match(both.stdout, /reverted 20260715130000_create_second/)
+      assert.match(both.stdout, /reverted 20260715120000_create_first/)
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects invalid rollback bounds and irreversible migrations', async () => {
+    let projectDir = await createDatabaseProject({ reversible: true })
+
+    try {
+      let both = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--step', '1', '--to', '20260715120000'], { cwd: projectDir }),
+      )
+      assert.equal(both.exitCode, 1)
+      assert.match(both.stderr, /Options --step and --to are mutually exclusive/)
+
+      let zero = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--step', '0'], { cwd: projectDir }),
+      )
+      assert.equal(zero.exitCode, 1)
+      assert.match(zero.stderr, /--step expects a positive integer/)
+
+      let notANumber = await captureOutput(() =>
+        runRemix(['db', 'rollback', '--step', 'two'], { cwd: projectDir }),
+      )
+      assert.equal(notANumber.exitCode, 1)
+      assert.match(notANumber.stderr, /--step expects a positive integer/)
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
+
+    // Without a down script the whole rollback fails before touching the database.
+    let irreversibleDir = await createDatabaseProject()
+
+    try {
+      await captureOutput(() => runRemix(['db', 'migrate'], { cwd: irreversibleDir }))
+
+      let irreversible = await captureOutput(() =>
+        runRemix(['db', 'rollback'], { cwd: irreversibleDir }),
+      )
+      assert.equal(irreversible.exitCode, 1)
+      assert.match(irreversible.stderr, /has no down script/)
+      assert.ok(readTableNames(irreversibleDir).includes('second_table'))
+    } finally {
+      await fs.rm(irreversibleDir, { recursive: true, force: true })
+    }
+  })
+
   it('reports unknown subcommands and invalid command options', async () => {
     let unknown = await captureOutput(() => runRemix(['db', 'wat']))
     let invalid = await captureOutput(() => runRemix(['db', 'migrate', '--seed', './seed.sql']))
@@ -266,6 +377,7 @@ async function createDatabaseProject(
   options: {
     migrationsDirectory?: string
     missingSeed?: boolean
+    reversible?: boolean
   } = {},
 ): Promise<string> {
   let projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-cli-db-command-'))
@@ -292,6 +404,15 @@ async function createDatabaseProject(
     'create table second_table (id integer primary key);\n',
     'utf8',
   )
+
+  // The second migration is irreversible by default, so `rollback` tests opt in to a down script.
+  if (options.reversible) {
+    await fs.writeFile(
+      path.join(projectDir, 'db/migrations/20260715130000_create_second/down.sql'),
+      'drop table second_table;\n',
+      'utf8',
+    )
+  }
 
   if (!options.missingSeed) {
     await fs.writeFile(

--- a/packages/cli/src/lib/commands/db.ts
+++ b/packages/cli/src/lib/commands/db.ts
@@ -355,11 +355,21 @@ async function executeDatabaseCommand(plan: DatabaseCommandPlan, db: Database): 
   }
 
   if (plan.command === 'rollback') {
+    if (plan.to !== undefined) {
+      return runRemixDb({
+        command: plan.command,
+        db,
+        migrations,
+        to: plan.to,
+        dryRun: plan.dryRun,
+        journalTable: plan.journalTable,
+      })
+    }
+
     return runRemixDb({
       command: plan.command,
       db,
       migrations,
-      to: plan.to,
       step: plan.step,
       dryRun: plan.dryRun,
       journalTable: plan.journalTable,

--- a/packages/cli/src/lib/commands/db.ts
+++ b/packages/cli/src/lib/commands/db.ts
@@ -63,6 +63,8 @@ export function getDbCommandHelpText(target: NodeJS.WriteStream = process.stdout
         'remix db wipe --force',
         'remix db migrate',
         'remix db migrate --to 20260715123000_add_users',
+        'remix db rollback',
+        'remix db rollback --step 2 --dry-run',
         'remix db status',
         'remix db seed',
         'remix db reset --force',
@@ -72,24 +74,35 @@ export function getDbCommandHelpText(target: NodeJS.WriteStream = process.stdout
           description: 'Read the database connection from an environment variable',
           label: '--connection-env <name>',
         },
+        {
+          description: 'Report what would be reverted without running it (rollback only)',
+          label: '--dry-run',
+        },
         { description: 'Confirm a destructive command (wipe and reset only)', label: '--force' },
         {
-          description: 'Use a migration journal table (migrate, status, and reset only)',
+          description: 'Use a migration journal table (migrate, rollback, status, and reset only)',
           label: '--journal-table <name>',
         },
         {
-          description: 'Load migrations from a directory (migrate, status, and reset only)',
+          description:
+            'Load migrations from a directory (migrate, rollback, status, and reset only)',
           label: '--migrations <path>',
         },
         { description: 'Run a SQL seed file (seed and reset only)', label: '--seed <path>' },
         {
-          description: 'Stop after applying the specified migration (migrate only)',
+          description: 'Revert this many migrations, newest first (rollback only)',
+          label: '--step <count>',
+        },
+        {
+          description:
+            'Stop after applying the specified migration, or revert back through it (migrate and rollback only)',
           label: '--to <migration>',
         },
       ],
       usage: [
         'remix db wipe --force [options]',
         'remix db migrate [--to <migration>] [options]',
+        'remix db rollback [--step <count> | --to <migration>] [--dry-run] [options]',
         'remix db status [options]',
         'remix db seed [options]',
         'remix db reset --force [options]',
@@ -118,6 +131,28 @@ function parseDbCommandArgs(argv: string[]): DatabaseCommandInvocation {
       { maxPositionals: 0 },
     )
     return { command, ...parsed.options }
+  }
+
+  if (command === 'rollback') {
+    let parsed = parseArgs(
+      commandArgv,
+      {
+        connectionEnv: connectionOption,
+        dryRun: { flag: '--dry-run', type: 'boolean' },
+        journalTable: journalOption,
+        migrations: migrationsOption,
+        step: { flag: '--step', type: 'string' },
+        to: { flag: '--to', type: 'string' },
+      },
+      { maxPositionals: 0 },
+    )
+
+    if (parsed.options.step !== undefined && parsed.options.to !== undefined) {
+      throw invalidOptionValue('Options --step and --to are mutually exclusive')
+    }
+
+    let { step: rawStep, ...options } = parsed.options
+    return { command, ...options, step: parseStepOption(rawStep) }
   }
 
   if (command === 'reset') {
@@ -171,6 +206,17 @@ function parseDbCommandArgs(argv: string[]): DatabaseCommandInvocation {
   return { command, ...parsed.options }
 }
 
+function parseStepOption(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined
+
+  let step = Number(value)
+  if (!Number.isInteger(step) || step < 1) {
+    throw invalidOptionValue(`Option --step expects a positive integer, received "${value}"`)
+  }
+
+  return step
+}
+
 async function resolveDbConfig(
   context: CliContext,
 ): Promise<{ config: RemixDbCommandConfig; configDir: string }> {
@@ -206,6 +252,7 @@ function resolveDatabaseCommandPlan(
   if (
     (invocation.command === 'migrate' ||
       invocation.command === 'reset' ||
+      invocation.command === 'rollback' ||
       invocation.command === 'status') &&
     migrations === undefined
   ) {
@@ -221,9 +268,11 @@ function resolveDatabaseCommandPlan(
   return {
     adapter,
     command: invocation.command,
+    dryRun: invocation.dryRun,
     journalTable,
     migrations,
     seed,
+    step: invocation.step,
     to: invocation.to,
   }
 }
@@ -301,6 +350,18 @@ async function executeDatabaseCommand(plan: DatabaseCommandPlan, db: Database): 
       db,
       migrations,
       to: plan.to,
+      journalTable: plan.journalTable,
+    })
+  }
+
+  if (plan.command === 'rollback') {
+    return runRemixDb({
+      command: plan.command,
+      db,
+      migrations,
+      to: plan.to,
+      step: plan.step,
+      dryRun: plan.dryRun,
       journalTable: plan.journalTable,
     })
   }

--- a/packages/cli/src/lib/completion.test.ts
+++ b/packages/cli/src/lib/completion.test.ts
@@ -51,12 +51,14 @@ describe('completion engine', () => {
     let wipeFlags = getCompletionResult(['remix', 'db', 'wipe', ''], 3)
     let resetFlags = getCompletionResult(['remix', 'db', 'reset', '--force', ''], 4)
     let migrateFlags = getCompletionResult(['remix', 'db', 'migrate', ''], 3)
+    let rollbackFlags = getCompletionResult(['remix', 'db', 'rollback', ''], 3)
     let seedFlags = getCompletionResult(['remix', 'db', 'seed', ''], 3)
 
     assert.equal(subcommands.mode, 'values')
     assert.deepEqual(subcommands.values, [
       'migrate',
       'reset',
+      'rollback',
       'seed',
       'status',
       'wipe',
@@ -93,6 +95,20 @@ describe('completion engine', () => {
       '--connection-env',
       '--journal-table',
       '--migrations',
+      '--to',
+      '--config',
+      '-h',
+      '--help',
+      '--no-color',
+    ])
+
+    assert.equal(rollbackFlags.mode, 'values')
+    assert.deepEqual(rollbackFlags.values, [
+      '--dry-run',
+      '--connection-env',
+      '--journal-table',
+      '--migrations',
+      '--step',
       '--to',
       '--config',
       '-h',

--- a/packages/cli/src/lib/completion.ts
+++ b/packages/cli/src/lib/completion.ts
@@ -6,7 +6,7 @@ export interface CompletionResult {
 }
 
 const COMPLETION_SHELLS = ['bash', 'zsh'] as const
-const DB_COMMANDS = ['migrate', 'reset', 'seed', 'status', 'wipe'] as const
+const DB_COMMANDS = ['migrate', 'reset', 'rollback', 'seed', 'status', 'wipe'] as const
 const HELP_COMMANDS = [
   'completion',
   'db',
@@ -530,6 +530,16 @@ function completeDb(
       usedGlobalFlags,
       ['--force'],
       ['--connection-env', '--journal-table', '--migrations', '--seed'],
+    )
+  }
+
+  if (subcommand === 'rollback') {
+    return completeDbOptions(
+      rest,
+      currentWord,
+      usedGlobalFlags,
+      ['--dry-run'],
+      ['--connection-env', '--journal-table', '--migrations', '--step', '--to'],
     )
   }
 

--- a/packages/cli/src/lib/database-command.ts
+++ b/packages/cli/src/lib/database-command.ts
@@ -1,22 +1,26 @@
 import type { RemixDbAdapterConfig } from './remix-config.ts'
 
-export type DatabaseCommand = 'migrate' | 'reset' | 'seed' | 'status' | 'wipe'
+export type DatabaseCommand = 'migrate' | 'reset' | 'rollback' | 'seed' | 'status' | 'wipe'
 
 export interface DatabaseCommandInvocation {
   command: DatabaseCommand
   connectionEnv?: string
+  dryRun?: boolean
   journalTable?: string
   migrations?: string
   seed?: string
+  step?: number
   to?: string
 }
 
 export interface DatabaseCommandPlan {
   adapter: RemixDbAdapterConfig
   command: DatabaseCommand
+  dryRun?: boolean
   journalTable?: string
   migrations?: string
   seed?: string
+  step?: number
   to?: string
 }
 
@@ -24,6 +28,7 @@ export function isDatabaseCommand(value: unknown): value is DatabaseCommand {
   return (
     value === 'migrate' ||
     value === 'reset' ||
+    value === 'rollback' ||
     value === 'seed' ||
     value === 'status' ||
     value === 'wipe'

--- a/packages/data-table/.changes/minor.add-rollback-command.md
+++ b/packages/data-table/.changes/minor.add-rollback-command.md
@@ -1,0 +1,5 @@
+Add a `rollback` command to `runRemixDb()`
+
+Reverts applied migrations newest first, bounded by `step` (default `1`) or `to` (inclusive), with
+optional `dryRun`. This is what backs `remix db rollback`, and it gives hosts embedding the
+data-table CLI the same command.

--- a/packages/data-table/.changes/minor.add-rollback-command.md
+++ b/packages/data-table/.changes/minor.add-rollback-command.md
@@ -1,5 +1,3 @@
 Add a `rollback` command to `runRemixDb()`
 
-Reverts applied migrations newest first, bounded by `step` (default `1`) or `to` (inclusive), with
-optional `dryRun`. This is what backs `remix db rollback`, and it gives hosts embedding the
-data-table CLI the same command.
+Reverts applied migrations newest first, bounded by `step` (default `1`) or `to` (inclusive), with optional `dryRun`. This is what backs `remix db rollback`, and it gives hosts embedding the data-table CLI the same command (see #11723).

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -11,7 +11,7 @@ Typed relational query toolkit for JavaScript runtimes.
 - **Relation-First Queries**: `hasMany`, `hasOne`, `belongsTo`, `hasManyThrough`, and nested eager loading
 - **Safe Scoped Writes**: `update`/`delete` with `orderBy`/`limit` run safely in a transaction
 - **First-Class Migrations**: Plain SQL `up.sql`/`down.sql` files with a journaling runner and dry-run planning
-- **Database Lifecycle Commands**: Wipe, migrate, inspect, seed, and reset through `remix db`
+- **Database Lifecycle Commands**: Wipe, migrate, rollback, inspect, seed, and reset through `remix db`
 - **Raw SQL Escape Hatch**: Execute SQL directly with `db.exec(sql\`...\`)`
 
 `data-table` gives you two complementary APIs:
@@ -433,12 +433,16 @@ Run lifecycle commands through the Remix CLI:
 remix db status
 remix db migrate
 remix db migrate --to 20260301113000_add_user_status
+remix db rollback
+remix db rollback --step 2
+remix db rollback --to 20260301113000_add_user_status
+remix db rollback --dry-run
 remix db seed
-remix db reset
-remix db wipe
+remix db reset --force
+remix db wipe --force
 ```
 
-`--to` accepts a bare migration id (`20260301113000`) or the full directory name (`20260301113000_add_user_status`).
+`rollback` reverts the most recently applied migration by default. Bound it with either `--step <count>` or `--to <migration>`, which reverts through the target migration inclusively. Migration targets accept a bare migration id (`20260301113000`) or the full directory name (`20260301113000_add_user_status`). Use `--dry-run` to report what would be reverted without changing the database.
 
 `remix db status` reports applied migrations whose files are no longer present as `missing`. If the journal table does not exist, it reports every migration as pending without creating the table. Forward migration runs stop before executing SQL when an applied journal entry is missing from the current migration set. Rollbacks skip those orphaned journal entries so migrations that are still present can be reverted.
 
@@ -472,6 +476,15 @@ for (let script of plan.sql) console.log(script)
 ```
 
 `to` and `step` are mutually exclusive. Omit `journalTable` to use `data_table_migrations`.
+
+Hosts that embed the database CLI can invoke the same rollback behavior through `runRemixDb()`:
+
+```ts
+import { runRemixDb } from 'remix/data-table/cli'
+
+await runRemixDb({ command: 'rollback', db, migrations })
+await runRemixDb({ command: 'rollback', db, migrations, step: 2, dryRun: true })
+```
 
 Database drivers with migration locking run the complete migration and journal lifecycle through the
 connection that owns the lock. This keeps advisory locks correctly paired when the driver uses a

--- a/packages/data-table/src/cli.test.ts
+++ b/packages/data-table/src/cli.test.ts
@@ -12,6 +12,7 @@ import type {
   MigrationStatusEntry,
   Seed,
 } from './lib/migrations.ts'
+import { MemoryMigrationDriver } from '../test/memory-migration-driver.ts'
 import { createRecordingDriver, TestDatabase } from '../test/recording-driver.ts'
 
 const migrations: Migrations = [
@@ -117,6 +118,82 @@ describe('runRemixDb', () => {
     )
 
     assert.deepEqual(lines, ['no pending migrations'])
+  })
+
+  it('rolls back migrations with the requested bounds and prints reverted migrations', async () => {
+    let db = new RecordingDatabase()
+    db.migrateResult = {
+      applied: [],
+      reverted: [{ id: '20260715123000', name: 'create_users', status: 'pending' }],
+      sql: [],
+    }
+
+    let { value: exitCode, lines } = await captureLog(() =>
+      runRemixDb({
+        command: 'rollback',
+        db,
+        migrations,
+        step: 2,
+        dryRun: true,
+        journalTable: 'app_migrations',
+      }),
+    )
+
+    assert.equal(exitCode, 0)
+    assert.deepEqual(db.calls, ['migrate'])
+    assert.deepEqual(db.migrateOptions, {
+      direction: 'down',
+      step: 2,
+      dryRun: true,
+      journalTable: 'app_migrations',
+    })
+    assert.deepEqual(lines, ['would revert 20260715123000_create_users'])
+  })
+
+  it('rejects conflicting rollback bounds without touching the database', async () => {
+    let db = new RecordingDatabase()
+
+    await assert.rejects(
+      () =>
+        runRemixDb({
+          command: 'rollback',
+          db,
+          migrations,
+          to: '20260715123000',
+          step: 1,
+        } as never),
+      /Cannot combine "to" and "step"/,
+    )
+    assert.deepEqual(db.calls, [])
+  })
+
+  it('rejects an empty rollback target without reverting migrations', async () => {
+    let driver = new MemoryMigrationDriver()
+    let db = new TestDatabase(driver)
+    let reversibleMigrations: Migrations = [
+      {
+        id: '20260715123000',
+        name: 'create_users',
+        up: 'create table users (id integer)',
+        down: 'drop table users',
+      },
+    ]
+
+    await db.migrate(reversibleMigrations)
+    driver.executedScripts = []
+
+    await assert.rejects(
+      () =>
+        runRemixDb({
+          command: 'rollback',
+          db,
+          migrations: reversibleMigrations,
+          to: '',
+        }),
+      /Unknown migration target/,
+    )
+    assert.equal(driver.executedScripts.length, 0)
+    assert.equal(driver.journalRows.length, 1)
   })
 
   it('wipes the database', async () => {

--- a/packages/data-table/src/cli.ts
+++ b/packages/data-table/src/cli.ts
@@ -6,6 +6,33 @@ interface DatabaseCommandOptions {
   db: Database
 }
 
+type RollbackBoundOptions =
+  | {
+      /**
+       * Reverts back through this migration, inclusive. Accepts a bare
+       * migration id or the full `id_name` directory form.
+       */
+      to: string
+      step?: never
+    }
+  | {
+      to?: never
+      /** Reverts this many migrations. Defaults to `1`. */
+      step?: number
+    }
+
+type RollbackCommandOptions = DatabaseCommandOptions &
+  RollbackBoundOptions & {
+    /** Reverts applied migrations, newest first. */
+    command: 'rollback'
+    /** Migrations to revert. */
+    migrations: Migrations
+    /** Reports what would be reverted without running it. */
+    dryRun?: boolean
+    /** Migration journal table. */
+    journalTable?: string
+  }
+
 /** Structured invocation options accepted by {@link runRemixDb}. */
 export type RunRemixDbOptions =
   | (DatabaseCommandOptions & {
@@ -21,24 +48,7 @@ export type RunRemixDbOptions =
       /** Migration journal table. */
       journalTable?: string
     })
-  | (DatabaseCommandOptions & {
-      /** Reverts applied migrations, newest first. */
-      command: 'rollback'
-      /** Migrations to revert. */
-      migrations: Migrations
-      /**
-       * Reverts back through this migration, inclusive. Accepts a bare
-       * migration id or the full `id_name` directory form. Mutually exclusive
-       * with `step`.
-       */
-      to?: string
-      /** Reverts this many migrations. Mutually exclusive with `to`. */
-      step?: number
-      /** Reports what would be reverted without running it. */
-      dryRun?: boolean
-      /** Migration journal table. */
-      journalTable?: string
-    })
+  | RollbackCommandOptions
   | (DatabaseCommandOptions & {
       /** Wipes, migrates, and optionally seeds the database. */
       command: 'reset'
@@ -95,14 +105,24 @@ export async function runRemixDb(options: RunRemixDbOptions): Promise<number> {
   }
 
   if (options.command === 'rollback') {
-    let bounds =
-      options.to === undefined ? { step: options.step ?? 1 } : ({ to: options.to } as const)
-    let result = await options.db.migrate(options.migrations, {
-      ...bounds,
-      direction: 'down',
-      dryRun: options.dryRun,
-      journalTable: options.journalTable,
-    })
+    if (options.to !== undefined && options.step !== undefined) {
+      throw new Error('Cannot combine "to" and "step" migration options in the same run')
+    }
+
+    let result =
+      options.to === undefined
+        ? await options.db.migrate(options.migrations, {
+            direction: 'down',
+            step: options.step ?? 1,
+            dryRun: options.dryRun,
+            journalTable: options.journalTable,
+          })
+        : await options.db.migrate(options.migrations, {
+            direction: 'down',
+            to: options.to,
+            dryRun: options.dryRun,
+            journalTable: options.journalTable,
+          })
 
     if (result.reverted.length === 0) {
       console.log('no migrations to revert')

--- a/packages/data-table/src/cli.ts
+++ b/packages/data-table/src/cli.ts
@@ -22,6 +22,24 @@ export type RunRemixDbOptions =
       journalTable?: string
     })
   | (DatabaseCommandOptions & {
+      /** Reverts applied migrations, newest first. */
+      command: 'rollback'
+      /** Migrations to revert. */
+      migrations: Migrations
+      /**
+       * Reverts back through this migration, inclusive. Accepts a bare
+       * migration id or the full `id_name` directory form. Mutually exclusive
+       * with `step`.
+       */
+      to?: string
+      /** Reverts this many migrations. Mutually exclusive with `to`. */
+      step?: number
+      /** Reports what would be reverted without running it. */
+      dryRun?: boolean
+      /** Migration journal table. */
+      journalTable?: string
+    })
+  | (DatabaseCommandOptions & {
       /** Wipes, migrates, and optionally seeds the database. */
       command: 'reset'
       /** Migrations to apply after wiping the database. */
@@ -71,6 +89,27 @@ export async function runRemixDb(options: RunRemixDbOptions): Promise<number> {
 
     for (let entry of result.applied) {
       console.log('applied ' + entry.id + '_' + entry.name)
+    }
+
+    return 0
+  }
+
+  if (options.command === 'rollback') {
+    let bounds =
+      options.to === undefined ? { step: options.step ?? 1 } : ({ to: options.to } as const)
+    let result = await options.db.migrate(options.migrations, {
+      ...bounds,
+      direction: 'down',
+      dryRun: options.dryRun,
+      journalTable: options.journalTable,
+    })
+
+    if (result.reverted.length === 0) {
+      console.log('no migrations to revert')
+    }
+
+    for (let entry of result.reverted) {
+      console.log((options.dryRun ? 'would revert ' : 'reverted ') + entry.id + '_' + entry.name)
     }
 
     return 0

--- a/packages/data-table/src/lib/migrations.test.ts
+++ b/packages/data-table/src/lib/migrations.test.ts
@@ -239,6 +239,28 @@ describe('migration runner', () => {
     )
   })
 
+  it('rejects an empty rollback target without reverting migrations', async () => {
+    let driver = new MemoryMigrationDriver()
+    let runner = createMigrationRunner(driver, [
+      {
+        id: '20260101000000',
+        name: 'create_users',
+        up: 'create table users (id integer)',
+        down: 'drop table users',
+      },
+    ])
+
+    await runner.up()
+    driver.executedScripts = []
+
+    await assert.rejects(() => runner.down({ to: '' }), /Unknown migration target/)
+    assert.equal(driver.executedScripts.length, 0)
+    assert.deepEqual(
+      driver.journalRows.map((row) => row.id),
+      ['20260101000000'],
+    )
+  })
+
   it('resolves full id_name targets against bare migration ids', async () => {
     let driver = new MemoryMigrationDriver()
     let migrations = [

--- a/packages/data-table/src/lib/migrations/runner.ts
+++ b/packages/data-table/src/lib/migrations/runner.ts
@@ -63,7 +63,7 @@ function resolveTargetOption(
   migrations: MigrationDescriptor[],
   to: string | undefined,
 ): string | undefined {
-  if (!to) {
+  if (to === undefined) {
     return undefined
   }
 

--- a/packages/remix/.changes/minor.cli.add-db-rollback.md
+++ b/packages/remix/.changes/minor.cli.add-db-rollback.md
@@ -1,0 +1,1 @@
+Add `remix db rollback` for reverting applied migrations with step, target, and dry-run bounds (see #11723).

--- a/packages/remix/.changes/minor.data-table.add-rollback-command.md
+++ b/packages/remix/.changes/minor.data-table.add-rollback-command.md
@@ -1,0 +1,1 @@
+Add the `runRemixDb()` rollback command through `remix/data-table/cli` (see #11723).

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -26,6 +26,7 @@ remix completion bash >> ~/.bashrc
 remix doctor
 remix doctor --fix
 remix db migrate
+remix db rollback
 remix db status
 remix routes
 remix routes --table
@@ -45,6 +46,7 @@ await runRemix(['completion', 'bash'])
 await runRemix(['doctor'])
 await runRemix(['doctor', '--fix'])
 await runRemix(['db', 'migrate'])
+await runRemix(['db', 'rollback'])
 await runRemix(['db', 'status'])
 await runRemix(['routes'])
 await runRemix(['routes', '--table'])


### PR DESCRIPTION
`Database.migrate()` already accepts `direction`, `step`, `to`, and `dryRun`, but the CLI never passes them, so a migration's `down.sql` was unreachable from `remix db`. `--to` only bounds forward progress: pointed at an applied migration it prints `no pending migrations` and reverts nothing. The only ways to run a down script were `reset` (which reverts everything) or a hand-written script calling `db.migrate()` directly.

Add `rollback`, which reverts applied migrations newest first:

    remix db rollback                   # revert the most recent migration
    remix db rollback --step 2          # revert the two most recent
    remix db rollback --to 20260101000000   # revert back through this one, inclusive
    remix db rollback --dry-run         # report without running

`--step` and `--to` are mutually exclusive, matching `MigrationOperationOptions`; `--step` defaults to 1. It also takes the `--migrations`, `--journal-table`, and `--connection-env` options the other migration commands take.

Unlike `wipe` and `reset`, `rollback` does not require `--force`: reverting one migration is a routine development step rather than a whole-database operation, and `--dry-run` covers the "what would this do" case. Happy to gate it behind `--force` if maintainers prefer.

The printing lives in `runRemixDb()` alongside the other commands, so hosts embedding the data-table CLI get `rollback` too.