### PR TITLE
fix(ui): allow handle.update() during a component's first render

### DIFF
--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -279,10 +279,13 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
   #updateDomParent: ParentNode | undefined
   #scheduleUpdate = (): void => {
     let queue = this.#updateQueue
-    if (!queue) throw new Error('scheduleUpdate not implemented')
     let vnode = this.#updateVNode
     let domParent = this.#updateDomParent
-    if (!vnode || !domParent) throw new Error('scheduleUpdate target not initialized')
+
+    // Updates during setup or the first render are already reflected by the
+    // in-flight render. Their tasks will be enqueued after the first commit.
+    if (!queue || !vnode || !domParent) return
+
     queue.enqueue(vnode, domParent)
   }
   #tasks: Task[] = []

--- a/packages/ui/src/test/vdom.components.test.tsx
+++ b/packages/ui/src/test/vdom.components.test.tsx
@@ -15,6 +15,44 @@ describe('vnode rendering', () => {
   describe('components', () => {
     it.todo('warns when render is called after component is removed')
 
+    it('allows handle.update() during setup and the first render', async () => {
+      let container = document.createElement('div')
+      let capturedUpdate = () => Promise.resolve(AbortSignal.abort())
+      let initialUpdates: Array<Promise<AbortSignal>> = []
+
+      function App(handle: Handle) {
+        capturedUpdate = () => handle.update()
+        initialUpdates.push(handle.update())
+
+        let renderCount = 0
+        return () => {
+          renderCount++
+          if (renderCount === 1) {
+            initialUpdates.push(handle.update())
+          }
+          return <p>{renderCount}</p>
+        }
+      }
+
+      let root = createRoot(container)
+      root.render(<App />)
+
+      // Both updates coalesce into the in-flight first render rather than
+      // scheduling an additional render.
+      expect(container.innerHTML).toBe('<p>1</p>')
+
+      root.flush()
+      await Promise.all(initialUpdates)
+
+      // Once the first commit has initialized the scheduling target, updates
+      // continue to schedule real re-renders.
+      let update = capturedUpdate()
+      root.flush()
+      await update
+
+      expect(container.innerHTML).toBe('<p>2</p>')
+    })
+
     it('inserts a component', () => {
       let container = document.createElement('div')
       function App() {


### PR DESCRIPTION
fixes #11642

handle.update() during setup or the first render calls scheduleUpdate before the queue exists, so you get scheduleUpdate not implemented.

We treat scheduling as a no-op until that is initialized. the update is already in the in-flight render.

the vdom component tests cover setup, first render, and after commit.