### PR TITLE
Add a module database adapter to remix.json

### DIFF
--- a/packages/cli/.changes/minor.module-database-adapter.md
+++ b/packages/cli/.changes/minor.module-database-adapter.md
@@ -1,0 +1,19 @@
+Added a `type: "module"` database adapter to `remix.json`, so `remix db` can drive databases the CLI does not ship an adapter for, such as Turso/libSQL or Cloudflare D1. Previously `db.adapter.type` accepted only `sqlite`, `postgres`, and `mysql`, and third-party databases had to reimplement the command instead.
+
+```jsonc
+{
+  "db": {
+    "adapter": {
+      "type": "module",
+      "module": "./app/database.ts",
+      "export": "createDatabase",
+      "connection": { "env": "DATABASE_URL" },
+      "options": { "syncInterval": 60 },
+    },
+  },
+}
+```
+
+The module exports a factory that receives `{ configDir, connection, options }` and returns a `Database`; the CLI closes it when the command finishes. `export` defaults to the default export, `connection` resolves like other adapters' connection values and is overridden by `--connection-env`, and `options` is passed through unchanged. Relative `module` specifiers resolve from `remix.json` and bare specifiers resolve from the app, so a database package installed by the app is reachable. Type the factory with the new `RemixDbModuleFactory` and `RemixDbModuleContext` exports.
+
+Two new errors report module problems: `RMX_DB_MODULE_NOT_FOUND` when the module cannot be imported, and `RMX_DB_MODULE_FACTORY_REQUIRED` when the named export is not a function.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -185,14 +185,37 @@ configured arrays, while nested Playwright and coverage settings merge by field.
 globs are resolved from the directory containing the config file. Use `remix doctor --no-strict` to
 disable configured strict mode for one run.
 
-`remix db` requires `db.adapter`. Adapters use `type: "sqlite"`, `type: "postgres"`, or
-`type: "mysql"`; PostgreSQL uses `connectionString` and MySQL uses `uri`. A connection value may be
-a string or an object naming an environment variable with an optional default. `db.seed` names a
-SQL file that `remix db seed` and `remix db reset` run against the database. Database flags such as
-`--migrations`, `--seed`, `--journal-table`, and `--connection-env` override the corresponding
-config for one invocation. Rollbacks also accept `--step`, `--to`, and `--dry-run`. When no global
-`--config` is provided, database commands find the nearest `remix.json` by walking up from the
-working directory.
+`remix db` requires `db.adapter`. Adapters use `type: "sqlite"`, `type: "postgres"`,
+`type: "mysql"`, or `type: "module"`; PostgreSQL uses `connectionString` and MySQL uses `uri`. A
+connection value may be a string or an object naming an environment variable with an optional
+default. `db.seed` names a SQL file that `remix db seed` and `remix db reset` run against the
+database. Database flags such as `--migrations`, `--seed`, `--journal-table`, and `--connection-env`
+override the corresponding config for one invocation. Rollbacks also accept `--step`, `--to`, and
+`--dry-run`. When no global `--config` is provided, database commands find the nearest `remix.json`
+by walking up from the working directory.
+
+A `type: "module"` adapter names a `module` that exports a database factory, so databases the CLI
+does not ship an adapter for — Turso/libSQL or Cloudflare D1, for example — can still run
+`remix db`:
+
+```jsonc
+{
+  "db": {
+    "adapter": {
+      "type": "module",
+      "module": "./app/database.ts",
+      "export": "createDatabase",
+      "connection": { "env": "DATABASE_URL" },
+      "options": { "syncInterval": 60 },
+    },
+  },
+}
+```
+
+Relative `module` specifiers resolve from `remix.json`, and bare specifiers resolve from the app.
+`export` defaults to the default export. The factory receives `{ configDir, connection, options }`
+and returns a `Database`, which the CLI closes when the command finishes. Type the factory with
+`RemixDbModuleFactory` from `remix/cli`.
 
 Use the global `--config` option to select another JSONC file. The option itself is resolved from the
 CLI working directory and may appear before or after the command:

--- a/packages/cli/schema/remix.json
+++ b/packages/cli/schema/remix.json
@@ -78,7 +78,8 @@
           "oneOf": [
             { "$ref": "#/$defs/dbSqliteAdapter" },
             { "$ref": "#/$defs/dbPostgresAdapter" },
-            { "$ref": "#/$defs/dbMysqlAdapter" }
+            { "$ref": "#/$defs/dbMysqlAdapter" },
+            { "$ref": "#/$defs/dbModuleAdapter" }
           ]
         },
         "migrations": {
@@ -124,6 +125,27 @@
         "connectionString": { "$ref": "#/$defs/dbString" },
         "maintenanceDatabase": { "type": "string" },
         "template": { "type": "string" }
+      }
+    },
+    "dbModuleAdapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "module"],
+      "properties": {
+        "type": { "const": "module" },
+        "module": {
+          "type": "string",
+          "description": "Module specifier exporting a database factory. Relative paths resolve from this file."
+        },
+        "export": {
+          "type": "string",
+          "description": "Name of the exported factory. Defaults to the default export."
+        },
+        "connection": { "$ref": "#/$defs/dbString" },
+        "options": {
+          "type": "object",
+          "description": "Values passed through to the database factory."
+        }
       }
     },
     "dbMysqlAdapter": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 export { runRemix, type RunRemixOptions } from './lib/cli.ts'
+export type { RemixDbModuleContext, RemixDbModuleFactory } from './lib/db-module.ts'
 export {
   loadConfig,
   type RemixAssetsConfig,

--- a/packages/cli/src/lib/commands/db.test.ts
+++ b/packages/cli/src/lib/commands/db.test.ts
@@ -267,6 +267,24 @@ describe('db command', () => {
     }
   })
 
+  it('creates a database from a module adapter', async () => {
+    let projectDir = await createModuleDatabaseProject()
+
+    try {
+      let migrate = await captureOutput(() => runRemix(['db', 'migrate'], { cwd: projectDir }))
+      assert.equal(migrate.exitCode, 0, migrate.stderr)
+      assert.match(migrate.stdout, /applied 20260715120000_create_first/)
+      assert.ok(readTableNames(projectDir).includes('first_table'))
+
+      let context = await readModuleContext(projectDir)
+      assert.equal(context.configDir, projectDir)
+      assert.equal(context.connection, './database.sqlite')
+      assert.deepEqual(context.options, { label: 'from-config' })
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
+  })
+
   it('bounds a rollback with --step, --to, and --dry-run', async () => {
     let projectDir = await createDatabaseProject({ reversible: true })
 
@@ -299,6 +317,36 @@ describe('db command', () => {
       assert.match(both.stdout, /reverted 20260715130000_create_second/)
       assert.match(both.stdout, /reverted 20260715120000_create_first/)
     } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('calls the default export of a module adapter and overrides its connection', async () => {
+    let projectDir = await createModuleDatabaseProject({
+      adapter: { type: 'module', module: './app/database.ts' },
+    })
+    let previous = process.env.REMIX_TEST_DATABASE
+    process.env.REMIX_TEST_DATABASE = './override.sqlite'
+
+    try {
+      let result = await captureOutput(() =>
+        runRemix(['db', 'migrate', '--connection-env', 'REMIX_TEST_DATABASE'], { cwd: projectDir }),
+      )
+      assert.equal(result.exitCode, 0, result.stderr)
+
+      let context = await readModuleContext(projectDir)
+      assert.equal(context.connection, './override.sqlite')
+      assert.equal(context.options, undefined)
+
+      let sqlite = new DatabaseSync(path.join(projectDir, 'override.sqlite'))
+      let table = sqlite
+        .prepare("select name from sqlite_master where type = 'table' and name = 'first_table'")
+        .get()
+      sqlite.close()
+      assert.ok(table)
+    } finally {
+      if (previous === undefined) delete process.env.REMIX_TEST_DATABASE
+      else process.env.REMIX_TEST_DATABASE = previous
       await fs.rm(projectDir, { recursive: true, force: true })
     }
   })
@@ -345,6 +393,30 @@ describe('db command', () => {
     }
   })
 
+  it('reports module adapters that cannot be imported or do not export a factory', async () => {
+    let missingModule = await createModuleDatabaseProject({
+      adapter: { type: 'module', module: './app/missing.ts' },
+    })
+    let missingExport = await createModuleDatabaseProject({
+      adapter: { type: 'module', module: './app/database.ts', export: 'createTursoDatabase' },
+    })
+
+    try {
+      let notFound = await captureOutput(() => runRemix(['db', 'status'], { cwd: missingModule }))
+      assert.equal(notFound.exitCode, 1)
+      assert.match(notFound.stderr, /RMX_DB_MODULE_NOT_FOUND/)
+      assert.match(notFound.stderr, /\.\/app\/missing\.ts/)
+
+      let noFactory = await captureOutput(() => runRemix(['db', 'status'], { cwd: missingExport }))
+      assert.equal(noFactory.exitCode, 1)
+      assert.match(noFactory.stderr, /RMX_DB_MODULE_FACTORY_REQUIRED/)
+      assert.match(noFactory.stderr, /"createTursoDatabase"/)
+    } finally {
+      await fs.rm(missingModule, { recursive: true, force: true })
+      await fs.rm(missingExport, { recursive: true, force: true })
+    }
+  })
+
   it('reports unknown subcommands and invalid command options', async () => {
     let unknown = await captureOutput(() => runRemix(['db', 'wat']))
     let invalid = await captureOutput(() => runRemix(['db', 'migrate', '--seed', './seed.sql']))
@@ -371,6 +443,69 @@ function countSeededRows(projectDir: string): number {
   let row = sqlite.prepare('select count(*) as count from seeded').get()
   sqlite.close()
   return Number(row?.count)
+}
+
+async function readModuleContext(projectDir: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(path.join(projectDir, 'module-context.json'), 'utf8'))
+}
+
+async function createModuleDatabaseProject(
+  options: { adapter?: Record<string, unknown> } = {},
+): Promise<string> {
+  let projectDir = await createDatabaseProject()
+  let sqliteModule = import.meta.resolve('@remix-run/data-table-sqlite')
+
+  await fs.writeFile(
+    path.join(projectDir, 'app/database.ts'),
+    [
+      "import { writeFileSync } from 'node:fs'",
+      "import * as path from 'node:path'",
+      '',
+      `import { createSqliteDatabase } from '${sqliteModule}'`,
+      '',
+      'export function createDatabase(context) {',
+      '  writeFileSync(',
+      "    path.join(context.configDir, 'module-context.json'),",
+      '    JSON.stringify({',
+      '      configDir: context.configDir,',
+      '      connection: context.connection,',
+      '      options: context.options,',
+      '    }),',
+      "    'utf8',",
+      '  )',
+      '  return createSqliteDatabase({',
+      "    filename: path.resolve(context.configDir, context.connection ?? './database.sqlite'),",
+      '  })',
+      '}',
+      '',
+      'export default createDatabase',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+
+  await fs.writeFile(
+    path.join(projectDir, 'remix.json'),
+    JSON.stringify(
+      {
+        db: {
+          adapter: options.adapter ?? {
+            type: 'module',
+            module: './app/database.ts',
+            export: 'createDatabase',
+            connection: './database.sqlite',
+            options: { label: 'from-config' },
+          },
+          migrations: { directory: './db/migrations' },
+          seed: './db/seed.sql',
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+  return projectDir
 }
 
 async function createDatabaseProject(

--- a/packages/cli/src/lib/commands/db.ts
+++ b/packages/cli/src/lib/commands/db.ts
@@ -8,6 +8,7 @@ import { loadMigrations, loadSeed } from '@remix-run/data-table/migrations/node'
 
 import { findAppRoot } from '../app-root.ts'
 import type { CliContext } from '../cli-context.ts'
+import { createModuleDatabase } from '../db-module.ts'
 import {
   isDatabaseCommand,
   type DatabaseCommandInvocation,
@@ -299,6 +300,9 @@ function overrideConnection(
   if (adapter.type === 'postgres') {
     return { ...adapter, connectionString: { env: environmentName } }
   }
+  if (adapter.type === 'module') {
+    return { ...adapter, connection: { env: environmentName } }
+  }
   return { ...adapter, uri: { env: environmentName } }
 }
 
@@ -415,6 +419,14 @@ async function createConfiguredDatabase(
       foreignKeys: adapter.foreignKeys,
       busyTimeout: adapter.busyTimeout,
     })
+  }
+
+  if (adapter.type === 'module') {
+    return createModuleDatabase(
+      adapter,
+      configDir,
+      adapter.connection === undefined ? undefined : resolveDbString(adapter.connection),
+    )
   }
 
   if (adapter.type === 'postgres') {

--- a/packages/cli/src/lib/db-module.ts
+++ b/packages/cli/src/lib/db-module.ts
@@ -1,0 +1,91 @@
+import { createRequire } from 'node:module'
+import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import type { Database } from '@remix-run/data-table'
+
+import { dbModuleFactoryRequired, dbModuleNotFound } from './errors.ts'
+import type { RemixDbAdapterConfig } from './remix-config.ts'
+
+export type RemixDbModuleAdapterConfig = Extract<RemixDbAdapterConfig, { type: 'module' }>
+
+/**
+ * Values a `db.adapter` module receives when the Remix CLI asks it for a
+ * database.
+ */
+export interface RemixDbModuleContext {
+  /** Directory that contains the `remix.json` naming the module. */
+  configDir: string
+  /**
+   * Connection value resolved from `db.adapter.connection` or the
+   * `--connection-env` option. Undefined when neither is configured.
+   */
+  connection?: string
+  /** Values passed through from `db.adapter.options`. */
+  options?: Record<string, unknown>
+}
+
+/**
+ * Database factory a `db.adapter` module exports so `remix db` can drive a
+ * database the CLI does not ship an adapter for.
+ *
+ * The CLI closes the returned database when the command finishes.
+ */
+export type RemixDbModuleFactory = (
+  context: RemixDbModuleContext,
+) => Database | PromiseLike<Database>
+
+/**
+ * Imports a `db.adapter` module and calls its database factory.
+ *
+ * @param adapter Module adapter configuration.
+ * @param configDir Directory that contains the `remix.json`.
+ * @param connection Connection value for the factory, if one is configured.
+ * @returns The database the module created.
+ */
+export async function createModuleDatabase(
+  adapter: RemixDbModuleAdapterConfig,
+  configDir: string,
+  connection: string | undefined,
+): Promise<Database> {
+  let specifier = resolveModuleSpecifier(adapter.module, configDir)
+  let exportName = adapter.export ?? 'default'
+  let namespace: Record<string, unknown>
+
+  try {
+    namespace = (await import(specifier)) as Record<string, unknown>
+  } catch (error) {
+    throw dbModuleNotFound(adapter.module, error)
+  }
+
+  let factory = namespace[exportName]
+  if (typeof factory !== 'function') {
+    throw dbModuleFactoryRequired(adapter.module, exportName)
+  }
+
+  return (factory as RemixDbModuleFactory)({
+    configDir,
+    connection,
+    options: adapter.options,
+  })
+}
+
+function resolveModuleSpecifier(specifier: string, configDir: string): string {
+  if (specifier.startsWith('.') || path.isAbsolute(specifier)) {
+    return pathToFileURL(path.resolve(configDir, specifier)).href
+  }
+
+  // Specifiers that already name a scheme, such as `file:`, `jsr:`, or `npm:`,
+  // are the runtime's to resolve.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(specifier)) return specifier
+
+  // Bare specifiers name a dependency of the app, not of the CLI, so resolve
+  // them from the config directory. Packages the CLI's own resolver can reach
+  // still load from the unresolved specifier.
+  try {
+    return pathToFileURL(createRequire(path.join(configDir, 'package.json')).resolve(specifier))
+      .href
+  } catch {
+    return specifier
+  }
+}

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -43,6 +43,16 @@ export const CLI_ERROR_DEFINITIONS = {
     title: 'Destructive database command requires --force',
     fix: 'Re-run with --force to confirm.',
   },
+  dbModuleFactoryRequired: {
+    code: 'RMX_DB_MODULE_FACTORY_REQUIRED',
+    title: 'Database module does not export a factory',
+    fix: 'Export a function that returns a Database, or name another export with db.adapter.export.',
+  },
+  dbModuleNotFound: {
+    code: 'RMX_DB_MODULE_NOT_FOUND',
+    title: 'Could not import the database module',
+    fix: 'Check db.adapter.module and make sure the module is installed.',
+  },
   remixVersionUnavailable: {
     code: 'RMX_REMIX_VERSION_UNAVAILABLE',
     title: 'Could not determine the Remix version',
@@ -216,6 +226,21 @@ export function dbForceRequired(command: string): UsageError {
   return createUsageError(CLI_ERROR_DEFINITIONS.dbForceRequired, {
     context: { command },
     message: `\`remix db ${command}\` destroys data in the current app database.`,
+  })
+}
+
+export function dbModuleFactoryRequired(specifier: string, exportName: string): CliError {
+  return createCliError(CLI_ERROR_DEFINITIONS.dbModuleFactoryRequired, {
+    context: { export: exportName, module: specifier },
+    message: `Database module ${specifier} does not export "${exportName}" as a function.`,
+  })
+}
+
+export function dbModuleNotFound(specifier: string, cause: unknown): CliError {
+  let details = cause instanceof Error ? cause.message : String(cause)
+  return createCliError(CLI_ERROR_DEFINITIONS.dbModuleNotFound, {
+    context: { details, module: specifier },
+    message: `Could not import database module ${specifier}: ${details}`,
   })
 }
 

--- a/packages/cli/src/lib/remix-config.test.ts
+++ b/packages/cli/src/lib/remix-config.test.ts
@@ -169,18 +169,70 @@ describe('Remix config loading', () => {
   })
 
   it('rejects unsupported database adapter types', async () => {
-    let cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-config-db-module-'))
+    let cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-config-db-unknown-'))
 
     try {
       await fs.writeFile(
         path.join(cwd, 'remix.json'),
-        JSON.stringify({ db: { adapter: { type: 'module', module: './app/database.ts' } } }),
+        JSON.stringify({ db: { adapter: { type: 'mongo', uri: 'mongodb://localhost' } } }),
         'utf8',
       )
 
       await assert.rejects(
         () => loadRemixConfig(cwd, undefined),
-        /Expected one of: sqlite, postgres, mysql at db\.adapter\.type/,
+        /Expected one of: sqlite, postgres, mysql, module at db\.adapter\.type/,
+      )
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('parses a module database configuration', async () => {
+    let cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-config-db-module-'))
+
+    try {
+      await fs.writeFile(
+        path.join(cwd, 'remix.json'),
+        JSON.stringify({
+          db: {
+            adapter: {
+              type: 'module',
+              module: './app/database.ts',
+              export: 'createDatabase',
+              connection: { env: 'DATABASE_URL', default: 'libsql://localhost' },
+              options: { authToken: { env: 'DATABASE_AUTH_TOKEN' } },
+            },
+          },
+        }),
+        'utf8',
+      )
+
+      let config = await loadRemixConfig(cwd, undefined)
+      assert.deepEqual(config.db?.adapter, {
+        type: 'module',
+        module: './app/database.ts',
+        export: 'createDatabase',
+        connection: { env: 'DATABASE_URL', default: 'libsql://localhost' },
+        options: { authToken: { env: 'DATABASE_AUTH_TOKEN' } },
+      })
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a module database configuration without a module', async () => {
+    let cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'remix-config-db-module-invalid-'))
+
+    try {
+      await fs.writeFile(
+        path.join(cwd, 'remix.json'),
+        JSON.stringify({ db: { adapter: { type: 'module' } } }),
+        'utf8',
+      )
+
+      await assert.rejects(
+        () => loadRemixConfig(cwd, undefined),
+        /Expected a string at db\.adapter\.module/,
       )
     } finally {
       await fs.rm(cwd, { recursive: true, force: true })

--- a/packages/cli/src/lib/remix-config.ts
+++ b/packages/cli/src/lib/remix-config.ts
@@ -69,6 +69,13 @@ export type RemixDbAdapterConfig =
       characterSet?: string
       collation?: string
     }
+  | {
+      type: 'module'
+      module: string
+      export?: string
+      connection?: RemixDbString
+      options?: Record<string, unknown>
+    }
 
 export interface RemixDbCommandConfig {
   adapter: RemixDbAdapterConfig
@@ -322,7 +329,7 @@ function parseDbConfig(
 function parseDbAdapterConfig(value: unknown, source: ConfigSource): RemixDbAdapterConfig {
   let objectPath = ['db', 'adapter']
   let object = requireObject(value, source, objectPath)
-  let type = requireEnum(object.type, ['sqlite', 'postgres', 'mysql'], source, [
+  let type = requireEnum(object.type, ['sqlite', 'postgres', 'mysql', 'module'], source, [
     ...objectPath,
     'type',
   ])
@@ -367,12 +374,34 @@ function parseDbAdapterConfig(value: unknown, source: ConfigSource): RemixDbAdap
     }
   }
 
-  requireKnownProperties(object, ['characterSet', 'collation', 'type', 'uri'], source, objectPath)
+  if (type === 'mysql') {
+    requireKnownProperties(object, ['characterSet', 'collation', 'type', 'uri'], source, objectPath)
+    return {
+      type,
+      uri: parseDbString(object.uri, source, [...objectPath, 'uri']),
+      characterSet: optionalString(object.characterSet, source, [...objectPath, 'characterSet']),
+      collation: optionalString(object.collation, source, [...objectPath, 'collation']),
+    }
+  }
+
+  requireKnownProperties(
+    object,
+    ['connection', 'export', 'module', 'options', 'type'],
+    source,
+    objectPath,
+  )
   return {
     type,
-    uri: parseDbString(object.uri, source, [...objectPath, 'uri']),
-    characterSet: optionalString(object.characterSet, source, [...objectPath, 'characterSet']),
-    collation: optionalString(object.collation, source, [...objectPath, 'collation']),
+    module: requireString(object.module, source, [...objectPath, 'module']),
+    export: optionalString(object.export, source, [...objectPath, 'export']),
+    connection:
+      object.connection === undefined
+        ? undefined
+        : parseDbString(object.connection, source, [...objectPath, 'connection']),
+    options:
+      object.options === undefined
+        ? undefined
+        : toPlainObject(requireObject(object.options, source, [...objectPath, 'options'])),
   }
 }
 
@@ -756,6 +785,22 @@ function getLineAndColumn(text: string, offset: number): { column: number; line:
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error
+}
+
+// The JSONC parser builds null-prototype objects. Adapter options are handed
+// to third-party code, so give them ordinary object prototypes first.
+function toPlainObject(value: Record<string, unknown>): Record<string, unknown> {
+  let result: Record<string, unknown> = {}
+  for (let [key, item] of Object.entries(value)) {
+    result[key] = toPlainValue(item)
+  }
+  return result
+}
+
+function toPlainValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toPlainValue)
+  if (isRecord(value)) return toPlainObject(value)
+  return value
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -427,6 +427,38 @@ environment variable at command runtime, and paths are resolved relative to `rem
 Application runtime setup remains application-owned. It does not need to expose any special
 exports for the CLI.
 
+To run `remix db` against a database this package does not ship an adapter for, such as Turso/libSQL
+or Cloudflare D1, point `db.adapter` at a module that creates it:
+
+```jsonc
+{
+  "db": {
+    "adapter": {
+      "type": "module",
+      "module": "./app/database.ts",
+      "export": "createDatabase",
+      "connection": { "env": "DATABASE_URL" },
+    },
+    "migrations": { "directory": "./db/migrations" },
+  },
+}
+```
+
+```ts
+import type { RemixDbModuleFactory } from 'remix/cli'
+
+export const createDatabase: RemixDbModuleFactory = ({ connection }) =>
+  createMyDatabase({ url: connection })
+```
+
+The factory receives `{ configDir, connection, options }`, where `connection` comes from
+`db.adapter.connection` or `--connection-env` and `options` is passed through from
+`db.adapter.options`. The CLI closes the returned database when the command finishes.
+
+Build such a database from your own `DatabaseDriver` implementation: `new Database(driver)`. Both are
+exported from this package. The SQLite adapter cannot stand in for these databases because its client
+interface is synchronous, while Turso and D1 clients are async.
+
 Run lifecycle commands through the Remix CLI:
 
 ```sh

--- a/packages/remix/.changes/minor.cli.module-database-adapter.md
+++ b/packages/remix/.changes/minor.cli.module-database-adapter.md
@@ -1,0 +1,1 @@
+`remix db` can now run against databases Remix does not ship an adapter for. Set `db.adapter.type` to `"module"` in `remix.json` and name a module that exports a database factory; `remix/cli` exports `RemixDbModuleFactory` and `RemixDbModuleContext` for typing it.


### PR DESCRIPTION
`db.adapter.type` accepted only `sqlite`, `postgres`, and `mysql`, so a project on any other database (cloudfare d1 or turso, etc) could not run `remix db` at all:

    Error [RMX_INVALID_CONFIG] Invalid Remix configuration
    remix.json:1:32: Expected one of: sqlite, postgres, mysql at db.adapter.type

There was no hook to plug one in, which left those projects reimplementing the command against `runRemixDb()` to get the migration directory layout, journal table, and output the CLI already produces.

Add a fourth adapter type that names a module instead of a driver:

    {
      "db": {
        "adapter": {
          "type": "module",
          "module": "./app/database.ts",
          "export": "createDatabase",
          "connection": { "env": "DATABASE_URL" },
          "options": { "syncInterval": 60 }
        }
      }
    }

The module exports a factory typed by the new `RemixDbModuleFactory`, receives `{ configDir, connection, options }`, and returns a `Database` that the CLI closes when the command finishes. `export` defaults to the default export. `connection` resolves like the other adapters' connection values and `--connection-env` overrides it, so the flag keeps working for module adapters. `options` is passed through unchanged.

Relative and absolute `module` specifiers resolve from `remix.json`. Specifiers that name a scheme belong to the runtime. Bare specifiers resolve from the app rather than the CLI, so a database package the app installed is reachable even when the CLI's own resolver cannot see it, and fall back to the raw specifier when that resolution fails.

Options come back from the JSONC parser as null-prototype objects; give them ordinary prototypes before handing them to third-party code.

`RMX_DB_MODULE_NOT_FOUND` reports an import that failed, and `RMX_DB_MODULE_FACTORY_REQUIRED` reports an export that is not a function.