### PR TITLE
fix(ui): preserve range media queries when escaping SSR style tags

### DIFF
--- a/packages/ui/.changes/patch.preserve-css-range-media-queries.md
+++ b/packages/ui/.changes/patch.preserve-css-range-media-queries.md
@@ -1,0 +1,1 @@
+Adjust CSS escaping to preserve CSS range media queries such as `@media (width < 900px)` in server-rendered `css()` output while continuing to neutralize literal closing `</style>` tags

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -1326,8 +1326,8 @@ function renderStyleTag(
 }
 
 function escapeStyleText(css: string): string {
-  // A literal "</style" closes an HTML style element even when it appears inside a CSS string.
-  return css.replace(/</g, '\\3C ')
+  // Only neutralize literal style end tags. Escaping every '<' breaks valid range media queries.
+  return css.replace(/<\/style/gi, '<\\/style')
 }
 
 function buildRmxDataScript(context: RenderContext): string {

--- a/packages/ui/src/server/stream.ts
+++ b/packages/ui/src/server/stream.ts
@@ -1327,7 +1327,7 @@ function renderStyleTag(
 
 function escapeStyleText(css: string): string {
   // Only neutralize literal style end tags. Escaping every '<' breaks valid range media queries.
-  return css.replace(/<\/style/gi, '<\\/style')
+  return css.replace(/<\/style/gi, '\\3C/style')
 }
 
 function buildRmxDataScript(context: RenderContext): string {

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -676,8 +676,11 @@ describe('stream', () => {
       )
 
       expect(html).not.toContain('</style><script>')
-      expect(html).not.toContain('<script>globalThis.__xss = true</script>')
-      expect(html).toContain('color: \\3C /style>\\3C script>globalThis.__xss = true\\3C /script>')
+
+      let shelf = document.createElement('template')
+      shelf.innerHTML = html
+      expect(shelf.content.querySelectorAll('script')).toHaveLength(0)
+      expect(html).toContain('<\\/style><script>globalThis.__xss = true</script><style>')
     })
   })
 
@@ -989,6 +992,22 @@ describe('stream', () => {
       // Should generate media query
       expect(html).toContain('@media (min-width: 768px)')
       expect(html).toContain('font-size: 16px')
+    })
+
+    it('preserves range media query operators in css mixin', async () => {
+      let html = await renderToString(
+        <div
+          mix={[
+            css({
+              '@media (width < 900px)': {
+                display: 'none',
+              },
+            }),
+          ]}
+        />,
+      )
+
+      expect(html).toContain('@media (width < 900px)')
     })
 
     it('merges styles with existing head content', async () => {

--- a/packages/ui/src/test/stream.test.tsx
+++ b/packages/ui/src/test/stream.test.tsx
@@ -680,7 +680,7 @@ describe('stream', () => {
       let shelf = document.createElement('template')
       shelf.innerHTML = html
       expect(shelf.content.querySelectorAll('script')).toHaveLength(0)
-      expect(html).toContain('<\\/style><script>globalThis.__xss = true</script><style>')
+      expect(html).toContain('\\3C/style><script>globalThis.__xss = true</script><style>')
     })
   })
 


### PR DESCRIPTION
This fixes a bug introduced by [#11672](https://github.com/remix-run/remix/pull/11672) that resulted in valid CSS being mutated during SSR style escaping (for example, range media queries like `@media (width < 900px)`) while protecting against XSS. Instead, this update only replaces literal closing style tags (searching for `</style` instead of `<`).

Resolves https://github.com/remix-run/remix/issues/11732

## Before / After

| Before | After |
| --- | --- |
|  <img width="572" height="758" alt="Screenshot 2026-08-19 at 11 19 26 PM" src="https://github.com/user-attachments/assets/f7185cb8-d09d-4dec-b73b-da2b85d044bd" />  |  <img width="605" height="661" alt="Screenshot 2026-08-19 at 11 18 46 PM" src="https://github.com/user-attachments/assets/fc468a83-797f-45e6-a261-61d4943bd866" /> |
