### PR TITLE
Update docs site navigation

### DIFF
--- a/docs/shared/ui/docs-header.test.tsx
+++ b/docs/shared/ui/docs-header.test.tsx
@@ -11,7 +11,7 @@ const navigationLinks = [
 ] satisfies readonly DocsNavigationLink[]
 
 describe('createDocsNavigationLinks', () => {
-  it('returns the six absolute links in navigation order', () => {
+  it('returns the seven absolute links in navigation order', () => {
     let links = createDocsNavigationLinks()
 
     assert.deepEqual(
@@ -19,10 +19,11 @@ describe('createDocsNavigationLinks', () => {
       [
         ['guides', { href: 'https://guides.remix.run/', label: 'Guides' }],
         ['api', { href: 'https://api.remix.run', label: 'API' }],
+        ['github', { href: 'https://github.com/remix-run/remix', label: 'GitHub' }],
         ['blog', { href: 'https://remix.run/blog', label: 'Blog' }],
+        ['newsletter', { href: 'https://remix.run/newsletter', label: 'Newsletter' }],
         ['jam', { href: 'https://remix.run/jam/2026', label: 'Jam' }],
         ['store', { href: 'https://shop.remix.run', label: 'Store' }],
-        ['github', { href: 'https://github.com/remix-run/remix', label: 'GitHub' }],
       ],
     )
   })
@@ -33,7 +34,7 @@ describe('createDocsNavigationLinks', () => {
 
     assert.deepEqual(
       [...links.values()].map((link) => link.label),
-      ['Guides', 'API', 'Blog', 'Jam', 'Store', 'GitHub'],
+      ['Guides', 'API', 'GitHub', 'Blog', 'Newsletter', 'Jam', 'Store'],
     )
     assert.deepEqual(links.get('api'), { href: '/v3', label: 'API', current: 'page' })
   })
@@ -50,7 +51,10 @@ describe('DocsHeader', () => {
     assert.match(html, /id="site-primary-navigation"[^>]*popover="auto"/)
     assert.equal(html.match(/>Guides<\/a>/g)?.length, 2)
     assert.equal(html.match(/href="\/guides"[^>]*aria-current="location"/g)?.length, 2)
-    assert.match(html, /href="https:\/\/remix\.run"[^>]*aria-label="Remix Docs"/)
+    assert.match(
+      html,
+      /id="docs-brand"[^>]*href="https:\/\/remix\.run"[^>]*aria-label="Remix Docs"/,
+    )
     assert.equal(html.match(/id="docs-search-button"/g)?.length, 1)
     assert.doesNotMatch(html, /class="[^"]*site-header/)
     assert.doesNotMatch(html, /\[object Object\]/)

--- a/docs/shared/ui/docs-header.tsx
+++ b/docs/shared/ui/docs-header.tsx
@@ -9,16 +9,24 @@ export interface DocsNavigationLink {
   current?: 'location' | 'page'
 }
 
-export type DocsNavigationLinkId = 'guides' | 'api' | 'blog' | 'jam' | 'store' | 'github'
+export type DocsNavigationLinkId =
+  | 'guides'
+  | 'api'
+  | 'github'
+  | 'blog'
+  | 'newsletter'
+  | 'jam'
+  | 'store'
 
 export function createDocsNavigationLinks(): Map<DocsNavigationLinkId, DocsNavigationLink> {
   return new Map<DocsNavigationLinkId, DocsNavigationLink>()
     .set('guides', { href: 'https://guides.remix.run/', label: 'Guides' })
     .set('api', { href: 'https://api.remix.run', label: 'API' })
+    .set('github', { href: 'https://github.com/remix-run/remix', label: 'GitHub' })
     .set('blog', { href: 'https://remix.run/blog', label: 'Blog' })
+    .set('newsletter', { href: 'https://remix.run/newsletter', label: 'Newsletter' })
     .set('jam', { href: 'https://remix.run/jam/2026', label: 'Jam' })
     .set('store', { href: 'https://shop.remix.run', label: 'Store' })
-    .set('github', { href: 'https://github.com/remix-run/remix', label: 'GitHub' })
 }
 
 export interface DocsHeaderProps {
@@ -31,7 +39,12 @@ export interface DocsHeaderProps {
 export function DocsHeader(handle: Handle<DocsHeaderProps>) {
   return () => (
     <header mix={docsHeaderCss}>
-      <a href="https://remix.run" aria-label={handle.props.brandLabel} mix={brandCss}>
+      <a
+        id="docs-brand"
+        href="https://remix.run"
+        aria-label={handle.props.brandLabel}
+        mix={brandCss}
+      >
         <img
           src="/remix-logo-light-mode.svg"
           alt=""

--- a/docs/shared/ui/docs-shell.test.browser.tsx
+++ b/docs/shared/ui/docs-shell.test.browser.tsx
@@ -35,6 +35,17 @@ describe('startDocsShellBehavior', () => {
     assert.equal(fixture.navigationToggle.getAttribute('aria-label'), 'Collapse chapter navigation')
   })
 
+  it('opens the Remix brand page from the brand context menu', () => {
+    let fixture = createShellFixture()
+    let event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+
+    fixture.brand.dispatchEvent(event)
+
+    assert.equal(event.defaultPrevented, true)
+    assert.equal(fixture.brandPageHref, 'https://remix.run/brand')
+    fixture.cleanup()
+  })
+
   it('preserves collapsed state when the shell is reconnected', () => {
     let fixture = createShellFixture()
 
@@ -126,6 +137,7 @@ describe('startDocsShellBehavior', () => {
 function createShellFixture() {
   let container = document.createElement('div')
   container.innerHTML = `
+    <a id="docs-brand" href="https://remix.run">Remix</a>
     <button id="docs-navigation-toggle" aria-expanded="true"></button>
     <button id="docs-mobile-navigation-toggle" aria-expanded="false"></button>
     <button id="docs-mobile-secondary-navigation-toggle" aria-expanded="false"></button>
@@ -138,6 +150,7 @@ function createShellFixture() {
   `
   document.body.append(container)
   let mobileNavigationBottom = 112
+  let brandPageHref: string | undefined
   let mobileNavigationBar = getElement('docs-mobile-navigation-bar')
   let navigationCompleteTarget = new EventTarget()
   mobileNavigationBar.getBoundingClientRect = () =>
@@ -147,6 +160,10 @@ function createShellFixture() {
   startBehavior()
 
   return {
+    brand: getElement('docs-brand'),
+    get brandPageHref() {
+      return brandPageHref
+    },
     navigation: getElement('docs-navigation'),
     navigationToggle: getElement('docs-navigation-toggle'),
     mobileNavigationToggle: getElement('docs-mobile-navigation-toggle'),
@@ -181,6 +198,9 @@ function createShellFixture() {
     startDocsShellBehavior(controller.signal, {
       navigationName: 'chapter navigation',
       navigationCompleteTarget,
+      navigateTo(href) {
+        brandPageHref = href
+      },
     })
   }
 }

--- a/docs/shared/ui/public/docs-shell.tsx
+++ b/docs/shared/ui/public/docs-shell.tsx
@@ -1,4 +1,4 @@
-import { clientEntry } from 'remix/ui'
+import { clientEntry, navigate } from 'remix/ui'
 import type { Handle } from 'remix/ui'
 
 interface DocsShellBehaviorProps {
@@ -9,6 +9,7 @@ interface DocsShellBehaviorProps {
 interface DocsShellBehaviorOptions {
   navigationName: string
   navigationCompleteTarget?: EventTarget
+  navigateTo?: (href: string) => void | Promise<void>
 }
 
 type MobilePanel = 'navigation' | 'secondary'
@@ -33,6 +34,7 @@ export function startDocsShellBehavior(
   options: DocsShellBehaviorOptions,
 ): void {
   let root = document.documentElement
+  let brand = document.getElementById('docs-brand')
   let siteNavigation = document.getElementById('site-primary-navigation')
   let navigation = document.getElementById('docs-navigation')
   let navigationToggle = document.getElementById('docs-navigation-toggle')
@@ -53,6 +55,7 @@ export function startDocsShellBehavior(
 
   updateShellState()
 
+  brand?.addEventListener('contextmenu', openBrandPage, { signal })
   navigationToggle?.addEventListener('click', toggleNavigation, { signal })
   mobileNavigationToggle?.addEventListener('click', toggleMobileNavigation, { signal })
   mobileSecondaryNavigationToggle?.addEventListener('click', toggleMobileSecondaryNavigation, {
@@ -96,6 +99,11 @@ export function startDocsShellBehavior(
     setNavigationCollapsed(navigationCollapsed)
     updateMobileNavigationTop()
     syncMobileNavigation()
+  }
+
+  function openBrandPage(event: MouseEvent) {
+    event.preventDefault()
+    void (options.navigateTo ?? navigate)('https://remix.run/brand')
   }
 
   function toggleNavigation() {


### PR DESCRIPTION
Aligns the API and guide site headers with the navigation on remix.run.

- reorders the shared navigation to Guides, API, GitHub, Blog, Newsletter, Jam, and Store
- adds the new Newsletter link at https://remix.run/newsletter
- sends the Remix logo's context-menu action to the brand page, matching remix.run
