### PR TITLE
Use remix db workflows across demos

### DIFF
--- a/demos/bookstore/README.md
+++ b/demos/bookstore/README.md
@@ -33,8 +33,9 @@ The setup command above creates `db/bookstore.sqlite`, applies the migrations, a
 ```sh
 pnpm db:status
 pnpm db:migrate
+pnpm db:rollback
 pnpm db:seed
 pnpm db:reset
 ```
 
-`db:reset` recreates the database from scratch. The other commands let you inspect or update it without discarding your local changes.
+`db:rollback` reverts the latest migration, while `db:reset` recreates the database from scratch. The other commands let you inspect or update it without discarding your local changes.

--- a/demos/bookstore/package.json
+++ b/demos/bookstore/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "db:migrate": "remix db migrate",
     "db:reset": "remix db reset --force",
+    "db:rollback": "remix db rollback",
     "db:seed": "remix db seed",
     "db:status": "remix db status",
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",

--- a/demos/social-auth/README.md
+++ b/demos/social-auth/README.md
@@ -63,7 +63,7 @@ If you configure the external providers locally, use these callback URLs:
 
 The demo keeps its runtime schema in `app/data/`, its SQLite database and migrations in `db/`, and its session files in `tmp/`. The database connection, migrations, and seed file are configured in [`remix.json`](remix.json).
 
-Use `pnpm db:status` to inspect migrations, `pnpm db:migrate` to apply them, and `pnpm db:seed` to reload the demo accounts. Run `pnpm db:reset` whenever you want a fresh database.
+Use `pnpm db:status` to inspect migrations, `pnpm db:migrate` to apply them, `pnpm db:rollback` to revert the latest one, and `pnpm db:seed` to reload the demo accounts. Run `pnpm db:reset` whenever you want a fresh database.
 
 On successful external login, the demo:
 

--- a/demos/social-auth/README.md
+++ b/demos/social-auth/README.md
@@ -14,6 +14,7 @@ This demo shows how to combine `remix/auth`, `remix/middleware/auth`, `remix/dat
 cd demos/social-auth
 cp .env.example .env
 pnpm install
+pnpm db:reset
 pnpm start
 ```
 
@@ -60,7 +61,9 @@ If you configure the external providers locally, use these callback URLs:
 
 ## Data Storage
 
-The demo keeps its runtime schema and setup code in `demos/social-auth/app/data/`, its SQLite files and migrations in `demos/social-auth/db/`, and its session files in `demos/social-auth/tmp/`.
+The demo keeps its runtime schema in `app/data/`, its SQLite database and migrations in `db/`, and its session files in `tmp/`. The database connection, migrations, and seed file are configured in [`remix.json`](remix.json).
+
+Use `pnpm db:status` to inspect migrations, `pnpm db:migrate` to apply them, and `pnpm db:seed` to reload the demo accounts. Run `pnpm db:reset` whenever you want a fresh database.
 
 On successful external login, the demo:
 

--- a/demos/social-auth/package.json
+++ b/demos/social-auth/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "db:migrate": "remix db migrate",
     "db:reset": "remix db reset --force",
+    "db:rollback": "remix db rollback",
     "db:seed": "remix db seed",
     "db:status": "remix db status",
     "dev": "node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",

--- a/demos/social-auth/package.json
+++ b/demos/social-auth/package.json
@@ -13,6 +13,10 @@
     "typescript": "catalog:"
   },
   "scripts": {
+    "db:migrate": "remix db migrate",
+    "db:reset": "remix db reset --force",
+    "db:seed": "remix db seed",
+    "db:status": "remix db status",
     "dev": "node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",
     "start": "node --env-file-if-exists=.env --import remix/node-tsx server.ts",
     "test": "NODE_ENV=test remix test",

--- a/demos/social-auth/server.ts
+++ b/demos/social-auth/server.ts
@@ -1,7 +1,6 @@
 import * as http from 'node:http'
 import { createRequestListener } from 'remix/node-fetch-server'
 
-import { db, loadAppMigrations, loadAppSeed } from './app/db.ts'
 import { createSocialAuthRouter } from './app/router.ts'
 import {
   externalProviderNames,
@@ -9,10 +8,6 @@ import {
   getExternalProviderLabel,
   getExternalProviderStatus,
 } from './app/utils/external-auth.ts'
-
-await db.migrate(await loadAppMigrations())
-const seed = await loadAppSeed()
-await seed(db)
 
 const router = createSocialAuthRouter()
 

--- a/demos/timeboxer/README.md
+++ b/demos/timeboxer/README.md
@@ -21,7 +21,7 @@ Then visit [http://localhost:44100](http://localhost:44100).
 
 ## Database Commands
 
-Use `pnpm db:status` to inspect migrations and `pnpm db:migrate` to apply them. Run `pnpm db:reset` whenever you want to recreate the local database from scratch.
+Use `pnpm db:status` to inspect migrations, `pnpm db:migrate` to apply them, and `pnpm db:rollback` to revert the latest one. Run `pnpm db:reset` whenever you want to recreate the local database from scratch. These commands load the same `.env` file as the server, so `DATABASE_URL` selects the same database for both.
 
 ## Code Highlights
 

--- a/demos/timeboxer/README.md
+++ b/demos/timeboxer/README.md
@@ -8,6 +8,7 @@ A small schedule-planning app that demonstrates username/password authentication
 cd demos/timeboxer
 cp .env.example .env
 pnpm install
+pnpm db:reset
 pnpm start
 ```
 
@@ -17,6 +18,10 @@ Then visit [http://localhost:44100](http://localhost:44100).
 
 - `SESSION_SECRET` signs the session cookie and is required outside tests.
 - `DATABASE_URL` optionally overrides the local SQLite path. By default the demo stores data in `db/timebox.sqlite`.
+
+## Database Commands
+
+Use `pnpm db:status` to inspect migrations and `pnpm db:migrate` to apply them. Run `pnpm db:reset` whenever you want to recreate the local database from scratch.
 
 ## Code Highlights
 

--- a/demos/timeboxer/package.json
+++ b/demos/timeboxer/package.json
@@ -13,9 +13,10 @@
     "typescript": "catalog:"
   },
   "scripts": {
-    "db:migrate": "remix db migrate",
-    "db:reset": "remix db reset --force",
-    "db:status": "remix db status",
+    "db:migrate": "node --env-file-if-exists=.env scripts/remix.js db migrate",
+    "db:reset": "node --env-file-if-exists=.env scripts/remix.js db reset --force",
+    "db:rollback": "node --env-file-if-exists=.env scripts/remix.js db rollback",
+    "db:status": "node --env-file-if-exists=.env scripts/remix.js db status",
     "dev": "NODE_ENV=development node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",
     "start": "node --env-file-if-exists=.env --import remix/node-tsx server.ts",
     "test": "NODE_ENV=test remix test",

--- a/demos/timeboxer/package.json
+++ b/demos/timeboxer/package.json
@@ -13,6 +13,9 @@
     "typescript": "catalog:"
   },
   "scripts": {
+    "db:migrate": "remix db migrate",
+    "db:reset": "remix db reset --force",
+    "db:status": "remix db status",
     "dev": "NODE_ENV=development node --env-file-if-exists=.env --watch --import remix/node-tsx server.ts",
     "start": "node --env-file-if-exists=.env --import remix/node-tsx server.ts",
     "test": "NODE_ENV=test remix test",

--- a/demos/timeboxer/scripts/remix.js
+++ b/demos/timeboxer/scripts/remix.js
@@ -1,0 +1,3 @@
+import { runRemix } from 'remix/cli'
+
+process.exitCode = await runRemix(process.argv.slice(2))

--- a/demos/timeboxer/server.ts
+++ b/demos/timeboxer/server.ts
@@ -2,10 +2,7 @@ import * as http from 'node:http'
 import { createRequestListener } from 'remix/node-fetch-server'
 
 import { assetServer } from './app/actions/assets/controller.ts'
-import { db, loadAppMigrations } from './app/db.ts'
 import { router } from './app/router.ts'
-
-await db.migrate(await loadAppMigrations())
 
 const server = http.createServer(
   createRequestListener(async (request) => {


### PR DESCRIPTION
The database-backed demos configure their connections and migrations in `remix.json`, but Social Auth and Timeboxer still ran migrations inside the application server. This makes `remix db` the explicit database lifecycle across Bookstore, Social Auth, and Timeboxer.

- adds migration status, migrate, rollback, and reset scripts to every database-backed demo
- keeps seed commands available where demos provide sample data
- separates Social Auth and Timeboxer database setup from server startup
- makes Timeboxer database commands load the same `.env` and `DATABASE_URL` as the server
- documents first-time setup and ongoing database maintenance

Before:

```sh
pnpm start
```

After:

```sh
pnpm db:reset
pnpm start
```

Builds on #11640 and #11728.
