### PR TITLE
Clarify Remix UI soft navigation behavior

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -100,8 +100,7 @@ await app.ready()
 ```
 
 This soft-navigation behavior applies even when the page only uses `clientEntry()` and does not
-render an explicit `<Frame>`. Because the browser keeps the current document, behavior that depends
-on loading a new document, including cross-document view transitions, does not run.
+render an explicit `<Frame>`.
 
 The default resolver is equivalent to:
 
@@ -160,9 +159,7 @@ and forms as document navigations while still hydrating client entries and using
 register a listener before calling `run()`:
 
 ```ts
-window.navigation?.addEventListener('navigate', (event) => {
-  event.stopImmediatePropagation()
-})
+window.navigation?.addEventListener('navigate', (e) => e.stopImmediatePropagation())
 ```
 
 This prevents Remix from intercepting Navigation API events. Explicit frame reloads such as

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -81,8 +81,10 @@ function Actions() {
 
 ## Frame Navigation
 
-`run()` progressively enhances same-origin links and forms using a default `resolveFrame` that
-fetches the frame source:
+Calling `run()` starts both hydration and frame navigation. It represents the current document as
+`app.frames.top` and intercepts eligible same-origin links and forms through the browser's
+Navigation API. Those navigations fetch HTML with the frame resolver and update the existing
+document in place instead of loading a new document:
 
 ```tsx
 import { run } from 'remix/ui'
@@ -96,6 +98,10 @@ let app = run({
 
 await app.ready()
 ```
+
+This soft-navigation behavior applies even when the page only uses `clientEntry()` and does not
+render an explicit `<Frame>`. Because the browser keeps the current document, behavior that depends
+on loading a new document, including cross-document view transitions, does not run.
 
 The default resolver is equivalent to:
 
@@ -149,7 +155,18 @@ CRLF-delimited text, and `multipart/form-data` submissions use `FormData`. Pass 
 `resolveFrame` when the server requires additional headers, another body encoding, or a different
 response policy.
 
-Add `data-rmx-document` to a link or form to leave its navigation to the browser.
+Add `data-rmx-document` to a link or form to leave that navigation to the browser. To keep all links
+and forms as document navigations while still hydrating client entries and using explicit frames,
+register a listener before calling `run()`:
+
+```ts
+window.navigation?.addEventListener('navigate', (event) => {
+  event.stopImmediatePropagation()
+})
+```
+
+This prevents Remix from intercepting Navigation API events. Explicit frame reloads such as
+`handle.frame.reload()` continue to use the frame resolver.
 
 The default resolver rejects non-OK responses with an error containing their status and status text.
 A custom `resolveFrame` may return a `Response` with any status when it wants Remix UI to render the

--- a/packages/ui/docs/component.md
+++ b/packages/ui/docs/component.md
@@ -105,9 +105,11 @@ let app = run({
 await app.ready()
 ```
 
-`run()` fetches frame sources by default, including the submitted method, encoding, and `FormData`.
-Provide `resolveFrame` only when the app needs custom request headers, body encoding, or response
-policy. Add `data-rmx-document` to a link or form to leave its navigation to the browser.
+`run()` hydrates client entries and makes the current document the top-level frame. Eligible
+same-origin links and forms then soft-navigate by fetching HTML and updating that frame in place,
+even when the page does not render an explicit `<Frame>`. Provide `resolveFrame` only when the app
+needs custom request headers, body encoding, or response policy. See
+[Link navigation](./frames.md#link-navigation) for document-navigation effects and opt-outs.
 
 ### Frames
 

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -232,29 +232,19 @@ additional headers, another body encoding, or a different response policy. Custo
 The default resolver rejects non-OK responses. A custom resolver may return a `Response` with any
 status when it wants Remix UI to render the response body.
 
-A client resolver may return frame content directly or return the fetched `Response`. Returning the response lets Remix stream its body. When `fetch()` followed a redirect during a top-frame navigation, the final response URL replaces the browser navigation URL and becomes the top frame's canonical `src`; other frames render the response without changing either URL.
+A client resolver may return frame content directly or return the fetched `Response`. Returning the
+response lets Remix stream its body. When `fetch()` followed a redirect during a top-frame navigation,
+the final response URL replaces the browser navigation URL and becomes the top frame's canonical `src`;
+other frames render the response without changing either URL.
 
 Because this function defines the trust boundary for frame HTML, only return content from sources you trust.
 
 ## Link navigation
 
 Calling `run()` represents the current document as `handle.frames.top` and starts a Navigation API
-listener. Eligible same-origin anchor navigations reload that top frame through the frame resolver
-instead of performing a full document navigation. This soft-navigation behavior applies even when
-the page does not render an explicit `<Frame>`.
-
-A soft navigation fetches the destination HTML and reconciles it into the existing document. The
-browser therefore does not run behavior tied to loading a new document, including cross-document
-view transitions.
-
-In browsers that support same-document view transitions, wrap an imperative soft navigation with
-`document.startViewTransition()`:
-
-```ts
-import { navigate } from 'remix/ui'
-
-document.startViewTransition(() => navigate('/dashboard'))
-```
+listener. Eligible same-origin anchor navigations reload top frame HTML through the frame resolver
+and reconcile it into the existing document instead of performing a full document navigation. This
+soft-navigation behavior applies even when the page does not render an explicit `<Frame>`.
 
 - `data-rmx-target="name"` reloads a named frame.
 - `data-rmx-src="/frame"` overrides the URL resolved into that frame while `href` remains the navigation destination.
@@ -262,15 +252,12 @@ document.startViewTransition(() => navigate('/dashboard'))
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
 - `data-rmx-document` leaves the link as a normal document navigation.
 
-The `link(href, { history })` mixin adds the corresponding `data-rmx-history` value when its host is a native anchor. Download links, cross-origin links, and links marked with `data-rmx-document` are left to the browser.
-
-To keep every link and form as a document navigation while still hydrating client entries and using
-explicit frames, register a Navigation API listener before calling `run()`:
+To keep links/forms as a document navigations while still hydrating client entries and using explicit
+frames, you can cancel the built-in `navigate` event behavior with your own listener before calling
+`run()`:
 
 ```ts
-window.navigation?.addEventListener('navigate', (event) => {
-  event.stopImmediatePropagation()
-})
+window.navigation?.addEventListener('navigate', (e) => event.stopImmediatePropagation())
 ```
 
 This prevents Remix from receiving navigation events, including events for `data-rmx-target` and

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -238,7 +238,23 @@ Because this function defines the trust boundary for frame HTML, only return con
 
 ## Link navigation
 
-Eligible same-origin anchor navigations reload `handle.frames.top` through the frame resolver instead of performing a full document navigation.
+Calling `run()` represents the current document as `handle.frames.top` and starts a Navigation API
+listener. Eligible same-origin anchor navigations reload that top frame through the frame resolver
+instead of performing a full document navigation. This soft-navigation behavior applies even when
+the page does not render an explicit `<Frame>`.
+
+A soft navigation fetches the destination HTML and reconciles it into the existing document. The
+browser therefore does not run behavior tied to loading a new document, including cross-document
+view transitions.
+
+In browsers that support same-document view transitions, wrap an imperative soft navigation with
+`document.startViewTransition()`:
+
+```ts
+import { navigate } from 'remix/ui'
+
+document.startViewTransition(() => navigate('/dashboard'))
+```
 
 - `data-rmx-target="name"` reloads a named frame.
 - `data-rmx-src="/frame"` overrides the URL resolved into that frame while `href` remains the navigation destination.
@@ -247,6 +263,18 @@ Eligible same-origin anchor navigations reload `handle.frames.top` through the f
 - `data-rmx-document` leaves the link as a normal document navigation.
 
 The `link(href, { history })` mixin adds the corresponding `data-rmx-history` value when its host is a native anchor. Download links, cross-origin links, and links marked with `data-rmx-document` are left to the browser.
+
+To keep every link and form as a document navigation while still hydrating client entries and using
+explicit frames, register a Navigation API listener before calling `run()`:
+
+```ts
+window.navigation?.addEventListener('navigate', (event) => {
+  event.stopImmediatePropagation()
+})
+```
+
+This prevents Remix from receiving navigation events, including events for `data-rmx-target` and
+imperative `navigate()` calls. Explicit reloads such as `handle.frame.reload()` continue to work.
 
 ## Form navigation
 

--- a/packages/ui/docs/getting-started.md
+++ b/packages/ui/docs/getting-started.md
@@ -124,9 +124,11 @@ let app = run({
 await app.ready()
 ```
 
-`run()` fetches frame sources by default, including the submitted method, encoding, and `FormData`.
-Provide `resolveFrame` only when the app needs custom request headers, body encoding, or response
-policy. Add `data-rmx-document` to a link or form to leave its navigation to the browser.
+`run()` hydrates client entries and makes the current document the top-level frame. Eligible
+same-origin links and forms then soft-navigate by fetching HTML and updating that frame in place,
+even when the page does not render an explicit `<Frame>`. Provide `resolveFrame` only when the app
+needs custom request headers, body encoding, or response policy. See
+[Link navigation](./frames.md#link-navigation) for document-navigation effects and opt-outs.
 
 ### Client entry component
 

--- a/packages/ui/docs/hydration.md
+++ b/packages/ui/docs/hydration.md
@@ -58,6 +58,14 @@ let app = run({
 await app.ready()
 ```
 
+`run()` also creates `app.frames.top` for the current document and starts listening for Navigation
+API events. Eligible same-origin links and forms then use soft navigation: Remix fetches their HTML
+through the frame resolver and updates the existing document instead of loading a new one. This
+happens even when the page only uses `clientEntry()` and does not render an explicit `<Frame>`.
+
+See [Link navigation](./frames.md#link-navigation) for the document-level effects of soft navigation
+and how to opt out for one navigation or the whole app.
+
 ### `run` options
 
 - **`loadModule(moduleUrl, exportName)`** (required) - Called for each client entry found in the page. Return the component function. Typically uses dynamic `import()`.


### PR DESCRIPTION
Calling `run()` hydrates client entries, but it also initializes the current document as the top frame and automatically intercepts eligible same-origin navigations. The existing docs mention frame navigation without making that coupling or its document-level consequences clear.

- Explain that soft navigations fetch and reconcile HTML in the existing document, even without an explicit `<Frame>`
- Call out that cross-document behavior such as document view transitions does not run during a soft navigation
- Document same-document view transitions and both per-navigation and app-wide opt-outs
- Align the package README, hydration, frames, component, and getting-started docs

Closes #11656
