### PR TITLE
Fix blank lines collapsing in API demo source code blocks

### DIFF
--- a/docs/api/app/actions/public/api.css
+++ b/docs/api/app/actions/public/api.css
@@ -201,6 +201,13 @@ html {
   border-radius: 0;
 }
 
+.api-demo__source .line {
+  position: relative;
+  display: block;
+  min-height: 1lh;
+  white-space: pre;
+}
+
 @media (width < 900px) {
   .api-page-content > h1:first-child,
   .api-page-content > div > h1:first-child {


### PR DESCRIPTION
## Summary

- Blank lines inside API demo source code blocks (e.g. `https://api.remix.run/api/remix/ui/checkbox/demos/checkbox/`) were invisible even though they're present in the DOM.
- Shiki renders each source line as `<span class="line">`, including a childless span for blank lines. Every other code-block rendering path in the docs (`[data-code-block]`, `[data-demo-source]`) already sizes these spans with `min-height: 1lh`; the API demo page's `.api-demo__source` block never did, so blank-line spans collapsed to zero height.
- Adds `min-height: 1lh` (plus `display: block`, `white-space: pre`, `position: relative`) for `.api-demo__source .line`, matching the existing sizing convention.

## Alternatives

The docs and api sites could probably do a better job of reusing CSS that they both load, but I opted for this solution since it seemed to follow the current CSS philosophy better. There's clearly an opportunity to consolidate some code in that area.