### PR TITLE
Add opt-in view transitions for enhanced navigation

### DIFF
--- a/docs/guides/app/actions/docs/chapters/05-interactivity.md
+++ b/docs/guides/app/actions/docs/chapters/05-interactivity.md
@@ -701,6 +701,7 @@ the `link(...)` and `navigate(...)` options:
 - `data-rmx-src` provides the URL to fetch for that frame while `href` remains the browser's destination.
 - `data-rmx-history="push|replace"` controls how the navigation updates history, including overriding a form's default.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
+- `data-rmx-view-transition` runs the frame reload inside a same-document view transition when the browser supports it. Pass `viewTransition: true` to `link(...)` or `navigate(...)` for the same behavior.
 - `data-rmx-document` opts out of interception and lets the browser perform a full-document navigation.
 
 [Streaming UI with Frames](/streaming-ui-with-frames/) shows these attributes with named frames and

--- a/packages/remix/.changes/minor.ui.document-view-transitions.md
+++ b/packages/remix/.changes/minor.ui.document-view-transitions.md
@@ -1,0 +1,1 @@
+Add opt-in same-document view transitions for enhanced `remix/ui` navigations through `viewTransition: true` and `data-rmx-view-transition`.

--- a/packages/ui/.changes/minor.document-view-transitions.md
+++ b/packages/ui/.changes/minor.document-view-transitions.md
@@ -1,0 +1,1 @@
+Add `viewTransition: true` and `data-rmx-view-transition` options for running intercepted frame navigations inside same-document view transitions when supported (see #11656).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -150,6 +150,9 @@ CRLF-delimited text, and `multipart/form-data` submissions use `FormData`. Pass 
 response policy.
 
 Add `data-rmx-document` to a link or form to leave its navigation to the browser.
+Add `data-rmx-view-transition` to run an enhanced navigation inside
+`document.startViewTransition()` when the browser supports it. The equivalent `navigate()` and
+`link()` option is `{ viewTransition: true }`.
 
 The default resolver rejects non-OK responses with an error containing their status and status text.
 A custom `resolveFrame` may return a `Response` with any status when it wants Remix UI to render the

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -246,9 +246,10 @@ Eligible same-origin anchor navigations reload `handle.frames.top` through the f
 - `data-rmx-src="/frame"` overrides the URL resolved into that frame while `href` remains the navigation destination.
 - `data-rmx-history="push|replace"` controls how the navigation updates history.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
+- `data-rmx-view-transition` runs the frame reload inside a same-document view transition when supported.
 - `data-rmx-document` leaves the link as a normal document navigation.
 
-The `link(href, { history })` mixin adds the corresponding `data-rmx-history` value when its host is a native anchor. Download links, cross-origin links, and links marked with `data-rmx-document` are left to the browser.
+The `link(href, { history, viewTransition })` mixin adds the corresponding runtime attributes when its host is a native anchor. Download links, cross-origin links, and links marked with `data-rmx-document` are left to the browser.
 
 ## Form navigation
 
@@ -259,6 +260,7 @@ Eligible same-origin form submissions use the same frame navigation path as link
 - `data-rmx-src="/frame"` overrides the URL resolved into that frame while the form action remains the navigation destination.
 - `data-rmx-history="push|replace"` overrides how the navigation updates history.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
+- `data-rmx-view-transition` runs the frame reload inside a same-document view transition when supported.
 - `data-rmx-document` leaves the submission as a normal document navigation.
 - Submitter overrides such as `formmethod`, `formenctype`, and `formtarget` take precedence over the form attributes.
 - Cross-origin submissions, `method="dialog"`, and `target="_blank"` are left to the browser.

--- a/packages/ui/src/runtime/dom.ts
+++ b/packages/ui/src/runtime/dom.ts
@@ -1796,6 +1796,8 @@ export interface PartialAnchorHTMLProps<
   'data-rmx-history'?: Trackable<'push' | 'replace' | undefined>
   /** The `data-rmx-reset-scroll` HTML attribute. */
   'data-rmx-reset-scroll'?: Trackable<string | undefined>
+  /** Runs this navigation inside a same-document view transition when supported. */
+  'data-rmx-view-transition'?: Trackable<boolean | '' | undefined>
 }
 
 export type AnchorAriaRoles =
@@ -2309,6 +2311,8 @@ export interface FormHTMLProps<
   'data-rmx-history'?: Trackable<'push' | 'replace' | undefined>
   /** The `data-rmx-reset-scroll` HTML attribute. */
   'data-rmx-reset-scroll'?: Trackable<string | undefined>
+  /** Runs this submission inside a same-document view transition when supported. */
+  'data-rmx-view-transition'?: Trackable<boolean | '' | undefined>
 }
 
 /**

--- a/packages/ui/src/runtime/mixins/link-mixin.test.tsx
+++ b/packages/ui/src/runtime/mixins/link-mixin.test.tsx
@@ -32,6 +32,7 @@ describe('link mixin', () => {
           target: 'auth',
           history: 'replace',
           resetScroll: false,
+          viewTransition: true,
         })}
       >
         Login
@@ -45,6 +46,7 @@ describe('link mixin', () => {
     expect(anchor.getAttribute('data-rmx-src')).toBe('/partials/login')
     expect(anchor.getAttribute('data-rmx-history')).toBe('replace')
     expect(anchor.getAttribute('data-rmx-reset-scroll')).toBe('false')
+    expect(anchor.getAttribute('data-rmx-view-transition')).toBe('')
     expect(anchor.getAttribute('role')).toBeNull()
   })
 
@@ -84,6 +86,7 @@ describe('link mixin', () => {
     expect(anchor.getAttribute('data-rmx-target')).toBeNull()
     expect(anchor.getAttribute('data-rmx-src')).toBeNull()
     expect(anchor.getAttribute('data-rmx-history')).toBeNull()
+    expect(anchor.getAttribute('data-rmx-view-transition')).toBeNull()
   })
 
   it('navigates on plain click for non-anchor hosts', (t) => {

--- a/packages/ui/src/runtime/mixins/link-mixin.ts
+++ b/packages/ui/src/runtime/mixins/link-mixin.ts
@@ -38,6 +38,7 @@ export const link: MixinFactory<
           ...(options?.src == null ? {} : { 'data-rmx-src': options.src }),
           ...(options?.history == null ? {} : { 'data-rmx-history': options.history }),
           ...(options?.resetScroll === false ? { 'data-rmx-reset-scroll': 'false' } : {}),
+          ...(options?.viewTransition === true ? { 'data-rmx-view-transition': '' } : {}),
         })
       }
 

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -15,6 +15,7 @@ type NavigationState = {
   target: string | undefined
   src: string
   resetScroll: boolean
+  viewTransition?: boolean
   $rmx: true
 }
 
@@ -46,6 +47,8 @@ const frameRedirectNavigationInfoType = 'frame-redirect'
  * Options for client-side frame-aware navigation.
  */
 export type NavigationOptions = {
+  /** Runs the frame reload inside a same-document view transition when supported. */
+  viewTransition?: boolean
   src?: string
   target?: string
   history?: 'push' | 'replace'
@@ -63,6 +66,7 @@ export async function navigate(href: string, options?: NavigationOptions) {
     target: options?.target,
     src: options?.src ?? href,
     resetScroll: options?.resetScroll !== false,
+    ...(options?.viewTransition === true ? { viewTransition: true } : {}),
     $rmx: true,
   } satisfies NavigationState
   let transition = window.navigation.navigate(href, { state, history: options?.history })
@@ -146,10 +150,15 @@ export function startNavigationListenerImpl(
 
         topFrame.src = event.destination.url
         if (frame !== topFrame) frame.src = state.src
-        let { redirectedTo } = await options.reloadFrame(frame, {
-          ...submission,
-          signal: event.signal,
-        })
+        let redirectedTo: string | undefined
+        let update = async () => {
+          let result = await options.reloadFrame(frame, {
+            ...submission,
+            signal: event.signal,
+          })
+          redirectedTo = result.redirectedTo
+        }
+        await (state.viewTransition ? updateWithViewTransition(update) : update())
 
         if (redirectedTo && frame === topFrame) {
           frame.src = redirectedTo
@@ -217,6 +226,15 @@ export function startNavigationListenerImpl(
     },
     { signal },
   )
+}
+
+async function updateWithViewTransition(update: () => Promise<void>): Promise<void> {
+  if (typeof document.startViewTransition !== 'function') {
+    await update()
+    return
+  }
+
+  await document.startViewTransition(update).updateCallbackDone
 }
 
 function isRuntimeNavigation(info: unknown): info is NavigationState {
@@ -348,6 +366,7 @@ function getSourceElementNavigation(
         target: linkElement.getAttribute('data-rmx-target') ?? undefined,
         src: linkElement.getAttribute('data-rmx-src') ?? event.destination.url,
         resetScroll: linkElement.getAttribute('data-rmx-reset-scroll') !== 'false',
+        ...(linkElement.hasAttribute('data-rmx-view-transition') ? { viewTransition: true } : {}),
         $rmx: true,
       },
       replaceHistory: getReplaceHistory(linkElement.getAttribute('data-rmx-history'), false),
@@ -366,6 +385,7 @@ function getSourceElementNavigation(
       target: formNavigation.getAttribute('data-rmx-target') ?? undefined,
       src: formNavigation.getAttribute('data-rmx-src') ?? event.destination.url,
       resetScroll: formNavigation.getAttribute('data-rmx-reset-scroll') !== 'false',
+      ...(formNavigation.hasAttribute('data-rmx-view-transition') ? { viewTransition: true } : {}),
       $rmx: true,
     },
     replaceHistory: getReplaceHistory(

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -27,20 +27,26 @@ function stubGlobalMethod(t: TestContext, api: string, method: string, impl: any
   return t.mock.method((globalThis as any)[api], method, impl)
 }
 
-// Replaces a property on `globalThis` and returns a function that restores the
-// previous value. Used for tests that swap `navigation` for a fake instance.
+// Replaces a property on `globalThis` and restores the previous value after the test.
+// Used for tests that swap `navigation` for a fake instance.
 function stubGlobalField(t: TestContext, name: string, value: unknown): void {
-  let key = name as keyof typeof globalThis
-  let hadOwn = Object.prototype.hasOwnProperty.call(globalThis, name)
-  let previous = (globalThis as any)[key]
-  ;(globalThis as any)[key] = value
+  stubObjectField(t, globalThis, name, value)
+}
+
+function stubObjectField(t: TestContext, object: object, name: string, value: unknown): void {
+  let hadOwn = Object.prototype.hasOwnProperty.call(object, name)
+  let previous = Reflect.get(object, name)
+  Reflect.set(object, name, value)
   t.after(() => {
-    if (hadOwn) (globalThis as any)[key] = previous
-    else delete (globalThis as any)[key]
+    if (hadOwn) Reflect.set(object, name, previous)
+    else Reflect.deleteProperty(object, name)
   })
 }
 
-function startStubNavigationListener(t: TestContext): (event: Event) => void {
+function startStubNavigationListener(
+  t: TestContext,
+  options: Parameters<typeof startNavigationListenerImpl>[1] = stubFrames,
+): (event: Event) => void {
   let navigateListener: EventListener | undefined
   let stubNavigation = {
     updateCurrentEntry: mock.fn(),
@@ -51,7 +57,7 @@ function startStubNavigationListener(t: TestContext): (event: Event) => void {
   stubGlobalField(t, 'navigation', stubNavigation)
 
   let controller = new AbortController()
-  startNavigationListenerImpl(controller.signal, stubFrames)
+  startNavigationListenerImpl(controller.signal, options)
   t.after(() => controller.abort())
 
   return (event) => {
@@ -74,10 +80,17 @@ describe('navigate', () => {
       src: '/partials/login',
       target: 'auth',
       history: 'replace',
+      viewTransition: true,
     })
 
     expect(navigateMock).toHaveBeenCalledWith('/login', {
-      state: { target: 'auth', src: '/partials/login', resetScroll: true, $rmx: true },
+      state: {
+        target: 'auth',
+        src: '/partials/login',
+        resetScroll: true,
+        viewTransition: true,
+        $rmx: true,
+      },
       history: 'replace',
     })
   })
@@ -95,6 +108,59 @@ describe('navigate', () => {
       state: { target: undefined, src: '/login', resetScroll: false, $rmx: true },
       history: undefined,
     })
+  })
+
+  it('runs opted-in frame reloads inside a view transition when supported', async (t) => {
+    let events: string[] = []
+    let startViewTransition = mock.fn((update: ViewTransitionUpdateCallback) => {
+      events.push('transition')
+      let updateCallbackDone = Promise.resolve().then(async () => {
+        events.push('update')
+        await update()
+      })
+      return { updateCallbackDone }
+    })
+    stubObjectField(t, document, 'startViewTransition', startViewTransition)
+
+    let topFrame = { src: '' } as FrameHandle
+    let reloadFrame = mock.fn(async () => {
+      events.push('reload')
+      return { signal: new AbortController().signal }
+    })
+    let dispatchNavigation = startStubNavigationListener(t, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: () => topFrame,
+      reloadFrame,
+    })
+    let anchor = document.createElement('a')
+    anchor.href = '/login'
+    let intercept = mock.fn()
+
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept,
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+    let handler = intercept.mock.calls[0]?.arguments[0]?.handler
+    if (!handler) throw new Error('Expected navigation interception handler')
+    await handler()
+
+    anchor.setAttribute('data-rmx-view-transition', '')
+    dispatchNavigation(
+      createAnchorNavigateEvent(anchor, {
+        intercept,
+        destinationUrl: new URL('/login', window.location.origin).href,
+      }),
+    )
+
+    handler = intercept.mock.calls[1]?.arguments[0]?.handler
+    if (!handler) throw new Error('Expected navigation interception handler')
+    await handler()
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(reloadFrame).toHaveBeenCalledTimes(2)
+    expect(events).toEqual(['reload', 'transition', 'update', 'reload'])
   })
 
   it('leaves default scrolling to the browser', async (t) => {
@@ -567,6 +633,40 @@ describe('navigate', () => {
 describe('form navigation', () => {
   afterEach(() => {
     document.body.textContent = ''
+  })
+
+  it('runs opted-in form reloads inside a view transition when supported', async (t) => {
+    let startViewTransition = mock.fn((update: ViewTransitionUpdateCallback) => {
+      let updateCallbackDone = Promise.resolve().then(async () => {
+        await update()
+      })
+      return { updateCallbackDone }
+    })
+    stubObjectField(t, document, 'startViewTransition', startViewTransition)
+
+    let reloadFrame = mock.fn(async () => ({ signal: new AbortController().signal }))
+    let dispatchNavigation = startStubNavigationListener(t, {
+      getTopFrame: () => stubFrame,
+      getNamedFrame: () => stubFrame,
+      reloadFrame,
+    })
+    let form = document.createElement('form')
+    form.setAttribute('data-rmx-view-transition', '')
+    let intercept = mock.fn()
+
+    dispatchNavigation(
+      createFormNavigateEvent(form, {
+        intercept,
+        destinationUrl: new URL('/account', window.location.origin).href,
+      }),
+    )
+
+    let handler = intercept.mock.calls[0]?.arguments[0]?.handler
+    if (!handler) throw new Error('Expected navigation interception handler')
+    await handler()
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(reloadFrame).toHaveBeenCalledTimes(1)
   })
 
   it('replaces same-location POST submission history before commit when supported', async () => {


### PR DESCRIPTION
Enhanced Remix UI navigation currently replaces frame content without invoking the View Transitions API, so applications cannot use same-document transitions for hydrated links and forms without taking over navigation themselves.

This adds an explicit opt-in while leaving existing navigation behavior unchanged by default.

- Add `data-rmx-view-transition` support to enhanced anchors and forms
- Add `viewTransition: true` to the `navigate()` and `link()` options
- Run opted-in frame reloads inside `document.startViewTransition()` with a normal fallback in unsupported browsers
- Document the new behavior and cover declarative and programmatic navigation

```tsx
<a href="/next" data-rmx-view-transition>
  Next
</a>

<form action="/account" method="post" data-rmx-view-transition>
  {/* ... */}
</form>

<a {...link('/next', { viewTransition: true })}>Next</a>
```

```ts
await navigate('/next', { viewTransition: true })
```

Closes #11656
