### PR TITLE
Fix reset scroll implementation and defer scrolling to the browser

### DIFF
--- a/packages/ui/.changes/patch.navigation-scroll.md
+++ b/packages/ui/.changes/patch.navigation-scroll.md
@@ -1,0 +1,1 @@
+Fix `data-rmx-reset-scroll="false"` and `navigate(..., { resetScroll: false })` to preserve the current scroll position. Default navigations now leave scroll resets and history restoration to the browser.

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -36,6 +36,7 @@ interface FormSubmissionNavigationInfo {
 
 interface FrameRedirectNavigationInfo {
   type: typeof frameRedirectNavigationInfoType
+  resetScroll: boolean
 }
 
 const formSubmissionNavigationInfoType = 'frame-form-submission'
@@ -108,7 +109,10 @@ export function startNavigationListenerImpl(
       if (!event.canIntercept || isCrossOriginDestination(event)) return
 
       if (isFrameRedirectNavigationInfo(event.info)) {
-        event.intercept({ async handler() {} })
+        event.intercept({
+          async handler() {},
+          scroll: event.info.resetScroll === false ? 'manual' : undefined,
+        })
         return
       }
 
@@ -150,15 +154,16 @@ export function startNavigationListenerImpl(
             state: { ...state, src: redirectedTo },
             info: {
               type: frameRedirectNavigationInfoType,
+              resetScroll: state.resetScroll,
             } satisfies FrameRedirectNavigationInfo,
           })
         }
-
-        let isNewEntry = event.navigationType === 'push' || event.navigationType === 'replace'
-        if (state.resetScroll && isNewEntry) {
-          window.scrollTo(0, 0)
-        }
       }
+
+      let interceptOptions = {
+        handler,
+        scroll: state.resetScroll === false ? 'manual' : undefined,
+      } satisfies NavigationInterceptOptions
 
       if (runtimeNavigation.getSubmission) {
         // <form method="post"> navigations
@@ -168,13 +173,13 @@ export function startNavigationListenerImpl(
 
           // Modern browsers allow you to update the in-flight navigation entry before it's committed
           if (supportsPrecommit) {
-            let interceptOptions: NavigationInterceptOptionsWithPrecommit = {
-              handler,
+            let precommitInterceptOptions: NavigationInterceptOptionsWithPrecommit = {
+              ...interceptOptions,
               precommitHandler(controller) {
                 controller.redirect(event.destination.url, { history: 'replace' })
               },
             }
-            event.intercept(interceptOptions)
+            event.intercept(precommitInterceptOptions)
             return
           }
 
@@ -194,14 +199,14 @@ export function startNavigationListenerImpl(
           }
         }
 
-        event.intercept({ handler })
+        event.intercept(interceptOptions)
       } else {
         // <a>/<form method="get"> navigations
         if (runtimeNavigation.replaceHistory && event.cancelable) {
           event.preventDefault()
           navigation.navigate(event.destination.url, { history: 'replace', state })
         } else {
-          event.intercept({ handler })
+          event.intercept(interceptOptions)
         }
       }
     },
@@ -231,7 +236,9 @@ function isFrameRedirectNavigationInfo(value: unknown): value is FrameRedirectNa
     typeof value === 'object' &&
     value != null &&
     'type' in value &&
-    value.type === frameRedirectNavigationInfoType
+    value.type === frameRedirectNavigationInfoType &&
+    'resetScroll' in value &&
+    typeof value.resetScroll === 'boolean'
   )
 }
 

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -173,13 +173,12 @@ export function startNavigationListenerImpl(
 
           // Modern browsers allow you to update the in-flight navigation entry before it's committed
           if (supportsPrecommit) {
-            let precommitInterceptOptions: NavigationInterceptOptionsWithPrecommit = {
+            event.intercept({
               ...interceptOptions,
               precommitHandler(controller) {
                 controller.redirect(event.destination.url, { history: 'replace' })
               },
-            }
-            event.intercept(precommitInterceptOptions)
+            })
             return
           }
 

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -39,6 +39,26 @@ function stubGlobalField(t: TestContext, name: string, value: unknown): void {
   })
 }
 
+function startStubNavigationListener(t: TestContext): (event: Event) => void {
+  let navigateListener: EventListener | undefined
+  let stubNavigation = {
+    updateCurrentEntry: mock.fn(),
+    addEventListener(type: string, listener: EventListener) {
+      if (type === 'navigate') navigateListener = listener
+    },
+  }
+  stubGlobalField(t, 'navigation', stubNavigation)
+
+  let controller = new AbortController()
+  startNavigationListenerImpl(controller.signal, stubFrames)
+  t.after(() => controller.abort())
+
+  return (event) => {
+    if (!navigateListener) throw new Error('Expected a navigate listener')
+    navigateListener(event)
+  }
+}
+
 describe('navigate', () => {
   afterEach(() => {
     document.body.textContent = ''
@@ -74,6 +94,84 @@ describe('navigate', () => {
       state: { target: undefined, src: '/login', resetScroll: false, $rmx: true },
       history: undefined,
     })
+  })
+
+  it('leaves default scrolling to the browser', async (t) => {
+    let dispatchNavigation = startStubNavigationListener(t)
+    let scrollTo = t.mock.method(window, 'scrollTo', () => {})
+    let anchor = document.createElement('a')
+    anchor.href = '/login'
+    let intercept = mock.fn()
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept,
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+
+    let interceptOptions = intercept.mock.calls[0]?.arguments[0]
+    expect(interceptOptions?.scroll).toBe(undefined)
+    await interceptOptions?.handler?.()
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('opts out of browser scrolling when data-rmx-reset-scroll is false', (t) => {
+    let dispatchNavigation = startStubNavigationListener(t)
+    let anchor = document.createElement('a')
+    anchor.href = '/login'
+    anchor.setAttribute('data-rmx-reset-scroll', 'false')
+    let intercept = mock.fn()
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept,
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+
+    expect(intercept.mock.calls[0]?.arguments[0]?.scroll).toBe('manual')
+  })
+
+  it('opts out of browser scroll restoration on traverse navigations', (t) => {
+    let dispatchNavigation = startStubNavigationListener(t)
+    let intercept = mock.fn()
+    let event = Object.assign(new Event('navigate'), {
+      canIntercept: true,
+      navigationType: 'traverse',
+      signal: new AbortController().signal,
+      destination: {
+        url: new URL('/previous', window.location.origin).href,
+        getState: () => ({
+          target: undefined,
+          src: '/previous',
+          resetScroll: false,
+          $rmx: true,
+        }),
+      },
+      intercept,
+    })
+
+    dispatchNavigation(event)
+
+    expect(intercept.mock.calls[0]?.arguments[0]?.scroll).toBe('manual')
+  })
+
+  it('preserves manual scrolling across frame redirects', (t) => {
+    let dispatchNavigation = startStubNavigationListener(t)
+    let intercept = mock.fn()
+    let event = Object.assign(new Event('navigate'), {
+      canIntercept: true,
+      destination: {
+        url: new URL('/redirected', window.location.origin).href,
+      },
+      info: { type: 'frame-redirect', resetScroll: false },
+      intercept,
+    })
+
+    dispatchNavigation(event)
+
+    expect(intercept.mock.calls[0]?.arguments[0]?.scroll).toBe('manual')
   })
 
   it('does not intercept anchors marked for document navigation', (t) => {
@@ -777,6 +875,27 @@ function createFormNavigateEvent(
     navigationType: 'push',
     sourceElement: form,
     formData: new FormData(form),
+    signal: new AbortController().signal,
+    destination: {
+      url: options.destinationUrl,
+      key: 'next',
+      getState: () => undefined,
+    },
+    intercept: options.intercept,
+  })
+}
+
+function createAnchorNavigateEvent(
+  anchor: HTMLAnchorElement,
+  options: {
+    intercept: (options?: NavigationInterceptOptions) => void
+    destinationUrl: string
+  },
+): Event {
+  return Object.assign(new Event('navigate'), {
+    canIntercept: true,
+    navigationType: 'push',
+    sourceElement: anchor,
     signal: new AbortController().signal,
     destination: {
       url: options.destinationUrl,


### PR DESCRIPTION
Intercepted navigations already have browser-owned scroll behavior: push and replace navigations reset to their destination, while traverse navigations restore the destination entry's position. Remix was manually duplicating the new-entry reset without actually opting out when `data-rmx-reset-scroll="false"` or `resetScroll: false` was used.

This lets the browser retain ownership of the default behavior and translates the explicit `false` value into `scroll: 'manual'` on the Navigation API interception.

- Remove the redundant post-reload `window.scrollTo(0, 0)` reset.
- Apply `scroll: 'manual'` to link, form, precommit, and traverse interceptions that opt out of browser scrolling.
- Carry the scroll preference through replacement navigations created by top-frame redirects.
- Cover browser-default scrolling, attribute opt-outs, traversal opt-outs, and redirect successors.

Fixes #11617. This overlaps #11736 and the older #11644, but differs by treating `false` as an opt-out from traversal restoration as well as push/replace resets and by leaving all default scroll behavior to the browser.
