### PR TITLE
Tighten docs navigation spacing

### DIFF
--- a/docs/shared/ui/docs-header.tsx
+++ b/docs/shared/ui/docs-header.tsx
@@ -426,7 +426,7 @@ const navigationCss = css({
   justifyContent: 'flex-end',
   width: 'auto',
   height: 'var(--site-header-height)',
-  gap: '32px',
+  gap: '24px',
   overflow: 'visible',
   fontSize: '16px',
   flexWrap: 'nowrap',


### PR DESCRIPTION
This extracts the docs navigation spacing adjustment from #11745 now that #11731 has fixed the original CSS serialization issue.

- Reduce the desktop navigation gap from `32px` to `24px`
- Give the header links more room without changing navigation behavior
