### PR TITLE
Fix Safari Navigation API scroll desynchronization

### DIFF
--- a/packages/ui/.changes/patch.webkit-navigation-scroll.md
+++ b/packages/ui/.changes/patch.webkit-navigation-scroll.md
@@ -1,0 +1,1 @@
+Prevent Safari Navigation API scroll resets from desynchronizing page hit testing after intercepted push and replace navigations (see [WebKit bug 309542](https://bugs.webkit.org/show_bug.cgi?id=309542)).

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -56,9 +56,10 @@ function resyncWebKitScrollAfterNavigation(event: NavigateEvent, resetScroll: bo
       // WebKit can reset its internal scroll position without synchronizing the visual viewport.
       // https://bugs.webkit.org/show_bug.cgi?id=309542
       if (event.signal.aborted || window.scrollX !== 0 || window.scrollY !== 0) return
-      window.scrollTo(0, 1)
+      window.scrollTo({ behavior: 'instant', left: 0, top: 1 })
       requestAnimationFrame(() => {
-        if (!event.signal.aborted) window.scrollTo(0, 0)
+        if (event.signal.aborted || window.scrollX !== 0 || window.scrollY !== 1) return
+        window.scrollTo({ behavior: 'instant', left: 0, top: 0 })
       })
     },
     { once: true, signal: event.signal },

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -42,6 +42,29 @@ interface FrameRedirectNavigationInfo {
 const formSubmissionNavigationInfoType = 'frame-form-submission'
 const frameRedirectNavigationInfoType = 'frame-redirect'
 
+function resyncWebKitScrollAfterNavigation(event: NavigateEvent, resetScroll: boolean): void {
+  let userAgent = navigator.userAgent
+  if (!userAgent.includes('AppleWebKit')) return
+  if (userAgent.includes('Chrome') || userAgent.includes('Chromium')) return
+  if (!resetScroll || (event.navigationType !== 'push' && event.navigationType !== 'replace'))
+    return
+  if (new URL(event.destination.url).hash) return
+
+  window.navigation.addEventListener(
+    'navigatesuccess',
+    () => {
+      // WebKit can reset its internal scroll position without synchronizing the visual viewport.
+      // https://bugs.webkit.org/show_bug.cgi?id=309542
+      if (event.signal.aborted || window.scrollX !== 0 || window.scrollY !== 0) return
+      window.scrollTo(0, 1)
+      requestAnimationFrame(() => {
+        if (!event.signal.aborted) window.scrollTo(0, 0)
+      })
+    },
+    { once: true, signal: event.signal },
+  )
+}
+
 /**
  * Options for client-side frame-aware navigation.
  */
@@ -109,6 +132,7 @@ export function startNavigationListenerImpl(
       if (!event.canIntercept || isCrossOriginDestination(event)) return
 
       if (isFrameRedirectNavigationInfo(event.info)) {
+        resyncWebKitScrollAfterNavigation(event, event.info.resetScroll)
         event.intercept({
           async handler() {},
           scroll: event.info.resetScroll === false ? 'manual' : undefined,
@@ -125,6 +149,7 @@ export function startNavigationListenerImpl(
         : getRuntimeNavigation(event, resolveFormNavigation)
       if (!runtimeNavigation) return
       let { state } = runtimeNavigation
+      resyncWebKitScrollAfterNavigation(event, state.resetScroll)
 
       let topFrame = options.getTopFrame()
       let namedFrame = state.target ? options.getNamedFrame(state.target) : undefined

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -49,6 +49,28 @@ function stubNavigatorUserAgent(t: TestContext, userAgent: string): void {
   })
 }
 
+function stubWindowScrollPosition(t: TestContext) {
+  let x = 0
+  let y = 0
+  let scrollXDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollX')
+  let scrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY')
+  Object.defineProperties(window, {
+    scrollX: { configurable: true, get: () => x },
+    scrollY: { configurable: true, get: () => y },
+  })
+  t.after(() => {
+    if (scrollXDescriptor) Object.defineProperty(window, 'scrollX', scrollXDescriptor)
+    else Reflect.deleteProperty(window, 'scrollX')
+    if (scrollYDescriptor) Object.defineProperty(window, 'scrollY', scrollYDescriptor)
+    else Reflect.deleteProperty(window, 'scrollY')
+  })
+
+  return (xPosition: number, yPosition: number) => {
+    x = xPosition
+    y = yPosition
+  }
+}
+
 function startStubNavigationListener(t: TestContext): (event: Event) => void {
   let stubNavigation = Object.assign(new EventTarget(), {
     updateCurrentEntry: mock.fn(),
@@ -128,6 +150,7 @@ describe('navigate', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15',
     )
     let dispatchNavigation = startStubNavigationListener(t)
+    let setScrollPosition = stubWindowScrollPosition(t)
     let scrollTo = t.mock.method(window, 'scrollTo', () => {})
     let animationFrameCallbacks: FrameRequestCallback[] = []
     t.mock.method(window, 'requestAnimationFrame', (callback: FrameRequestCallback) => {
@@ -146,12 +169,53 @@ describe('navigate', () => {
     expect(scrollTo).not.toHaveBeenCalled()
 
     dispatchNavigation(new Event('navigatesuccess'))
-    expect(scrollTo).toHaveBeenNthCalledWith(1, 0, 1)
+    expect(scrollTo).toHaveBeenNthCalledWith(1, {
+      behavior: 'instant',
+      left: 0,
+      top: 1,
+    })
+    setScrollPosition(0, 1)
 
     let animationFrameCallback = animationFrameCallbacks[0]
     if (!animationFrameCallback) throw new Error('Expected an animation frame callback')
     animationFrameCallback(0)
-    expect(scrollTo).toHaveBeenNthCalledWith(2, 0, 0)
+    expect(scrollTo).toHaveBeenNthCalledWith(2, {
+      behavior: 'instant',
+      left: 0,
+      top: 0,
+    })
+  })
+
+  it('preserves scrolling that occurs after WebKit scroll resynchronization', (t) => {
+    stubNavigatorUserAgent(
+      t,
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15',
+    )
+    let dispatchNavigation = startStubNavigationListener(t)
+    let setScrollPosition = stubWindowScrollPosition(t)
+    let scrollTo = t.mock.method(window, 'scrollTo', () => {})
+    let animationFrameCallbacks: FrameRequestCallback[] = []
+    t.mock.method(window, 'requestAnimationFrame', (callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback)
+      return 1
+    })
+    let anchor = document.createElement('a')
+    anchor.href = '/login'
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept: mock.fn(),
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+    dispatchNavigation(new Event('navigatesuccess'))
+    setScrollPosition(0, 200)
+
+    let animationFrameCallback = animationFrameCallbacks[0]
+    if (!animationFrameCallback) throw new Error('Expected an animation frame callback')
+    animationFrameCallback(0)
+
+    expect(scrollTo).toHaveBeenCalledTimes(1)
   })
 
   it('does not resynchronize WebKit scroll state for fragment navigations', (t) => {

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -40,14 +40,19 @@ function stubGlobalField(t: TestContext, name: string, value: unknown): void {
   })
 }
 
+function stubNavigatorUserAgent(t: TestContext, userAgent: string): void {
+  let descriptor = Object.getOwnPropertyDescriptor(navigator, 'userAgent')
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, value: userAgent })
+  t.after(() => {
+    if (descriptor) Object.defineProperty(navigator, 'userAgent', descriptor)
+    else Reflect.deleteProperty(navigator, 'userAgent')
+  })
+}
+
 function startStubNavigationListener(t: TestContext): (event: Event) => void {
-  let navigateListener: EventListener | undefined
-  let stubNavigation = {
+  let stubNavigation = Object.assign(new EventTarget(), {
     updateCurrentEntry: mock.fn(),
-    addEventListener(type: string, listener: EventListener) {
-      if (type === 'navigate') navigateListener = listener
-    },
-  }
+  })
   stubGlobalField(t, 'navigation', stubNavigation)
 
   let controller = new AbortController()
@@ -55,8 +60,7 @@ function startStubNavigationListener(t: TestContext): (event: Event) => void {
   t.after(() => controller.abort())
 
   return (event) => {
-    if (!navigateListener) throw new Error('Expected a navigate listener')
-    navigateListener(event)
+    stubNavigation.dispatchEvent(event)
   }
 }
 
@@ -114,6 +118,60 @@ describe('navigate', () => {
     let interceptOptions = intercept.mock.calls[0]?.arguments[0]
     expect(interceptOptions?.scroll).toBe(undefined)
     await interceptOptions?.handler?.()
+    dispatchNavigation(new Event('navigatesuccess'))
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('resynchronizes WebKit scroll state after a navigation scroll reset', (t) => {
+    stubNavigatorUserAgent(
+      t,
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15',
+    )
+    let dispatchNavigation = startStubNavigationListener(t)
+    let scrollTo = t.mock.method(window, 'scrollTo', () => {})
+    let animationFrameCallbacks: FrameRequestCallback[] = []
+    t.mock.method(window, 'requestAnimationFrame', (callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback)
+      return 1
+    })
+    let anchor = document.createElement('a')
+    anchor.href = '/login'
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept: mock.fn(),
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+    expect(scrollTo).not.toHaveBeenCalled()
+
+    dispatchNavigation(new Event('navigatesuccess'))
+    expect(scrollTo).toHaveBeenNthCalledWith(1, 0, 1)
+
+    let animationFrameCallback = animationFrameCallbacks[0]
+    if (!animationFrameCallback) throw new Error('Expected an animation frame callback')
+    animationFrameCallback(0)
+    expect(scrollTo).toHaveBeenNthCalledWith(2, 0, 0)
+  })
+
+  it('does not resynchronize WebKit scroll state for fragment navigations', (t) => {
+    stubNavigatorUserAgent(
+      t,
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15',
+    )
+    let dispatchNavigation = startStubNavigationListener(t)
+    let scrollTo = t.mock.method(window, 'scrollTo', () => {})
+    let anchor = document.createElement('a')
+    anchor.href = '/login#details'
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept: mock.fn(),
+        destinationUrl: new URL('/login#details', window.location.origin).href,
+      }),
+    )
+    dispatchNavigation(new Event('navigatesuccess'))
+
     expect(scrollTo).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Safari can reset its internal scroll position after an intercepted Navigation API transition without synchronizing the visual viewport. This leaves hit testing offset from the rendered page, making links and controls difficult or impossible to click. The underlying WebKit issue is tracked in [WebKit bug 309542](https://bugs.webkit.org/show_bug.cgi?id=309542) and was fixed upstream in [WebKit/WebKit#60240](https://github.com/WebKit/WebKit/pull/60240), but affected Safari releases remain in circulation.

- Force WebKit to resynchronize after successful browser-managed scroll resets with a one-pixel scroll nudge followed by restoration on the next animation frame.
- Limit the workaround to non-Chromium WebKit push/replace navigations without fragments, and skip it when scrolling was disabled, the navigation was aborted, or the page is no longer at the origin.
- Apply the fix to both regular frame navigations and frame redirects without changing the public navigation API or taking over normal browser scroll behavior.
- Cover the WebKit behavior, Chromium exclusion, and fragment-navigation exclusion in browser tests.
