### PR TITLE
Install Playwright browsers for Bun tests

### DIFF
--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -158,6 +158,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright Version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(pnpm --filter @remix-run/ui exec playwright --version | cut -d ' ' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright Browsers
+        id: cache-browsers
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Browsers
+        if: steps.cache-browsers.outputs.cache-hit != 'true'
+        run: pnpm --filter @remix-run/ui exec playwright install --with-deps
+
       - name: Run Bun tests
         run: pnpm test:bun
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,6 +73,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright Version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(pnpm --filter @remix-run/ui exec playwright --version | cut -d ' ' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v5
+        id: cache-browsers
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Browsers
+        if: steps.cache-browsers.outputs.cache-hit != 'true'
+        run: pnpm --filter @remix-run/ui exec playwright install --with-deps
+
       - name: Run Bun tests
         run: pnpm test:bun
 


### PR DESCRIPTION
The Bun jobs on `main` run browser tests but did not install Playwright's browser binaries. This caused the new `@remix-run/spa` browser tests to fail before they could run.

- Add the same versioned Playwright browser cache used by the Node test jobs.
- Install the browsers when the cache is missing.
- Apply the fix to both the [Test](https://github.com/remix-run/remix/actions/runs/33427344183) and [Check main](https://github.com/remix-run/remix/actions/runs/33427344198) Bun jobs.
