### PR TITLE
Skip Navigation API usage when window.navigation is missing

### DIFF
--- a/packages/ui/.changes/patch.navigation-api-fallback.md
+++ b/packages/ui/.changes/patch.navigation-api-fallback.md
@@ -1,1 +1,1 @@
-Gracefully degrade to document navigations for browsers that do not support the Navigation API (see #11665).
+`run()` no longer throws on browsers without the Navigation API. Skip listener setup and fall back to `location.assign` / `location.replace` for `navigate()` (see #11641).

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -42,7 +42,11 @@ interface FrameRedirectNavigationInfo {
 const formSubmissionNavigationInfoType = 'frame-form-submission'
 const frameRedirectNavigationInfoType = 'frame-redirect'
 
-function resyncWebKitScrollAfterNavigation(event: NavigateEvent, resetScroll: boolean): void {
+function resyncWebKitScrollAfterNavigation(
+  navigation: Navigation,
+  event: NavigateEvent,
+  resetScroll: boolean,
+): void {
   let userAgent = navigator.userAgent
   if (!userAgent.includes('AppleWebKit')) return
   if (userAgent.includes('Chrome') || userAgent.includes('Chromium')) return
@@ -50,7 +54,7 @@ function resyncWebKitScrollAfterNavigation(event: NavigateEvent, resetScroll: bo
     return
   if (new URL(event.destination.url).hash) return
 
-  window.navigation.addEventListener(
+  navigation.addEventListener(
     'navigatesuccess',
     () => {
       // WebKit can reset its internal scroll position without synchronizing the visual viewport.
@@ -77,7 +81,10 @@ export type NavigationOptions = {
 }
 
 /**
- * Performs a Navigation API transition understood by Remix frame runtime state.
+ * Performs a frame-aware navigation.
+ *
+ * Uses the Navigation API when it is available. On browsers without that API, falls back to
+ * `location.assign` or `location.replace` so `run()` and `navigate()` still complete.
  *
  * @param href Destination URL.
  * @param options Navigation options.
@@ -105,6 +112,8 @@ export async function navigate(href: string, options?: NavigationOptions) {
 
 /**
  * Starts listening for Navigation API transitions and routes them through frame reloads.
+ *
+ * Does nothing on browsers that do not implement the Navigation API.
  *
  * @param signal Abort signal used to remove the listener.
  * @returns void
@@ -144,7 +153,7 @@ export function startNavigationListenerImpl(
       if (!event.canIntercept || isCrossOriginDestination(event)) return
 
       if (isFrameRedirectNavigationInfo(event.info)) {
-        resyncWebKitScrollAfterNavigation(event, event.info.resetScroll)
+        resyncWebKitScrollAfterNavigation(navigation, event, event.info.resetScroll)
         event.intercept({
           async handler() {},
           scroll: event.info.resetScroll === false ? 'manual' : undefined,
@@ -161,7 +170,7 @@ export function startNavigationListenerImpl(
         : getRuntimeNavigation(navigation, event, resolveFormNavigation)
       if (!runtimeNavigation) return
       let { state } = runtimeNavigation
-      resyncWebKitScrollAfterNavigation(event, state.resetScroll)
+      resyncWebKitScrollAfterNavigation(navigation, event, state.resetScroll)
 
       let topFrame = options.getTopFrame()
       let namedFrame = state.target ? options.getNamedFrame(state.target) : undefined

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../runtime/navigation.ts'
 import type { FrameHandle } from '../runtime/component.ts'
 import type { ResolveFrameOptions } from '../runtime/frame.ts'
+import { run } from '../runtime/run.ts'
 import { withResolvers } from './utils.ts'
 
 // Stand-in frame the navigation handler can call without dragging in the
@@ -171,10 +172,26 @@ describe('navigate', () => {
     let addDocumentListener = t.mock.method(document, 'addEventListener')
     let controller = new AbortController()
 
-    startNavigationListener(controller.signal)
+    expect(() => startNavigationListener(controller.signal)).not.toThrow()
 
     expect(addDocumentListener).not.toHaveBeenCalled()
     controller.abort()
+  })
+
+  it('lets run() return when the Navigation API is unavailable', (t) => {
+    stubGlobalField(t, 'navigation', undefined)
+    let afterRun = false
+
+    let app = run({ loadModule: mock.fn() })
+    t.after(() => app.dispose())
+
+    // Application code sequenced after run() must still execute, including error reporting.
+    app.addEventListener('error', () => {})
+    afterRun = true
+
+    expect(afterRun).toBe(true)
+    expect(typeof app.ready).toBe('function')
+    expect(typeof app.dispose).toBe('function')
   })
 
   it('leaves default scrolling to the browser', async (t) => {


### PR DESCRIPTION
fixes #11641

run() reads window.navigation on boot. on browsers without the Navigation API that throw is unhandled, so run() never returns.

We skip the Navigation API listeners when window.navigation is missing and fall back to location.assign / location.replace.

the ui navigation test covers run() still returning.