### PR TITLE
Include Remix version in release PR title

### DIFF
--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -8,7 +8,7 @@
  *   GITHUB_TOKEN - Required (unless --preview)
  */
 import { parseAllChangeFiles, generateCommitMessage } from './utils/changes.ts'
-import { generatePrBody } from './utils/release-pr.ts'
+import { generatePrBody, generatePrTitle } from './utils/release-pr.ts'
 import { logAndExec } from './utils/process.ts'
 import { findOpenPr, createPr, updatePr, closePr } from './utils/github.ts'
 
@@ -17,7 +17,6 @@ const preview = args.includes('--preview')
 
 const baseBranch = 'main'
 const prBranch = 'release-pr/main'
-const prTitle = 'Release'
 
 async function main() {
   console.log(preview ? '🔍 PREVIEW MODE\n' : '')
@@ -63,6 +62,7 @@ async function main() {
 
   // Generate content
   let commitMessage = generateCommitMessage(releases)
+  let prTitle = generatePrTitle(releases)
   let prBody = generatePrBody(releases)
 
   if (preview) {

--- a/scripts/utils/release-pr.test.ts
+++ b/scripts/utils/release-pr.test.ts
@@ -1,7 +1,7 @@
 import assert from '@remix-run/assert'
-import { test } from '@remix-run/test'
+import { describe, it } from '@remix-run/test'
 import type { PackageRelease } from './changes.ts'
-import { generatePrBody } from './release-pr.ts'
+import { generatePrBody, generatePrTitle } from './release-pr.ts'
 
 function makeRelease({
   packageDirName,
@@ -23,53 +23,86 @@ function makeRelease({
   }
 }
 
-test('generatePrBody puts remix first and sorts remaining packages alphabetically', () => {
-  let body = generatePrBody([
-    makeRelease({
-      packageDirName: 'zeta',
-      packageName: '@remix-run/zeta',
-      nextVersion: '1.0.1',
-    }),
-    makeRelease({
-      packageDirName: 'remix',
-      packageName: 'remix',
-      nextVersion: '3.0.0',
-    }),
-    makeRelease({
-      packageDirName: 'beta',
-      packageName: '@remix-run/beta',
-      nextVersion: '1.0.1',
-    }),
-    makeRelease({
-      packageDirName: 'alpha',
-      packageName: '@remix-run/alpha',
-      nextVersion: '1.0.1',
-    }),
-  ])
+describe('generatePrTitle', () => {
+  it('uses the pending Remix version', () => {
+    let title = generatePrTitle([
+      makeRelease({
+        packageDirName: 'assets',
+        packageName: '@remix-run/assets',
+        nextVersion: '0.6.0',
+      }),
+      makeRelease({
+        packageDirName: 'remix',
+        packageName: 'remix',
+        nextVersion: '3.0.0-rc.1',
+      }),
+    ])
 
-  let remixTableIndex = body.indexOf('| remix |')
-  let alphaTableIndex = body.indexOf('| @remix-run/alpha |')
-  let betaTableIndex = body.indexOf('| @remix-run/beta |')
-  let zetaTableIndex = body.indexOf('| @remix-run/zeta |')
+    assert.equal(title, 'Release v3.0.0-rc.1')
+  })
 
-  assert.notEqual(remixTableIndex, -1)
-  assert.notEqual(alphaTableIndex, -1)
-  assert.notEqual(betaTableIndex, -1)
-  assert.notEqual(zetaTableIndex, -1)
-  assert.ok(remixTableIndex < alphaTableIndex)
-  assert.ok(alphaTableIndex < betaTableIndex)
-  assert.ok(betaTableIndex < zetaTableIndex)
+  it('keeps the generic title for subpackage-only releases', () => {
+    let title = generatePrTitle([
+      makeRelease({
+        packageDirName: 'assets',
+        packageName: '@remix-run/assets',
+        nextVersion: '0.6.0',
+      }),
+    ])
 
-  let remixChangelogIndex = body.indexOf('## remix v3.0.0')
-  let alphaChangelogIndex = body.indexOf('## @remix-run/alpha v1.0.1')
-  let betaChangelogIndex = body.indexOf('## @remix-run/beta v1.0.1')
-  let zetaChangelogIndex = body.indexOf('## @remix-run/zeta v1.0.1')
+    assert.equal(title, 'Release')
+  })
+})
 
-  assert.notEqual(remixChangelogIndex, -1)
-  assert.notEqual(alphaChangelogIndex, -1)
-  assert.notEqual(betaChangelogIndex, -1)
-  assert.notEqual(zetaChangelogIndex, -1)
-  assert.ok(remixChangelogIndex < alphaChangelogIndex)
-  assert.ok(alphaChangelogIndex < betaChangelogIndex)
-  assert.ok(betaChangelogIndex < zetaChangelogIndex)
+describe('generatePrBody', () => {
+  it('puts remix first and sorts remaining packages alphabetically', () => {
+    let body = generatePrBody([
+      makeRelease({
+        packageDirName: 'zeta',
+        packageName: '@remix-run/zeta',
+        nextVersion: '1.0.1',
+      }),
+      makeRelease({
+        packageDirName: 'remix',
+        packageName: 'remix',
+        nextVersion: '3.0.0',
+      }),
+      makeRelease({
+        packageDirName: 'beta',
+        packageName: '@remix-run/beta',
+        nextVersion: '1.0.1',
+      }),
+      makeRelease({
+        packageDirName: 'alpha',
+        packageName: '@remix-run/alpha',
+        nextVersion: '1.0.1',
+      }),
+    ])
+
+    let remixTableIndex = body.indexOf('| remix |')
+    let alphaTableIndex = body.indexOf('| @remix-run/alpha |')
+    let betaTableIndex = body.indexOf('| @remix-run/beta |')
+    let zetaTableIndex = body.indexOf('| @remix-run/zeta |')
+
+    assert.notEqual(remixTableIndex, -1)
+    assert.notEqual(alphaTableIndex, -1)
+    assert.notEqual(betaTableIndex, -1)
+    assert.notEqual(zetaTableIndex, -1)
+    assert.ok(remixTableIndex < alphaTableIndex)
+    assert.ok(alphaTableIndex < betaTableIndex)
+    assert.ok(betaTableIndex < zetaTableIndex)
+
+    let remixChangelogIndex = body.indexOf('## remix v3.0.0')
+    let alphaChangelogIndex = body.indexOf('## @remix-run/alpha v1.0.1')
+    let betaChangelogIndex = body.indexOf('## @remix-run/beta v1.0.1')
+    let zetaChangelogIndex = body.indexOf('## @remix-run/zeta v1.0.1')
+
+    assert.notEqual(remixChangelogIndex, -1)
+    assert.notEqual(alphaChangelogIndex, -1)
+    assert.notEqual(betaChangelogIndex, -1)
+    assert.notEqual(zetaChangelogIndex, -1)
+    assert.ok(remixChangelogIndex < alphaChangelogIndex)
+    assert.ok(alphaChangelogIndex < betaChangelogIndex)
+    assert.ok(betaChangelogIndex < zetaChangelogIndex)
+  })
 })

--- a/scripts/utils/release-pr.ts
+++ b/scripts/utils/release-pr.ts
@@ -5,6 +5,14 @@ import { generateChangelogContent } from './changes.ts'
 const maxBodyLength = 60_000
 
 /**
+ * Generates the title for a release PR
+ */
+export function generatePrTitle(releases: PackageRelease[]): string {
+  let remixRelease = releases.find((release) => release.packageDirName === 'remix')
+  return remixRelease ? `Release v${remixRelease.nextVersion}` : 'Release'
+}
+
+/**
  * Generates the PR body for a release PR
  */
 export function generatePrBody(releases: PackageRelease[]): string {


### PR DESCRIPTION
Update the managed release PR title to include the pending Remix version. For the current release, this changes #11724 from `Release` to `Release v3.0.0-rc.1` the next time the workflow runs.

- Derive the title from the pending `remix` release
- Keep the existing `Release` title for subpackage-only releases
- Cover both title paths with focused tests
