### PR TITLE
Preserve scroll for no-reset navigations

### DIFF
--- a/demos/frames/app/actions/controller.tsx
+++ b/demos/frames/app/actions/controller.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'remix/response/redirect'
 import { createController } from 'remix/router'
 
 import { routes } from '../routes.ts'
@@ -6,6 +7,7 @@ import { ClientMountedPage } from './client-mounted.tsx'
 import { HomePage } from './home.tsx'
 import { ReloadScopePage } from './reload-scope.tsx'
 import { rootReloadClientEntriesAction } from './root-reload-client-entries.tsx'
+import { ScrollRestorationDetailPage, ScrollRestorationPage } from './scroll-restoration.tsx'
 import { StateSearchRoutePage } from './state-search.tsx'
 import { TimePage } from './time.tsx'
 
@@ -41,5 +43,35 @@ export default createController(routes, {
     },
 
     rootReloadClientEntries: rootReloadClientEntriesAction,
+
+    scrollRestoration({ render, url }) {
+      let newsletterHistory = getNewsletterHistory(url.searchParams.get('newsletter'))
+      return render(<ScrollRestorationPage newsletterHistory={newsletterHistory} />)
+    },
+
+    scrollRestorationDetail({ render }) {
+      return render(<ScrollRestorationDetailPage />)
+    },
+
+    async newsletterSignup({ request }) {
+      let formData = await request.formData()
+      let email = formData.get('email')
+      let history = getNewsletterHistory(formData.get('history'))
+
+      if (typeof email !== 'string' || email.trim() === '' || history === undefined) {
+        return new Response('Enter an email address and choose a navigation type.', { status: 400 })
+      }
+
+      return redirect(
+        routes.scrollRestoration.href(undefined, {
+          searchParams: { newsletter: history },
+        }),
+        303,
+      )
+    },
   },
 })
+
+function getNewsletterHistory(value: unknown): 'push' | 'replace' | undefined {
+  return value === 'push' || value === 'replace' ? value : undefined
+}

--- a/demos/frames/app/actions/frames/controller.tsx
+++ b/demos/frames/app/actions/frames/controller.tsx
@@ -3,6 +3,7 @@ import { Frame, css, type RemixNode } from 'remix/ui'
 
 import { Counter } from '../../ui/public/counter.tsx'
 import { ReloadScope } from '../../ui/public/reload-scope.tsx'
+import { ScrollRestorationList } from '../public/scroll-restoration.tsx'
 import { ReloadTime } from './public/reload-time.tsx'
 import { routes } from '../../routes.ts'
 import { clockLabelStyle, leadStyle, mutedStyle } from '../../ui/public/styles.ts'
@@ -193,6 +194,10 @@ export const framesController = createController(routes.frames, {
       await delay(500)
 
       return renderReloadScopeFrame(context, 'Blocking frame server time')
+    },
+
+    async scrollRestorationItems(context) {
+      return render(context, <ScrollRestorationList loadedAt={new Date().toLocaleTimeString()} />)
     },
 
     async stateSearchResults(context) {

--- a/demos/frames/app/actions/home.tsx
+++ b/demos/frames/app/actions/home.tsx
@@ -33,6 +33,10 @@ export function HomePage() {
           Root reload client entries
         </a>
         {' · '}
+        <a href={routes.scrollRestoration.href()} mix={linkStyle}>
+          Navigation scroll behavior
+        </a>
+        {' · '}
         <a href={routes.stateSearch.href()} mix={linkStyle}>
           Dynamic src search demo
         </a>

--- a/demos/frames/app/actions/public/scroll-restoration.tsx
+++ b/demos/frames/app/actions/public/scroll-restoration.tsx
@@ -1,5 +1,6 @@
-import { clientEntry, css, on, type Handle } from 'remix/ui'
+import { clientEntry, Frame, css, on, type Handle } from 'remix/ui'
 
+import { routes } from '../../routes.ts'
 import { leadStyle, mutedStyle, panelStyle, sectionHeadingStyle } from '../../ui/public/styles.ts'
 
 const listItems = Array.from({ length: 48 }, (_, index) => index + 1)
@@ -39,7 +40,7 @@ export const ScrollRestorationList = clientEntry(
               css({ marginLeft: 12 }),
             ]}
           >
-            Hydration check: {interactions}
+            Frame hydration check: {interactions}
           </button>
         </div>
 
@@ -66,43 +67,84 @@ export const ScrollRestorationList = clientEntry(
   },
 )
 
-export const ScrollRestorationDetail = clientEntry(
+export const StoreScrollReproduction = clientEntry(
   import.meta.url,
-  function ScrollRestorationDetail(handle: Handle) {
+  function StoreScrollReproduction(handle: Handle<{ variant: 'list' | 'detail' }>) {
     let interactions = 0
 
     return () => (
-      <article
-        id="scroll-restoration-detail"
-        mix={[
-          panelStyle,
-          css({
-            minHeight: 1400,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            padding: 20,
-            marginTop: 20,
-            background: 'rgba(255,255,255,0.03)',
-          }),
-        ]}
-      >
-        <div>
-          <h2 mix={sectionHeadingStyle}>Hydrated detail content</h2>
+      <section id="store-scroll-reproduction">
+        <div
+          mix={[
+            panelStyle,
+            css({
+              position: 'sticky',
+              top: 12,
+              zIndex: 1,
+              padding: 14,
+              marginBottom: 20,
+              background: '#151c35',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+            }),
+          ]}
+        >
+          <strong>Store-style top-level client entry</strong>
+          <span mix={[mutedStyle, css({ marginLeft: 8 })]}>
+            rendering {handle.props.variant === 'list' ? 'the collection frame' : 'a short detail'}
+          </span>
           <button
             type="button"
-            mix={on('click', () => {
-              interactions++
-              handle.update()
-            })}
+            mix={[
+              on('click', () => {
+                interactions++
+                handle.update()
+              }),
+              css({ marginLeft: 12 }),
+            ]}
           >
             Hydration check: {interactions}
           </button>
         </div>
-        <p mix={[leadStyle, css({ marginBottom: 0 })]}>
-          You are near the end of the detail page. Use the browser Back button now.
-        </p>
-      </article>
+
+        {handle.props.variant === 'list' ? (
+          <div>
+            <section mix={[panelStyle, css({ marginBottom: 20 })]}>
+              <h2 mix={css({ marginTop: 0, fontSize: 18 })}>Traversal restoration</h2>
+              <ol mix={css({ marginBottom: 0, paddingLeft: 22, lineHeight: 1.7 })}>
+                <li>Click the top-level hydration check to give the client entry local state.</li>
+                <li>Scroll to the end of the collection and open the detail view.</li>
+                <li>Use the browser Back button—not a return link.</li>
+                <li>Confirm the hydration count and collection scroll position are restored.</li>
+              </ol>
+            </section>
+            <Frame src={routes.frames.scrollRestorationItems.href()} />
+          </div>
+        ) : (
+          <article
+            id="scroll-restoration-detail"
+            mix={[
+              panelStyle,
+              css({
+                minHeight: 1000,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                padding: 20,
+                background: 'rgba(255,255,255,0.03)',
+              }),
+            ]}
+          >
+            <div>
+              <h2 mix={sectionHeadingStyle}>Short detail view</h2>
+              <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+                The top-level client entry now renders much less content than the collection. Use
+                the browser Back button while this short layout is present.
+              </p>
+            </div>
+            <p mix={[leadStyle, css({ marginBottom: 0 })]}>Use the browser Back button now.</p>
+          </article>
+        )}
+      </section>
     )
   },
 )

--- a/demos/frames/app/actions/public/scroll-restoration.tsx
+++ b/demos/frames/app/actions/public/scroll-restoration.tsx
@@ -1,0 +1,108 @@
+import { clientEntry, css, on, type Handle } from 'remix/ui'
+
+import { leadStyle, mutedStyle, panelStyle, sectionHeadingStyle } from '../../ui/public/styles.ts'
+
+const listItems = Array.from({ length: 48 }, (_, index) => index + 1)
+
+export const ScrollRestorationList = clientEntry(
+  import.meta.url,
+  function ScrollRestorationList(handle: Handle<{ loadedAt: string }>) {
+    let interactions = 0
+
+    return () => (
+      <section id="scroll-restoration-list">
+        <div
+          mix={[
+            panelStyle,
+            css({
+              position: 'sticky',
+              top: 12,
+              zIndex: 1,
+              padding: 14,
+              marginBottom: 12,
+              background: '#151c35',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+            }),
+          ]}
+        >
+          <strong>Blocking frame client entry</strong>
+          <span mix={[mutedStyle, css({ marginLeft: 8 })]}>
+            resolved at {handle.props.loadedAt}
+          </span>
+          <button
+            type="button"
+            mix={[
+              on('click', () => {
+                interactions++
+                handle.update()
+              }),
+              css({ marginLeft: 12 }),
+            ]}
+          >
+            Hydration check: {interactions}
+          </button>
+        </div>
+
+        <ol mix={css({ display: 'grid', gap: 10, margin: 0, padding: 0, listStyle: 'none' })}>
+          {listItems.map((item) => (
+            <li
+              key={item}
+              mix={css({
+                minHeight: 76,
+                display: 'flex',
+                alignItems: 'center',
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: 10,
+                padding: '0 18px',
+                background: item % 2 === 0 ? 'rgba(255,255,255,0.04)' : 'transparent',
+              })}
+            >
+              List row {item}
+            </li>
+          ))}
+        </ol>
+      </section>
+    )
+  },
+)
+
+export const ScrollRestorationDetail = clientEntry(
+  import.meta.url,
+  function ScrollRestorationDetail(handle: Handle) {
+    let interactions = 0
+
+    return () => (
+      <article
+        id="scroll-restoration-detail"
+        mix={[
+          panelStyle,
+          css({
+            minHeight: 1400,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            padding: 20,
+            marginTop: 20,
+            background: 'rgba(255,255,255,0.03)',
+          }),
+        ]}
+      >
+        <div>
+          <h2 mix={sectionHeadingStyle}>Hydrated detail content</h2>
+          <button
+            type="button"
+            mix={on('click', () => {
+              interactions++
+              handle.update()
+            })}
+          >
+            Hydration check: {interactions}
+          </button>
+        </div>
+        <p mix={[leadStyle, css({ marginBottom: 0 })]}>
+          You are near the end of the detail page. Use the browser Back button now.
+        </p>
+      </article>
+    )
+  },
+)

--- a/demos/frames/app/actions/scroll-restoration.tsx
+++ b/demos/frames/app/actions/scroll-restoration.tsx
@@ -79,8 +79,8 @@ function NewsletterSignup(handle: Handle<{ history?: 'push' | 'replace' }>) {
       </h2>
       <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
         This form submits to another URL and redirects back here. Both buttons preserve the current
-        scroll position with <code>data-rmx-reset-scroll="false"</code>; they differ only in whether the
-        navigation pushes or replaces the history entry.
+        scroll position with <code>data-rmx-reset-scroll="false"</code>; they differ only in whether
+        the navigation pushes or replaces the history entry.
       </p>
 
       {handle.props.history ? (

--- a/demos/frames/app/actions/scroll-restoration.tsx
+++ b/demos/frames/app/actions/scroll-restoration.tsx
@@ -1,0 +1,184 @@
+import { Frame, css, type Handle } from 'remix/ui'
+
+import { routes } from '../routes.ts'
+import { Document } from '../ui/document.tsx'
+import { leadStyle, linkStyle, pageHeadingStyle, panelStyle } from '../ui/public/styles.ts'
+import { ScrollRestorationDetail } from './public/scroll-restoration.tsx'
+
+export function ScrollRestorationPage(handle: Handle<{ newsletterHistory?: 'push' | 'replace' }>) {
+  return () => (
+    <Document title="Navigation scroll behavior" maxWidth="860px">
+      <a href={routes.home.href()} mix={linkStyle}>
+        ← Back to demos
+      </a>
+      <h1 mix={pageHeadingStyle}>Navigation scroll behavior</h1>
+      <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+        This page exercises native traversal restoration and explicit scroll preservation for new
+        push and replace navigations.
+      </p>
+
+      <section mix={[panelStyle, css({ margin: '20px 0' })]}>
+        <h2 mix={css({ marginTop: 0, fontSize: 18 })}>Traversal restoration</h2>
+        <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+          The tall list is rendered in a blocking frame with a hydrated client entry. Traversal
+          waits for that frame to finish reconciling before the browser restores scroll.
+        </p>
+        <ol mix={css({ marginBottom: 0, paddingLeft: 22, lineHeight: 1.7 })}>
+          <li>Scroll to the end of the list and open the detail page.</li>
+          <li>Scroll partway down the detail page, then use the browser Back button.</li>
+          <li>Confirm this page returns to the end of the list.</li>
+        </ol>
+      </section>
+
+      <Frame src={routes.frames.scrollRestorationItems.href()} />
+
+      <section
+        id="scroll-restoration-list-end"
+        mix={css({
+          border: '1px solid rgba(255,255,255,0.16)',
+          borderRadius: 12,
+          padding: 20,
+          marginTop: 20,
+          background: 'rgba(129,140,248,0.12)',
+        })}
+      >
+        <h2 mix={css({ marginTop: 0, fontSize: 20 })}>End of the list</h2>
+        <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+          Note <code>window.scrollY</code>, open the detail page, and return with the browser Back
+          button.
+        </p>
+        <a
+          id="scroll-restoration-detail-link"
+          href={routes.scrollRestorationDetail.href()}
+          mix={css({ color: '#ffffff', fontWeight: 700, textDecoration: 'underline' })}
+        >
+          Open the shorter detail page →
+        </a>
+      </section>
+
+      <NewsletterSignup history={handle.props.newsletterHistory} />
+    </Document>
+  )
+}
+
+function NewsletterSignup(handle: Handle<{ history?: 'push' | 'replace' }>) {
+  return () => (
+    <section
+      aria-labelledby="newsletter-heading"
+      mix={[
+        panelStyle,
+        css({
+          marginTop: 20,
+          padding: 20,
+          background: 'rgba(34,197,94,0.08)',
+        }),
+      ]}
+    >
+      <h2 id="newsletter-heading" mix={css({ marginTop: 0, fontSize: 20 })}>
+        Newsletter form navigation
+      </h2>
+      <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+        This form submits to another URL and redirects back here. Both buttons preserve the current
+        scroll position with <code>data-rmx-reset-scroll="false"</code>; they differ only in whether the
+        navigation pushes or replaces the history entry.
+      </p>
+
+      {handle.props.history ? (
+        <p
+          role="status"
+          mix={css({
+            border: '1px solid rgba(34,197,94,0.45)',
+            borderRadius: 10,
+            padding: 12,
+            color: '#bbf7d0',
+            background: 'rgba(34,197,94,0.12)',
+          })}
+        >
+          Subscribed using a <strong>{handle.props.history}</strong> navigation. The form stayed in
+          view after the redirect.
+        </p>
+      ) : null}
+
+      <form
+        method="post"
+        action={routes.newsletterSignup.href()}
+        data-rmx-reset-scroll="false"
+        mix={css({ display: 'grid', gap: 12 })}
+      >
+        <label for="newsletter-email" mix={css({ display: 'grid', gap: 6 })}>
+          <span mix={css({ fontWeight: 700 })}>Email address</span>
+          <input
+            id="newsletter-email"
+            name="email"
+            type="email"
+            autocomplete="email"
+            required
+            placeholder="you@example.com"
+            mix={css({
+              width: '100%',
+              maxWidth: 420,
+              boxSizing: 'border-box',
+              border: '1px solid rgba(255,255,255,0.2)',
+              borderRadius: 10,
+              padding: '10px 12px',
+              color: '#e9eefc',
+              background: 'rgba(255,255,255,0.06)',
+            })}
+          />
+        </label>
+        <div mix={css({ display: 'flex', flexWrap: 'wrap', gap: 10 })}>
+          <button
+            type="submit"
+            name="history"
+            value="push"
+            data-rmx-history="push"
+            mix={newsletterButtonStyle}
+          >
+            Subscribe with push
+          </button>
+          <button
+            type="submit"
+            name="history"
+            value="replace"
+            data-rmx-history="replace"
+            mix={newsletterButtonStyle}
+          >
+            Subscribe with replace
+          </button>
+        </div>
+      </form>
+      <p mix={css({ marginBottom: 0, color: '#9aa8e8', fontSize: 14, lineHeight: 1.5 })}>
+        After a push, Back returns to the previous entry. A replace updates the current entry
+        instead. Neither submission should jump to the top of this page.
+      </p>
+    </section>
+  )
+}
+
+const newsletterButtonStyle = css({
+  border: '1px solid rgba(255,255,255,0.2)',
+  borderRadius: 10,
+  padding: '10px 14px',
+  color: '#ffffff',
+  background: 'rgba(129,140,248,0.35)',
+  cursor: 'pointer',
+  fontWeight: 700,
+  '&:hover': { background: 'rgba(129,140,248,0.5)' },
+  '&:focus-visible': { outline: '2px solid #a5b4fc', outlineOffset: 2 },
+})
+
+export function ScrollRestorationDetailPage() {
+  return () => (
+    <Document title="Scroll restoration detail" maxWidth="860px">
+      <a href={routes.scrollRestoration.href()} mix={linkStyle}>
+        ← Return with a new navigation
+      </a>
+      <h1 mix={pageHeadingStyle}>Shorter detail document</h1>
+      <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
+        Scroll down this page, note <code>window.scrollY</code>, then use the browser Back button.
+        The link above starts a new navigation and does not test traversal restoration.
+      </p>
+      <ScrollRestorationDetail />
+    </Document>
+  )
+}

--- a/demos/frames/app/actions/scroll-restoration.tsx
+++ b/demos/frames/app/actions/scroll-restoration.tsx
@@ -1,9 +1,9 @@
-import { Frame, css, type Handle } from 'remix/ui'
+import { css, type Handle } from 'remix/ui'
 
 import { routes } from '../routes.ts'
 import { Document } from '../ui/document.tsx'
 import { leadStyle, linkStyle, pageHeadingStyle, panelStyle } from '../ui/public/styles.ts'
-import { ScrollRestorationDetail } from './public/scroll-restoration.tsx'
+import { StoreScrollReproduction } from './public/scroll-restoration.tsx'
 
 export function ScrollRestorationPage(handle: Handle<{ newsletterHistory?: 'push' | 'replace' }>) {
   return () => (
@@ -13,24 +13,11 @@ export function ScrollRestorationPage(handle: Handle<{ newsletterHistory?: 'push
       </a>
       <h1 mix={pageHeadingStyle}>Navigation scroll behavior</h1>
       <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
-        This page exercises native traversal restoration and explicit scroll preservation for new
-        push and replace navigations.
+        This mirrors the store issue: a top-level client entry switches between a short detail and a
+        tall collection rendered by a blocking frame.
       </p>
 
-      <section mix={[panelStyle, css({ margin: '20px 0' })]}>
-        <h2 mix={css({ marginTop: 0, fontSize: 18 })}>Traversal restoration</h2>
-        <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
-          The tall list is rendered in a blocking frame with a hydrated client entry. Traversal
-          waits for that frame to finish reconciling before the browser restores scroll.
-        </p>
-        <ol mix={css({ marginBottom: 0, paddingLeft: 22, lineHeight: 1.7 })}>
-          <li>Scroll to the end of the list and open the detail page.</li>
-          <li>Scroll partway down the detail page, then use the browser Back button.</li>
-          <li>Confirm this page returns to the end of the list.</li>
-        </ol>
-      </section>
-
-      <Frame src={routes.frames.scrollRestorationItems.href()} />
+      <StoreScrollReproduction variant="list" />
 
       <section
         id="scroll-restoration-list-end"
@@ -169,16 +156,17 @@ const newsletterButtonStyle = css({
 
 export function ScrollRestorationDetailPage() {
   return () => (
-    <Document title="Scroll restoration detail" maxWidth="860px">
-      <a href={routes.scrollRestoration.href()} mix={linkStyle}>
-        ← Return with a new navigation
+    <Document title="Navigation scroll behavior" maxWidth="860px">
+      <a href={routes.home.href()} mix={linkStyle}>
+        ← Back to demos
       </a>
-      <h1 mix={pageHeadingStyle}>Shorter detail document</h1>
+      <h1 mix={pageHeadingStyle}>Navigation scroll behavior</h1>
       <p mix={[leadStyle, css({ lineHeight: 1.6 })]}>
-        Scroll down this page, note <code>window.scrollY</code>, then use the browser Back button.
-        The link above starts a new navigation and does not test traversal restoration.
+        This mirrors the store issue: a top-level client entry switches between a short detail and a
+        tall collection rendered by a blocking frame.
       </p>
-      <ScrollRestorationDetail />
+
+      <StoreScrollReproduction variant="detail" />
     </Document>
   )
 }

--- a/demos/frames/app/router.test.ts
+++ b/demos/frames/app/router.test.ts
@@ -57,6 +57,18 @@ describe('router', () => {
     assert.equal(response.status, 200)
     assert.match(await response.text(), /Reload top frame/)
   })
+
+  it('redirects newsletter submissions back to the scroll-preservation example', async () => {
+    let response = await router.fetch(
+      new Request('http://localhost/scroll-restoration/newsletter', {
+        method: 'POST',
+        body: new URLSearchParams({ email: 'reader@example.com', history: 'push' }),
+      }),
+    )
+
+    assert.equal(response.status, 303)
+    assert.equal(response.headers.get('Location'), '/scroll-restoration?newsletter=push')
+  })
 })
 
 async function* readChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string, void, void> {

--- a/demos/frames/app/routes.ts
+++ b/demos/frames/app/routes.ts
@@ -1,4 +1,4 @@
-import { get, route } from 'remix/routes'
+import { get, post, route } from 'remix/routes'
 
 export const assetsBase = '/assets'
 
@@ -8,6 +8,9 @@ export const routes = route({
   time: get('/time'),
   reloadScope: get('/reload-scope'),
   rootReloadClientEntries: get('/root-reload-client-entries'),
+  scrollRestoration: get('/scroll-restoration'),
+  scrollRestorationDetail: get('/scroll-restoration/detail'),
+  newsletterSignup: post('/scroll-restoration/newsletter'),
   stateSearch: get('/state-search'),
   clientMounted: get('/client-mounted'),
   frames: route('frames', {
@@ -22,6 +25,7 @@ export const routes = route({
     time: get('/time'),
     reloadScope: get('/reload-scope'),
     reloadScopeBlocking: get('/reload-scope/blocking'),
+    scrollRestorationItems: get('/scroll-restoration-items'),
     stateSearchResults: get('/state-search-results'),
   }),
 })

--- a/packages/ui/.changes/patch.form-navigation-jsx-attributes.md
+++ b/packages/ui/.changes/patch.form-navigation-jsx-attributes.md
@@ -1,0 +1,1 @@
+Add a JSX prop type for `data-rmx-history` on submit buttons.

--- a/packages/ui/.changes/patch.form-navigation-jsx-attributes.md
+++ b/packages/ui/.changes/patch.form-navigation-jsx-attributes.md
@@ -1,1 +1,1 @@
-Add a JSX prop type for `data-rmx-history` on submit buttons.
+Add a JSX prop type for `data-rmx-history` on submit buttons and inputs.

--- a/packages/ui/.changes/patch.no-reset-scroll.md
+++ b/packages/ui/.changes/patch.no-reset-scroll.md
@@ -1,0 +1,1 @@
+Preserve the current scroll position for enhanced push and replace navigations that set `data-rmx-reset-scroll="false"`, including when a frame reload redirects.

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -2645,6 +2645,10 @@ export interface PartialInputHTMLProps<
   value?: Trackable<string | number | undefined>
   /** The `width` HTML attribute. */
   width?: Trackable<number | string | undefined>
+
+  // Non-standard Attributes
+  /** Overrides how this input's form submission updates the current history entry. */
+  'data-rmx-history'?: Trackable<'push' | 'replace' | undefined>
 }
 
 export type InputAriaRoles =

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -2065,6 +2065,10 @@ export interface ButtonHTMLProps<
   type?: Trackable<'submit' | 'reset' | 'button' | undefined>
   /** The `value` HTML attribute. */
   value?: Trackable<string | number | undefined>
+
+  // Non-standard Attributes
+  /** Overrides how this button's form submission updates the current history entry. */
+  'data-rmx-history'?: Trackable<'push' | 'replace' | undefined>
 }
 
 /**

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -36,6 +36,7 @@ interface FormSubmissionNavigationInfo {
 
 interface FrameRedirectNavigationInfo {
   type: typeof frameRedirectNavigationInfoType
+  resetScroll: boolean
 }
 
 const formSubmissionNavigationInfoType = 'frame-form-submission'
@@ -108,7 +109,14 @@ export function startNavigationListenerImpl(
       if (!event.canIntercept || isCrossOriginDestination(event)) return
 
       if (isFrameRedirectNavigationInfo(event.info)) {
-        event.intercept({ async handler() {} })
+        event.intercept({
+          ...getScrollInterceptionOptions(event, event.info.resetScroll),
+          async handler() {
+            if (!event.signal.aborted && event.info.resetScroll) {
+              window.scrollTo(0, 0)
+            }
+          },
+        })
         return
       }
 
@@ -141,7 +149,7 @@ export function startNavigationListenerImpl(
           signal: event.signal,
         })
 
-        if (redirectedTo && frame === topFrame) {
+        if (redirectedTo !== undefined && frame === topFrame) {
           frame.src = redirectedTo
           // Start the successor navigation without awaiting it: this handler must settle before
           // the replacement navigation can finish.
@@ -150,13 +158,14 @@ export function startNavigationListenerImpl(
             state: { ...state, src: redirectedTo },
             info: {
               type: frameRedirectNavigationInfoType,
+              resetScroll: state.resetScroll,
             } satisfies FrameRedirectNavigationInfo,
           })
-        }
-
-        let isNewEntry = event.navigationType === 'push' || event.navigationType === 'replace'
-        if (state.resetScroll && isNewEntry) {
-          window.scrollTo(0, 0)
+        } else {
+          let isNewEntry = event.navigationType === 'push' || event.navigationType === 'replace'
+          if (!event.signal.aborted && state.resetScroll && isNewEntry) {
+            window.scrollTo(0, 0)
+          }
         }
       }
 
@@ -170,6 +179,7 @@ export function startNavigationListenerImpl(
           if (supportsPrecommit) {
             let interceptOptions: NavigationInterceptOptionsWithPrecommit = {
               handler,
+              ...getScrollInterceptionOptions(event, state.resetScroll),
               precommitHandler(controller) {
                 controller.redirect(event.destination.url, { history: 'replace' })
               },
@@ -194,14 +204,14 @@ export function startNavigationListenerImpl(
           }
         }
 
-        event.intercept({ handler })
+        event.intercept({ handler, ...getScrollInterceptionOptions(event, state.resetScroll) })
       } else {
         // <a>/<form method="get"> navigations
         if (runtimeNavigation.replaceHistory && event.cancelable) {
           event.preventDefault()
           navigation.navigate(event.destination.url, { history: 'replace', state })
         } else {
-          event.intercept({ handler })
+          event.intercept({ handler, ...getScrollInterceptionOptions(event, state.resetScroll) })
         }
       }
     },
@@ -211,6 +221,14 @@ export function startNavigationListenerImpl(
 
 function isRuntimeNavigation(info: unknown): info is NavigationState {
   return typeof info === 'object' && info != null && '$rmx' in info
+}
+
+function getScrollInterceptionOptions(
+  event: NavigateEvent,
+  resetScroll: boolean,
+): Partial<Pick<NavigationInterceptOptions, 'scroll'>> {
+  let isNewEntry = event.navigationType === 'push' || event.navigationType === 'replace'
+  return isNewEntry && !resetScroll ? { scroll: 'manual' } : {}
 }
 
 function isFormSubmissionNavigationInfo(value: unknown): value is FormSubmissionNavigationInfo {
@@ -231,7 +249,9 @@ function isFrameRedirectNavigationInfo(value: unknown): value is FrameRedirectNa
     typeof value === 'object' &&
     value != null &&
     'type' in value &&
-    value.type === frameRedirectNavigationInfoType
+    value.type === frameRedirectNavigationInfoType &&
+    'resetScroll' in value &&
+    typeof value.resetScroll === 'boolean'
   )
 }
 

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -285,6 +285,9 @@ describe('navigate', () => {
     })
 
     let entryCountBeforeNavigation = window.navigation.entries().length
+    let originalBodyHeight = document.body.style.height
+    document.body.style.height = '3000px'
+    window.scrollTo(0, 600)
     try {
       let redirected = waitForNavigationUrl(redirectedUrl.href)
       void navigate(requestedUrl.href).catch(() => {})
@@ -300,6 +303,7 @@ describe('navigate', () => {
         resetScroll: true,
         $rmx: true,
       })
+      expect(window.scrollY).toBe(0)
 
       await window.navigation.back().finished
       expect(topFrame.src).toBe(originalUrl)
@@ -312,6 +316,8 @@ describe('navigate', () => {
       if (window.location.href !== originalUrl) {
         await navigate(originalUrl, { history: 'replace' })
       }
+      document.body.style.height = originalBodyHeight
+      window.scrollTo(0, 0)
       controller.abort()
     }
   })
@@ -511,6 +517,67 @@ describe('form navigation', () => {
       expect(reload.mock.calls[0]?.arguments[0]?.method).toBe('post')
     } finally {
       if (didNavigate) await window.navigation.back().finished
+      controller.abort()
+    }
+  })
+
+  it('preserves scroll across POST frame redirects when reset is disabled', async () => {
+    let originalUrl = window.location.href
+    let requestedUrl = new URL(originalUrl)
+    requestedUrl.searchParams.set('form-navigation', 'requested')
+    let redirectedUrl = new URL(originalUrl)
+    redirectedUrl.searchParams.set('form-navigation', 'redirected')
+    let topFrame = { src: '' } as FrameHandle
+    let shouldRedirect = true
+    let reload = mock.fn(async (_options?: ResolveFrameOptions) => {
+      if (shouldRedirect) {
+        shouldRedirect = false
+        return {
+          signal: new AbortController().signal,
+          redirectedTo: redirectedUrl.href,
+        }
+      }
+      return { signal: new AbortController().signal }
+    })
+    let controller = new AbortController()
+    startNavigationListenerImpl(controller.signal, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: () => topFrame,
+      reloadFrame: (_frame, options) => reload(options),
+    })
+
+    let form = document.createElement('form')
+    form.action = requestedUrl.href
+    form.method = 'post'
+    form.setAttribute('data-rmx-reset-scroll', 'false')
+    document.body.append(form)
+
+    let originalBodyHeight = document.body.style.height
+    document.body.style.height = '3000px'
+    window.scrollTo(0, 600)
+    expect(window.scrollY).toBe(600)
+
+    let didNavigate = false
+    try {
+      let redirected = waitForNavigationUrl(redirectedUrl.href)
+      form.requestSubmit()
+      await redirected
+      didNavigate = true
+
+      expect(reload).toHaveBeenCalledTimes(1)
+      expect(reload.mock.calls[0]?.arguments[0]?.method).toBe('post')
+      expect(topFrame.src).toBe(redirectedUrl.href)
+      expect(window.navigation.currentEntry?.getState()).toEqual({
+        target: undefined,
+        src: redirectedUrl.href,
+        resetScroll: false,
+        $rmx: true,
+      })
+      expect(window.scrollY).toBe(600)
+    } finally {
+      if (didNavigate) await window.navigation.back().finished
+      document.body.style.height = originalBodyHeight
+      window.scrollTo(0, 0)
       controller.abort()
     }
   })


### PR DESCRIPTION
Enhanced navigations that set `data-rmx-reset-scroll="false"` should preserve the current scroll position. The Navigation API was still applying its default scrolling after the intercepted transition, and a top-frame redirect started a replacement navigation without carrying the original reset intent.

- Use `scroll: 'manual'` only for new push and replace navigations that opt out of resetting scroll.
- Carry `resetScroll` into the redirect successor navigation so POST frame redirects preserve the original form's intent.
- Keep the default top reset for redirects that do not opt out, and avoid scrolling aborted or superseded navigations.

This is stacked on the navigation scroll behavior demo in [#11733](https://github.com/remix-run/remix/pull/11733). [#11699](https://github.com/remix-run/remix/pull/11699) builds on this with the separate traversal reconciliation fix.

https://github.com/user-attachments/assets/d1e419eb-d5cf-49aa-ac58-99ecf69c1cc6

The Frames demo reproduction:

https://github.com/user-attachments/assets/68568c97-0af1-4cba-9bad-44031c883172
