### PR TITLE
Clarify form data upload middleware lifecycle

### DIFF
--- a/.agents/skills/remix/references/middleware-and-server.md
+++ b/.agents/skills/remix/references/middleware-and-server.md
@@ -73,6 +73,7 @@ let router = createRouter({ middleware })
 
 - Put fast exits early: `staticFiles()`, `cors()` preflight handling, and `cop()` when used
 - Parse request bodies before middleware that depends on them, such as `methodOverride()` and form field token extraction in `csrf()`
+- `formData()` parses eagerly and awaits custom upload handlers before downstream middleware runs. For protected uploads, run authentication first and place `requireAuth()` before `formData({ uploadHandler })` on the controller or action so anonymous requests cannot write files before rejection
 - Run `session()` before `csrf()` and before session-backed `auth()`
 - Add `asyncContext()` before helpers or shared code call `getContext()`
 - Keep route protection like `requireAuth()` as controller middleware or action middleware unless the entire app is private
@@ -81,7 +82,7 @@ let router = createRouter({ middleware })
 
 - **Session-backed HTML app** -> `compression()`, `staticFiles()`, optional `cop()`, `formData()`, `methodOverride()`, `session()`, optional `csrf()`, `asyncContext()`, `auth({ schemes })`
 - **Cross-origin API** -> `compression()`, `cors()`, optional `asyncContext()`, optional `auth({ schemes })`
-- **Upload flow** -> `compression()`, `staticFiles()`, `formData({ uploadHandler })`, then sessions, auth, and data-loading middleware as needed
+- **Protected upload flow** -> resolve sessions and auth without consuming the body, then use `requireAuth()`, `formData({ uploadHandler })`, and data-loading middleware on the protected controller or action
 - **Optional development HMR** -> keep `server.ts` as the child app server, add `hmr.ts` for `remix/node-hmr`, and proxy public requests through `createHmrReadyFetch()`
 
 ### Middleware with options
@@ -108,6 +109,8 @@ formData({
 ```
 
 Errors thrown or rejected by `uploadHandler` propagate directly. Catch domain-specific upload errors at the route boundary when they should become user-facing `Response` objects.
+
+`formData()` consumes form bodies before calling downstream middleware. Router middleware also runs when no route matches, so a router-level upload handler can write files for requests that later receive `401`, `403`, or `404` responses. Scope side-effecting upload handlers to the controller or action that owns the upload, after any authentication or authorization middleware. Storage writes are not rolled back automatically when later middleware or the action fails, so use temporary storage and cleanup when the workflow requires atomicity.
 
 ## Writing Custom Middleware
 

--- a/packages/form-data-middleware/README.md
+++ b/packages/form-data-middleware/README.md
@@ -17,9 +17,11 @@ npm i remix
 
 ## Usage
 
-Use the `formData()` middleware at the router level to parse `FormData` from the request body and make it available as `context.formData` (or `context.get(FormData)`).
+Use the `formData()` middleware at the router, controller, or action level to parse `FormData` from the request body and make it available as `context.formData` (or `context.get(FormData)`).
 
 When `formData()` runs successfully it always provides a `FormData` value. Requests that do not contain a form body, including `GET` and `HEAD` requests, receive an empty `FormData`.
+
+`formData()` parses the request body eagerly. It finishes parsing the form, awaits every custom `uploadHandler`, and then runs downstream middleware and the action handler. Reading `context.formData` does not trigger parsing lazily.
 
 Uploaded files are available in the parsed `FormData` object. For a single file field, use `formData.get(name)`. For repeated file fields, use `formData.getAll(name)`.
 
@@ -45,25 +47,59 @@ router.post('/users', async (context) => {
 
 Use `context.formData` (or `context.get(FormData)`).
 
+### Middleware Ordering
+
+Router middleware runs before controller and action middleware, including when no route matches the request. A router-level `formData()` with an `uploadHandler` may therefore write uploaded files before downstream authentication or authorization middleware rejects the request. Those writes are not rolled back automatically.
+
+For protected uploads, resolve authentication without consuming the body, then put `requireAuth()` before `formData()` on the controller or action that accepts the upload:
+
+```ts
+import { requireAuth } from 'remix/middleware/auth'
+import { formData } from 'remix/middleware/form-data'
+
+router.post('/users/avatar', {
+  middleware: [
+    requireAuth(),
+    formData({
+      async uploadHandler(upload) {
+        return uploadStorage.put(crypto.randomUUID(), upload)
+      },
+    }),
+  ],
+  handler(context) {
+    let avatar = context.formData.get('avatar')
+    return Response.json({ uploaded: avatar != null })
+  },
+})
+```
+
+This example assumes an earlier `auth()` middleware has populated `context.auth`. Put any authorization checks that do not need the form body before `formData()` as well. If authorization depends on parsed form fields, write uploads to temporary storage and promote them only after authorization succeeds. Also set multipart size limits, rate-limit upload endpoints as appropriate, and clean up temporary files when downstream work fails.
+
 ### Custom File Upload Handler
 
 You can use a custom upload handler to customize how file uploads are handled. The return value of the upload handler will be used as the value of the form field in the `FormData` object.
 
-```ts
-import { formData } from 'remix/middleware/form-data'
-import { writeFile } from 'node:fs/promises'
+The multipart request is read incrementally, but each complete file part is buffered in memory before the upload handler receives its `FileUpload`. Returning a path or storage key prevents completed file contents from accumulating in the returned `FormData`, but it does not stream bytes directly from the request to storage.
 
-let router = createRouter({
+```ts
+import { requireAuth } from 'remix/middleware/auth'
+import { formData } from 'remix/middleware/form-data'
+import { createFsFileStorage } from 'remix/file-storage/fs'
+
+let uploadStorage = createFsFileStorage('./uploads')
+
+router.post('/users/avatar', {
   middleware: [
+    requireAuth(),
     formData({
       async uploadHandler(upload) {
-        // Save to disk and return path
-        let path = `./uploads/${upload.name}`
-        await writeFile(path, Buffer.from(await upload.arrayBuffer()))
-        return path
+        return uploadStorage.put(crypto.randomUUID(), upload)
       },
     }),
   ],
+  handler(context) {
+    return Response.json({ uploaded: context.formData.has('avatar') })
+  },
 })
 ```
 

--- a/packages/form-data-parser/README.md
+++ b/packages/form-data-parser/README.md
@@ -1,11 +1,11 @@
 # form-data-parser
 
-A streaming `multipart/form-data` parser that solves memory issues with file uploads in server environments. Built as an enhanced replacement for the native `request.formData()` API, it enables efficient handling of large file uploads by streaming directly to disk or cloud storage services like [AWS S3](https://aws.amazon.com/s3/) or [Cloudflare R2](https://www.cloudflare.com/developer-platform/r2/), preventing server crashes from memory exhaustion.
+A `multipart/form-data` parser with configurable limits and custom file upload handling. It reads the request stream incrementally, buffers each complete file part, and lets you replace that file with a storage value in the returned `FormData`.
 
 ## Features
 
-- **Drop-in replacement** for `request.formData()` with streaming file upload support
-- **Minimal buffering** - processes file upload streams with minimal memory footprint
+- **Drop-in replacement** for `request.formData()` with custom file upload handling
+- **Bounded parsing** - configurable limits for files, parts, headers, and total content
 - **Standards-based** - built on the [web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) and [File API](https://developer.mozilla.org/en-US/docs/Web/API/File)
 - **Smart fallback** - parses `application/x-www-form-urlencoded` requests with the same total size and field count limits, and uses native `request.formData()` for other form requests
 - **Storage agnostic** - works with any storage backend (local disk, S3, R2, etc.)
@@ -22,7 +22,7 @@ In normal usage, this makes it difficult to process requests with large file upl
 
 For attackers, this creates an attack vector where malicious actors can overwhelm your server's memory by sending large payloads with many files.
 
-`form-data-parser` solves this by handling file uploads as they arrive in the request body stream, allowing you to safely store files and use either a) the `File` directly or b) a unique identifier for that file in the returned `FormData` object.
+`form-data-parser` applies configurable limits while reading the request body and passes each completed file to an upload handler. Each file is buffered in memory before the upload handler runs. The handler can store the file and return a path, key, or other `FormData` value so completed files do not remain in the returned `FormData`.
 
 ## Installation
 
@@ -58,8 +58,7 @@ async function uploadHandler(fileUpload: FileUpload) {
 
 // Handle form submissions with file uploads
 async function requestHandler(request: Request) {
-  // Parse the form data from the request.body stream, passing any files
-  // through your upload handler as they are parsed from the stream
+  // Parse the form data and pass each completed file to the upload handler
   let formData = await parseFormData(request, uploadHandler)
 
   let avatarFilename = formData.get('user-avatar')


### PR DESCRIPTION
Clarify when form bodies and file uploads are processed so applications can order authentication and other request checks safely.

- document that `formData()` eagerly parses and awaits upload handlers before downstream middleware
- warn that router-level upload handlers can run before controller auth and on unmatched routes
- show protected upload ordering with `requireAuth()` before `formData()`
- recommend temporary storage and cleanup for downstream failures
- correct the parser documentation to explain that each complete file part is buffered before custom handling