### PR TITLE
Add lazy-loaded Frames demo

### DIFF
--- a/demos/lazy-frames/.gitignore
+++ b/demos/lazy-frames/.gitignore
@@ -1,0 +1,1 @@
+public/assets/

--- a/demos/lazy-frames/README.md
+++ b/demos/lazy-frames/README.md
@@ -37,6 +37,6 @@ For motion content, `pauseAnimationsWhenInactive` adds a zero-margin observer. `
 - [`app/middleware/demo-latency.ts`](app/middleware/demo-latency.ts) reads the latency cookie, exposes its state through typed request context, and applies the delay across the middleware stack.
 - [`app/actions/frames/controller.tsx`](app/actions/frames/controller.tsx) shows the three response strategies behind one typed route map. Plain HTML routes use `openLazyFile()` and `createFileResponse()` to stream files from [`app/actions/frames/html`](app/actions/frames/html). [`edition-orbit.html`](app/actions/frames/html/edition-orbit.html) models a motion-pipeline artifact with scoped inline CSS, prefixed keyframes, and a reduced-motion fallback.
 - [`app/actions/frames/public/frame-playground.tsx`](app/actions/frames/public/frame-playground.tsx) is loaded only when an interactive frame arrives. Its local count survives a containing-frame reload.
-- [`app/app.test.e2e.ts`](app/app.test.e2e.ts) verifies eager SSR versus lazy browser delivery, root-level theming without refetching, viewport-driven motion pausing, one-request retention, and hydration of client components inserted by a Frame.
+- [`app/app.test.e2e.ts`](app/app.test.e2e.ts) verifies lazy browser delivery, viewport-driven motion pausing, one-request retention, and theme changes without refetching.
 
 Run `pnpm test` and `pnpm typecheck` to validate the demo.

--- a/demos/lazy-frames/README.md
+++ b/demos/lazy-frames/README.md
@@ -12,7 +12,7 @@ pnpm start
 
 Visit [http://localhost:44100](http://localhost:44100) and scroll through the page. Use the browser network panel to see frame requests begin only as their sections approach. The fixed controls can switch the entire document between light and dark themes without refetching Frames, or enable a cookie-backed 520 ms delay on every router request, including pages, frames, and browser modules.
 
-For server restarts while editing, run `pnpm dev`.
+`pnpm start` runs in production mode. Frame responses are publicly cacheable for five minutes and may be served stale while revalidating for one hour. Run `pnpm dev` to use the watch server and send `Cache-Control: no-store` from Frame routes. Switching between the commands makes the cache behavior visible in the network panel without changing application code.
 
 ## One Shared Document
 

--- a/demos/lazy-frames/README.md
+++ b/demos/lazy-frames/README.md
@@ -1,0 +1,42 @@
+# Lazy Frames Demo
+
+This demo renders a long page without fetching every section up front. Its first study sends one checked-in HTML/CSS motion artifact through a regular server-rendered `Frame` and the same route through `LazyFrame`. The remaining sections use the same lazy client component: it server-renders a placeholder, observes its stable host, then mounts a Remix `Frame` when the host enters a 320 px vertical viewport margin. Requested Frames stay mounted when they leave the viewport, so scrolling back never triggers another round trip.
+
+## Run It
+
+```sh
+cd demos/lazy-frames
+pnpm install
+pnpm start
+```
+
+Visit [http://localhost:44100](http://localhost:44100) and scroll through the page. Use the browser network panel to see frame requests begin only as their sections approach. The fixed controls can switch the entire document between light and dark themes without refetching Frames, or enable a cookie-backed 520 ms delay on every router request, including pages, frames, and browser modules.
+
+For server restarts while editing, run `pnpm dev`.
+
+## One Shared Document
+
+A Frame is not an iframe. Its response becomes ordinary DOM inside the parent document, so inherited CSS custom properties theme checked-in HTML, server-rendered Remix UI, and hydrated client components together. The theme control changes `data-theme` on the document root and persists the value in a cookie; existing Frames update in place without losing client state or making another request.
+
+For motion content, `pauseAnimationsWhenInactive` adds a zero-margin observer. `LazyFrame` applies a host-level `css()` mixin while that host is outside the viewport, pausing descendant animations until it returns. The Frame stays mounted throughout; non-motion Frames avoid the extra observer.
+
+## Response Shapes
+
+| Frame route               | Response                                         | Demonstrates                                                    |
+| ------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| `/frames/html/:id`        | A checked-in `.html` fragment streamed from disk | Frames do not require the Remix UI renderer                     |
+| `/frames/ui/:id`          | Server-rendered Remix UI                         | Components and generated styles delivered as frame HTML         |
+| `/frames/interactive/:id` | Remix UI containing a `clientEntry`              | Client components discovered and hydrated after frame insertion |
+
+## Explore the Code
+
+- [`app/ui/public/lazy-frame.tsx`](app/ui/public/lazy-frame.tsx) owns Frame mounting and optional stage activity. Its `children` and `fallback` props keep waiting and fetching presentation caller-owned, while its host-level `css()` mixin demonstrates styling Frame descendants from outside the response.
+- [`app/ui/public/theme-toggle.tsx`](app/ui/public/theme-toggle.tsx) updates the root theme and its browser-writable preference cookie without navigating or reloading Frames.
+- [`app/actions/home.tsx`](app/actions/home.tsx) compares eager and lazy delivery of the same artifact, then composes nine more sections without repeating browser lifecycle code.
+- [`app/middleware/theme.ts`](app/middleware/theme.ts) supplies the saved theme during server rendering, while [`app/ui/document.tsx`](app/ui/document.tsx) defines the shared light and dark design tokens inherited by every response shape.
+- [`app/middleware/demo-latency.ts`](app/middleware/demo-latency.ts) reads the latency cookie, exposes its state through typed request context, and applies the delay across the middleware stack.
+- [`app/actions/frames/controller.tsx`](app/actions/frames/controller.tsx) shows the three response strategies behind one typed route map. Plain HTML routes use `openLazyFile()` and `createFileResponse()` to stream files from [`app/actions/frames/html`](app/actions/frames/html). [`edition-orbit.html`](app/actions/frames/html/edition-orbit.html) models a motion-pipeline artifact with scoped inline CSS, prefixed keyframes, and a reduced-motion fallback.
+- [`app/actions/frames/public/frame-playground.tsx`](app/actions/frames/public/frame-playground.tsx) is loaded only when an interactive frame arrives. Its local count survives a containing-frame reload.
+- [`app/app.test.e2e.ts`](app/app.test.e2e.ts) verifies eager SSR versus lazy browser delivery, root-level theming without refetching, viewport-driven motion pausing, one-request retention, and hydration of client components inserted by a Frame.
+
+Run `pnpm test` and `pnpm typecheck` to validate the demo.

--- a/demos/lazy-frames/app/actions/controller.tsx
+++ b/demos/lazy-frames/app/actions/controller.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'remix/response/redirect'
+import { createController } from 'remix/router'
+
+import { demoLatencyContext, serializeDemoLatency } from '../middleware/demo-latency.ts'
+import { themeContext } from '../middleware/theme.ts'
+import { routes } from '../routes.ts'
+import { assets } from '../utils/assets.ts'
+import { HomePage } from './home.tsx'
+
+export default createController(routes, {
+  actions: {
+    async assets({ request }) {
+      let response = await assets.fetch(request)
+      return response ?? new Response('Not found', { status: 404 })
+    },
+
+    home({ get, render }) {
+      return render(<HomePage latency={get(demoLatencyContext)} theme={get(themeContext)} />)
+    },
+
+    async latency({ request }) {
+      let formData = await request.formData()
+      let enabled = formData.get('enabled')
+      if (enabled !== 'true' && enabled !== 'false') {
+        return new Response('Expected enabled to be true or false', { status: 400 })
+      }
+
+      return redirect(routes.home.href(), {
+        status: 303,
+        headers: { 'Set-Cookie': await serializeDemoLatency(enabled === 'true') },
+      })
+    },
+  },
+})

--- a/demos/lazy-frames/app/actions/frames/controller.tsx
+++ b/demos/lazy-frames/app/actions/frames/controller.tsx
@@ -21,7 +21,7 @@ export const framesController = createController(routes.frames, {
       if (filename === undefined) return notFound()
 
       return createFileResponse(openLazyFile(filename), request, {
-        cacheControl: 'no-cache',
+        cacheControl: frameCacheControl,
         acceptRanges: false,
       })
     },
@@ -30,7 +30,10 @@ export const framesController = createController(routes.frames, {
       let exhibit = getExhibit(params.id)
       if (exhibit?.kind !== 'ui') return notFound()
 
-      return render(<MetricFrame exhibit={exhibit} servedAt={formatTime(new Date())} />, noStore)
+      return render(
+        <MetricFrame exhibit={exhibit} servedAt={formatTime(new Date())} />,
+        frameResponseInit,
+      )
     },
 
     async interactive({ params, render }) {
@@ -39,7 +42,7 @@ export const framesController = createController(routes.frames, {
 
       return render(
         <InteractiveFrame exhibit={exhibit} servedAt={formatTime(new Date())} />,
-        noStore,
+        frameResponseInit,
       )
     },
   },
@@ -119,8 +122,13 @@ const htmlFrameFiles = new Map([
   ['reading-list', fileURLToPath(new URL('./html/reading-list.html', import.meta.url))],
 ])
 
-const noStore = {
-  headers: { 'Cache-Control': 'no-store' },
+const frameCacheControl =
+  process.env.NODE_ENV === 'production'
+    ? 'public, max-age=300, stale-while-revalidate=3600'
+    : 'no-store'
+
+const frameResponseInit = {
+  headers: { 'Cache-Control': frameCacheControl },
 } satisfies ResponseInit
 
 const uiFrameStyle = css({

--- a/demos/lazy-frames/app/actions/frames/controller.tsx
+++ b/demos/lazy-frames/app/actions/frames/controller.tsx
@@ -1,0 +1,229 @@
+import { fileURLToPath } from 'node:url'
+
+import { openLazyFile } from 'remix/fs'
+import { createFileResponse } from 'remix/response/file'
+import { createController } from 'remix/router'
+import { css, type Handle } from 'remix/ui'
+
+import {
+  getExhibit,
+  motionArtifact,
+  type InteractiveExhibit,
+  type UiExhibit,
+} from '../../data/exhibits.ts'
+import { routes } from '../../routes.ts'
+import { FramePlayground } from './public/frame-playground.tsx'
+
+export const framesController = createController(routes.frames, {
+  actions: {
+    async html({ params, request }) {
+      let filename = htmlFrameFiles.get(params.id)
+      if (filename === undefined) return notFound()
+
+      return createFileResponse(openLazyFile(filename), request, {
+        cacheControl: 'no-cache',
+        acceptRanges: false,
+      })
+    },
+
+    async ui({ params, render }) {
+      let exhibit = getExhibit(params.id)
+      if (exhibit?.kind !== 'ui') return notFound()
+
+      return render(<MetricFrame exhibit={exhibit} servedAt={formatTime(new Date())} />, noStore)
+    },
+
+    async interactive({ params, render }) {
+      let exhibit = getExhibit(params.id)
+      if (exhibit?.kind !== 'interactive') return notFound()
+
+      return render(
+        <InteractiveFrame exhibit={exhibit} servedAt={formatTime(new Date())} />,
+        noStore,
+      )
+    },
+  },
+})
+
+function MetricFrame(handle: Handle<{ exhibit: UiExhibit; servedAt: string }>) {
+  return () => {
+    let { exhibit, servedAt } = handle.props
+
+    return (
+      <article mix={uiFrameStyle}>
+        <div mix={uiFrameHeaderStyle}>
+          <h3 mix={uiHeadingStyle}>{exhibit.metricLabel}</h3>
+          <p mix={servedTimeStyle}>
+            Delivered at <time>{servedAt}</time>
+          </p>
+        </div>
+
+        <div mix={metricGridStyle}>
+          <p mix={metricStyle}>{exhibit.metric}</p>
+          <p mix={trendStyle}>{exhibit.trend}</p>
+        </div>
+
+        <ul mix={detailListStyle}>
+          {exhibit.details.map((detail) => (
+            <li key={detail} mix={detailItemStyle}>
+              <span aria-hidden="true" mix={detailMarkStyle} />
+              {detail}
+            </li>
+          ))}
+        </ul>
+      </article>
+    )
+  }
+}
+
+function InteractiveFrame(handle: Handle<{ exhibit: InteractiveExhibit; servedAt: string }>) {
+  return () => {
+    let { exhibit, servedAt } = handle.props
+
+    return (
+      <article mix={interactiveFrameStyle}>
+        <div mix={uiFrameHeaderStyle}>
+          <h3 mix={interactiveHeadingStyle}>{exhibit.prompt}</h3>
+        </div>
+
+        <FramePlayground
+          initialCount={exhibit.initialCount}
+          actionLabel={exhibit.actionLabel}
+          accent={exhibit.accent}
+          servedAt={servedAt}
+        />
+      </article>
+    )
+  }
+}
+
+function notFound(): Response {
+  return new Response('Frame example not found', {
+    status: 404,
+    headers: { 'Content-Type': 'text/plain; charset=UTF-8' },
+  })
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+const htmlFrameFiles = new Map([
+  [motionArtifact.id, fileURLToPath(new URL('./html/edition-orbit.html', import.meta.url))],
+  ['field-notes', fileURLToPath(new URL('./html/field-notes.html', import.meta.url))],
+  ['packing-list', fileURLToPath(new URL('./html/packing-list.html', import.meta.url))],
+  ['reading-list', fileURLToPath(new URL('./html/reading-list.html', import.meta.url))],
+])
+
+const noStore = {
+  headers: { 'Cache-Control': 'no-store' },
+} satisfies ResponseInit
+
+const uiFrameStyle = css({
+  borderRadius: '6px',
+  padding: 'clamp(24px, 4vw, 42px)',
+  backgroundColor: 'var(--server-frame-bg)',
+  color: 'var(--server-frame-text)',
+  transition: 'background-color 180ms ease, color 180ms ease',
+})
+
+const uiFrameHeaderStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: '24px',
+  '@media (max-width: 640px)': {
+    flexDirection: 'column',
+  },
+})
+
+const uiHeadingStyle = css({
+  maxWidth: '520px',
+  margin: 0,
+  fontSize: 'clamp(22px, 3vw, 34px)',
+  lineHeight: 1.08,
+  letterSpacing: '-0.03em',
+})
+
+const servedTimeStyle = css({
+  margin: 0,
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '11px',
+  color: 'var(--server-frame-muted)',
+  whiteSpace: 'nowrap',
+})
+
+const metricGridStyle = css({
+  display: 'grid',
+  gap: '16px',
+  marginTop: '42px',
+  paddingBottom: '32px',
+  borderBottom: '1px solid var(--server-frame-rule)',
+})
+
+const metricStyle = css({
+  margin: 0,
+  fontSize: 'clamp(48px, 8vw, 86px)',
+  fontWeight: 800,
+  lineHeight: 0.9,
+  letterSpacing: '-0.07em',
+  color: 'var(--server-frame-highlight)',
+})
+
+const trendStyle = css({
+  margin: 0,
+  paddingBottom: '5px',
+  fontSize: '15px',
+  lineHeight: 1.5,
+  color: 'var(--server-frame-copy)',
+})
+
+const detailListStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  gap: '12px',
+  margin: '28px 0 0',
+  padding: 0,
+  listStyle: 'none',
+  '@media (max-width: 720px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+const detailItemStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+  fontSize: '13px',
+  lineHeight: 1.4,
+  color: 'var(--server-frame-detail)',
+})
+
+const detailMarkStyle = css({
+  flex: '0 0 auto',
+  width: '7px',
+  height: '7px',
+  borderRadius: '50%',
+  backgroundColor: 'var(--server-frame-accent)',
+})
+
+const interactiveFrameStyle = css({
+  border: '1px solid var(--interactive-border)',
+  borderRadius: '6px',
+  padding: 'clamp(24px, 4vw, 42px)',
+  backgroundColor: 'var(--interactive-bg)',
+  color: 'var(--interactive-text)',
+  transition: 'background-color 180ms ease, border-color 180ms ease, color 180ms ease',
+})
+
+const interactiveHeadingStyle = css({
+  maxWidth: '520px',
+  margin: 0,
+  fontSize: 'clamp(22px, 3vw, 34px)',
+  lineHeight: 1.08,
+  letterSpacing: '-0.03em',
+})

--- a/demos/lazy-frames/app/actions/frames/html/edition-orbit.html
+++ b/demos/lazy-frames/app/actions/frames/html/edition-orbit.html
@@ -1,0 +1,185 @@
+<style>
+  [data-motion-artifact='edition-orbit'] {
+    --motion-coral: var(--theme-motion-coral, #ff785a);
+    --motion-cream: var(--theme-motion-cream, #fff7e8);
+    --motion-lime: var(--theme-motion-lime, #c9f27b);
+    --motion-bg-start: var(--theme-motion-bg-start, #1c3942);
+    --motion-bg-end: var(--theme-motion-bg-end, #182c35);
+    --motion-glow: var(--theme-motion-glow, rgba(201, 242, 123, 0.2));
+    --motion-border: var(--theme-motion-border, rgba(255, 247, 232, 0.22));
+    --motion-ring: var(--theme-motion-ring, rgba(255, 247, 232, 0.34));
+    --motion-ring-soft: var(--theme-motion-ring-soft, rgba(255, 247, 232, 0.2));
+    --motion-caption: var(--theme-motion-caption, rgba(255, 247, 232, 0.7));
+    position: relative;
+    min-height: 304px;
+    margin: 0;
+    overflow: hidden;
+    border: 1px solid var(--motion-border);
+    border-radius: 6px;
+    background:
+      radial-gradient(circle at 18% 14%, var(--motion-glow), transparent 31%),
+      linear-gradient(145deg, var(--motion-bg-start), var(--motion-bg-end));
+    color: var(--motion-cream);
+    isolation: isolate;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__copy {
+    position: relative;
+    z-index: 2;
+    width: min(58%, 320px);
+    padding: clamp(28px, 5vw, 48px);
+  }
+
+  [data-motion-artifact='edition-orbit'] h3 {
+    margin: 0;
+    font:
+      720 clamp(28px, 5vw, 54px) / 0.92 ui-sans-serif,
+      system-ui,
+      sans-serif;
+    letter-spacing: -0.055em;
+  }
+
+  [data-motion-artifact='edition-orbit'] figcaption {
+    margin-top: 20px;
+    font:
+      500 12px/1.6 ui-sans-serif,
+      system-ui,
+      sans-serif;
+    color: var(--motion-caption);
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__stage {
+    position: absolute;
+    z-index: 1;
+    top: 50%;
+    right: clamp(-108px, -9vw, -36px);
+    width: clamp(230px, 42vw, 390px);
+    aspect-ratio: 1;
+    transform: translateY(-50%);
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ring {
+    position: absolute;
+    inset: 11%;
+    border: 1px solid var(--motion-ring);
+    border-radius: 50%;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ring::before,
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ring::after {
+    position: absolute;
+    inset: 17%;
+    border: 1px solid var(--motion-ring-soft);
+    border-radius: inherit;
+    content: '';
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ring::after {
+    inset: 35%;
+    background: var(--motion-coral);
+    border-color: transparent;
+    box-shadow: 0 0 52px color-mix(in srgb, var(--motion-coral) 40%, transparent);
+    animation: lazy-frames-motion-breathe 2.8s ease-in-out infinite alternate;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__orbit {
+    position: absolute;
+    inset: 0;
+    animation: lazy-frames-motion-orbit 7s linear infinite;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__satellite {
+    position: absolute;
+    top: 5%;
+    left: 50%;
+    width: 18%;
+    aspect-ratio: 1;
+    border-radius: 35%;
+    background: var(--motion-lime);
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--motion-lime) 22%, transparent);
+    transform: translateX(-50%) rotate(18deg);
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ticker {
+    position: absolute;
+    right: 14%;
+    bottom: 14%;
+    display: grid;
+    grid-template-columns: repeat(3, 7px);
+    gap: 5px;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ticker span {
+    height: 7px;
+    border-radius: 999px;
+    background: var(--motion-cream);
+    opacity: 0.32;
+    animation: lazy-frames-motion-signal 1.4s ease-in-out infinite alternate;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ticker span:nth-child(2) {
+    animation-delay: 180ms;
+  }
+
+  [data-motion-artifact='edition-orbit'] .edition-orbit__ticker span:nth-child(3) {
+    animation-delay: 360ms;
+  }
+
+  @keyframes lazy-frames-motion-orbit {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+
+  @keyframes lazy-frames-motion-breathe {
+    to {
+      transform: scale(1.18);
+      box-shadow: 0 0 76px color-mix(in srgb, var(--motion-coral) 58%, transparent);
+    }
+  }
+
+  @keyframes lazy-frames-motion-signal {
+    to {
+      opacity: 1;
+      transform: translateY(-5px);
+    }
+  }
+
+  @media (max-width: 560px) {
+    [data-motion-artifact='edition-orbit'] .edition-orbit__copy {
+      width: 72%;
+    }
+
+    [data-motion-artifact='edition-orbit'] .edition-orbit__stage {
+      right: -120px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-motion-artifact='edition-orbit'] .edition-orbit__orbit,
+    [data-motion-artifact='edition-orbit'] .edition-orbit__ring::after,
+    [data-motion-artifact='edition-orbit'] .edition-orbit__ticker span {
+      animation: none;
+    }
+  }
+</style>
+
+<figure class="edition-orbit" data-motion-artifact="edition-orbit">
+  <div class="edition-orbit__copy">
+    <h3>Markup, styles,<br />and keyframes.</h3>
+    <figcaption>
+      This checked-in response inserts scoped CSS and motion into the parent document.
+    </figcaption>
+  </div>
+  <div class="edition-orbit__stage" aria-hidden="true">
+    <div class="edition-orbit__ring"></div>
+    <div class="edition-orbit__orbit">
+      <span class="edition-orbit__satellite"></span>
+    </div>
+    <div class="edition-orbit__ticker">
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+  </div>
+</figure>

--- a/demos/lazy-frames/app/actions/frames/html/edition-orbit.html
+++ b/demos/lazy-frames/app/actions/frames/html/edition-orbit.html
@@ -164,7 +164,7 @@
   }
 </style>
 
-<figure class="edition-orbit" data-motion-artifact="edition-orbit">
+<figure data-motion-artifact="edition-orbit">
   <div class="edition-orbit__copy">
     <h3>Markup, styles,<br />and keyframes.</h3>
     <figcaption>

--- a/demos/lazy-frames/app/actions/frames/html/field-notes.html
+++ b/demos/lazy-frames/app/actions/frames/html/field-notes.html
@@ -1,7 +1,7 @@
 <article class="plain-frame">
-  <header class="plain-frame__header">
-    <p class="plain-frame__label">Static HTML fragment</p>
-    <p class="plain-frame__time">field-notes.html</p>
+  <header>
+    <p>Static HTML fragment</p>
+    <p>field-notes.html</p>
   </header>
   <h3>This route returns a file, not a rendered component.</h3>
   <ul>
@@ -9,7 +9,7 @@
     <li>The route streams it from disk without calling the Remix UI renderer.</li>
     <li>The parent document styles it after the Frame inserts it.</li>
   </ul>
-  <p class="plain-frame__note">
+  <p>
     The route uses <code>openLazyFile()</code> and <code>createFileResponse()</code> to create the
     response.
   </p>

--- a/demos/lazy-frames/app/actions/frames/html/field-notes.html
+++ b/demos/lazy-frames/app/actions/frames/html/field-notes.html
@@ -1,0 +1,16 @@
+<article class="plain-frame">
+  <header class="plain-frame__header">
+    <p class="plain-frame__label">Static HTML fragment</p>
+    <p class="plain-frame__time">field-notes.html</p>
+  </header>
+  <h3>This route returns a file, not a rendered component.</h3>
+  <ul>
+    <li>The fragment is checked into the repository as HTML.</li>
+    <li>The route streams it from disk without calling the Remix UI renderer.</li>
+    <li>The parent document styles it after the Frame inserts it.</li>
+  </ul>
+  <p class="plain-frame__note">
+    The route uses <code>openLazyFile()</code> and <code>createFileResponse()</code> to create the
+    response.
+  </p>
+</article>

--- a/demos/lazy-frames/app/actions/frames/html/packing-list.html
+++ b/demos/lazy-frames/app/actions/frames/html/packing-list.html
@@ -1,0 +1,17 @@
+<article class="plain-frame">
+  <header class="plain-frame__header">
+    <p class="plain-frame__label">Static HTML fragment</p>
+    <p class="plain-frame__time">packing-list.html</p>
+  </header>
+  <h3>The file route keeps its input and response policy explicit.</h3>
+  <ul>
+    <li>Known IDs map to checked-in files.</li>
+    <li>Unknown IDs return a 404 response.</li>
+    <li><code>openLazyFile()</code> opens the selected file lazily.</li>
+    <li><code>createFileResponse()</code> handles the response body and headers.</li>
+    <li>Byte-range requests are disabled for these small fragments.</li>
+  </ul>
+  <p class="plain-frame__note">
+    The explicit ID map prevents route parameters from becoming arbitrary filesystem paths.
+  </p>
+</article>

--- a/demos/lazy-frames/app/actions/frames/html/packing-list.html
+++ b/demos/lazy-frames/app/actions/frames/html/packing-list.html
@@ -1,7 +1,7 @@
 <article class="plain-frame">
-  <header class="plain-frame__header">
-    <p class="plain-frame__label">Static HTML fragment</p>
-    <p class="plain-frame__time">packing-list.html</p>
+  <header>
+    <p>Static HTML fragment</p>
+    <p>packing-list.html</p>
   </header>
   <h3>The file route keeps its input and response policy explicit.</h3>
   <ul>
@@ -11,7 +11,5 @@
     <li><code>createFileResponse()</code> handles the response body and headers.</li>
     <li>Byte-range requests are disabled for these small fragments.</li>
   </ul>
-  <p class="plain-frame__note">
-    The explicit ID map prevents route parameters from becoming arbitrary filesystem paths.
-  </p>
+  <p>The explicit ID map prevents route parameters from becoming arbitrary filesystem paths.</p>
 </article>

--- a/demos/lazy-frames/app/actions/frames/html/reading-list.html
+++ b/demos/lazy-frames/app/actions/frames/html/reading-list.html
@@ -1,7 +1,7 @@
 <article class="plain-frame">
-  <header class="plain-frame__header">
-    <p class="plain-frame__label">Static HTML fragment</p>
-    <p class="plain-frame__time">reading-list.html</p>
+  <header>
+    <p>Static HTML fragment</p>
+    <p>reading-list.html</p>
   </header>
   <h3>Inserted Frame content becomes part of the parent document.</h3>
   <ul>
@@ -9,7 +9,5 @@
     <li>Parent descendant selectors can match the inserted elements.</li>
     <li>Theme changes update existing content without another Frame request.</li>
   </ul>
-  <p class="plain-frame__note">
-    A Remix Frame is not an iframe. This fragment has no script or component runtime.
-  </p>
+  <p>A Remix Frame is not an iframe. This fragment has no script or component runtime.</p>
 </article>

--- a/demos/lazy-frames/app/actions/frames/html/reading-list.html
+++ b/demos/lazy-frames/app/actions/frames/html/reading-list.html
@@ -1,0 +1,15 @@
+<article class="plain-frame">
+  <header class="plain-frame__header">
+    <p class="plain-frame__label">Static HTML fragment</p>
+    <p class="plain-frame__time">reading-list.html</p>
+  </header>
+  <h3>Inserted Frame content becomes part of the parent document.</h3>
+  <ul>
+    <li>Inherited properties and CSS custom properties cross the Frame boundary.</li>
+    <li>Parent descendant selectors can match the inserted elements.</li>
+    <li>Theme changes update existing content without another Frame request.</li>
+  </ul>
+  <p class="plain-frame__note">
+    A Remix Frame is not an iframe. This fragment has no script or component runtime.
+  </p>
+</article>

--- a/demos/lazy-frames/app/actions/frames/public/frame-playground.tsx
+++ b/demos/lazy-frames/app/actions/frames/public/frame-playground.tsx
@@ -1,0 +1,159 @@
+import { clientEntry, css, on, type Handle } from 'remix/ui'
+
+type FramePlaygroundProps = {
+  initialCount: number
+  actionLabel: string
+  accent: 'coral' | 'violet' | 'teal'
+  servedAt: string
+}
+
+export const FramePlayground = clientEntry(
+  import.meta.url,
+  function FramePlayground(handle: Handle<FramePlaygroundProps>) {
+    let count = handle.props.initialCount
+    let hydrated = false
+
+    handle.queueTask(() => {
+      hydrated = true
+      handle.update()
+    })
+
+    return () => (
+      <div mix={playgroundStyle}>
+        <div mix={statusRowStyle}>
+          <span
+            aria-hidden="true"
+            mix={[statusDotStyle, hydrated ? readyDotStyle : pendingDotStyle]}
+          />
+          {hydrated ? 'Client component ready' : 'Hydrating client component…'}
+        </div>
+
+        <p mix={countStyle}>Local count: {count}</p>
+        <div mix={buttonRowStyle}>
+          <button
+            type="button"
+            mix={[
+              actionButtonStyle,
+              accentStyles[handle.props.accent],
+              on('click', () => {
+                count++
+                handle.update()
+              }),
+            ]}
+          >
+            {handle.props.actionLabel}
+          </button>
+          <button
+            type="button"
+            mix={[
+              reloadButtonStyle,
+              on('click', async () => {
+                await handle.frame.reload()
+              }),
+            ]}
+          >
+            Reload Frame
+          </button>
+        </div>
+
+        <p mix={servedAtStyle}>
+          Frame response rendered at <time>{handle.props.servedAt}</time>. Local count is retained
+          when the Frame reloads.
+        </p>
+      </div>
+    )
+  },
+)
+
+const playgroundStyle = css({
+  marginTop: '24px',
+})
+
+const statusRowStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '13px',
+  fontWeight: 650,
+  color: 'var(--interactive-muted)',
+})
+
+const statusDotStyle = css({
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+})
+
+const pendingDotStyle = css({
+  backgroundColor: 'var(--interactive-pending)',
+})
+
+const readyDotStyle = css({
+  backgroundColor: '#13866f',
+  boxShadow: '0 0 0 4px rgba(19, 134, 111, 0.12)',
+})
+
+const countStyle = css({
+  margin: '14px 0 16px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '18px',
+  fontWeight: 700,
+  color: 'var(--interactive-text)',
+})
+
+const buttonRowStyle = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '10px',
+})
+
+const actionButtonStyle = css({
+  border: 0,
+  borderRadius: '6px',
+  padding: '11px 17px',
+  font: 'inherit',
+  fontSize: '14px',
+  fontWeight: 750,
+  color: '#ffffff',
+  cursor: 'pointer',
+  '&:hover': {
+    filter: 'brightness(0.92)',
+  },
+  '&:focus-visible': {
+    outline: '3px solid var(--interactive-text)',
+    outlineOffset: '3px',
+  },
+})
+
+const accentStyles = {
+  coral: css({ backgroundColor: '#d4543f' }),
+  violet: css({ backgroundColor: '#7557c8' }),
+  teal: css({ backgroundColor: '#157c70' }),
+}
+
+const reloadButtonStyle = css({
+  border: '1px solid var(--interactive-button-border)',
+  borderRadius: '6px',
+  padding: '10px 16px',
+  backgroundColor: 'transparent',
+  font: 'inherit',
+  fontSize: '14px',
+  fontWeight: 700,
+  color: 'var(--interactive-button-text)',
+  cursor: 'pointer',
+  '&:hover': {
+    borderColor: 'var(--interactive-accent)',
+    backgroundColor: 'var(--interactive-button-hover)',
+  },
+  '&:focus-visible': {
+    outline: '3px solid var(--interactive-accent)',
+    outlineOffset: '3px',
+  },
+})
+
+const servedAtStyle = css({
+  margin: '16px 0 0',
+  fontSize: '12px',
+  lineHeight: 1.6,
+  color: 'var(--interactive-subtle)',
+})

--- a/demos/lazy-frames/app/actions/home.tsx
+++ b/demos/lazy-frames/app/actions/home.tsx
@@ -1,0 +1,730 @@
+import { Frame, css, type Handle } from 'remix/ui'
+
+import { exhibits, motionArtifact, type Exhibit } from '../data/exhibits.ts'
+import type { DemoLatency } from '../middleware/demo-latency.ts'
+import { routes } from '../routes.ts'
+import { Document } from '../ui/document.tsx'
+import { LazyFrame } from '../ui/public/lazy-frame.tsx'
+import type { Theme } from '../ui/public/theme.ts'
+import { ThemeToggle } from '../ui/public/theme-toggle.tsx'
+
+export function HomePage(handle: Handle<{ latency: DemoLatency; theme: Theme }>) {
+  return () => (
+    <Document title="Lazy-loaded Frames" theme={handle.props.theme}>
+      <div mix={demoControlsStyle}>
+        <ThemeToggle theme={handle.props.theme} />
+        <LatencyToggle latency={handle.props.latency} />
+      </div>
+      <header mix={heroStyle}>
+        <div mix={heroInnerStyle}>
+          <h1 mix={heroHeadingStyle}>
+            Load Frames as
+            <br />
+            they approach.
+          </h1>
+          <p mix={heroCopyStyle}>
+            This demo’s <code>LazyFrame</code> renders a placeholder with the page, then mounts a
+            Remix <code>Frame</code> within 320 pixels of the viewport. Loaded Frames stay mounted.
+          </p>
+
+          <ol mix={flowStyle} aria-label="Lazy frame lifecycle">
+            <li mix={flowItemStyle}>
+              <span mix={flowNumberStyle}>1</span>
+              <span>The initial document contains the placeholder.</span>
+            </li>
+            <li mix={flowItemStyle}>
+              <span mix={flowNumberStyle}>2</span>
+              <span>An observer detects the host 320 pixels from the viewport.</span>
+            </li>
+            <li mix={flowItemStyle}>
+              <span mix={flowNumberStyle}>3</span>
+              <span>The Frame requests its route once and remains mounted.</span>
+            </li>
+          </ol>
+
+          <a href="#delivery-comparison" mix={scrollCueStyle}>
+            Compare delivery <span aria-hidden="true">↓</span>
+          </a>
+        </div>
+      </header>
+
+      <main mix={mainStyle}>
+        <DeliveryComparison />
+
+        <section mix={introStyle} aria-labelledby="response-shapes-heading">
+          <h2 id="response-shapes-heading" mix={introHeadingStyle}>
+            LazyFrame works with every response type
+          </h2>
+          <p mix={introCopyStyle}>
+            The examples alternate between checked-in HTML, server-rendered Remix UI, and Remix UI
+            with a client component. The loading behavior does not change.
+          </p>
+        </section>
+
+        {exhibits.map((exhibit, index) => (
+          <ExhibitSection key={exhibit.id} exhibit={exhibit} index={index} />
+        ))}
+      </main>
+
+      <footer mix={footerStyle}>
+        <h2 mix={footerHeadingStyle}>
+          Ten Frames loaded near the viewport. The first shipped with the document.
+        </h2>
+        <a href="#top" mix={footerLinkStyle}>
+          Return to the beginning
+        </a>
+      </footer>
+    </Document>
+  )
+}
+
+function LatencyToggle(handle: Handle<{ latency: DemoLatency }>) {
+  return () => {
+    let { enabled, duration } = handle.props.latency
+
+    return (
+      <form action={routes.latency.href()} method="post" mix={latencyToggleStyle}>
+        <input type="hidden" name="enabled" value={enabled ? 'false' : 'true'} />
+        <div mix={latencyStatusStyle}>
+          <span
+            aria-hidden="true"
+            mix={[latencyDotStyle, enabled ? latencyDotEnabledStyle : latencyDotDisabledStyle]}
+          />
+          <span>
+            <strong mix={latencyLabelStyle}>Global latency {enabled ? 'on' : 'off'}</strong>
+            <small mix={latencyDetailStyle}>
+              {enabled ? `${duration} ms on every request` : 'Responses run at full speed'}
+            </small>
+          </span>
+        </div>
+        <button type="submit" aria-pressed={enabled} mix={latencyButtonStyle}>
+          {enabled ? 'Disable' : 'Enable'}
+        </button>
+      </form>
+    )
+  }
+}
+
+function DeliveryComparison() {
+  return () => {
+    let frameHref = routes.frames.html.href({ id: motionArtifact.id })
+
+    return (
+      <section id="delivery-comparison" mix={comparisonSectionStyle}>
+        <header mix={comparisonHeaderStyle}>
+          <h2 mix={comparisonHeadingStyle}>The same response, eager and lazy</h2>
+          <div mix={comparisonDescriptionStyle}>
+            <p>
+              Both Frames resolve the route below. The regular Frame is resolved during server
+              rendering; LazyFrame waits to mount it in the browser. The checked-in fragment carries
+              scoped CSS, keyframes, and a reduced-motion fallback.
+            </p>
+            <code mix={routeStyle}>{frameHref}</code>
+          </div>
+        </header>
+
+        <div mix={comparisonGridStyle}>
+          <article data-delivery="eager" mix={deliveryCardStyle}>
+            <header mix={deliveryHeaderStyle}>
+              <h3 mix={deliveryHeadingStyle}>Regular Frame</h3>
+              <p mix={deliveryDetailStyle}>
+                <strong>Initial document.</strong> Resolved before the response is sent.
+              </p>
+            </header>
+            <div mix={frameShellStyle}>
+              <Frame src={frameHref} />
+            </div>
+          </article>
+
+          <article data-delivery="lazy" mix={deliveryCardStyle}>
+            <header mix={deliveryHeaderStyle}>
+              <h3 mix={deliveryHeadingStyle}>LazyFrame</h3>
+              <p mix={deliveryDetailStyle}>
+                <strong>Near the viewport.</strong> Requested once, retained, and paused offscreen.
+              </p>
+            </header>
+            <div mix={frameShellStyle}>
+              <LazyFrame
+                src={frameHref}
+                pauseAnimationsWhenInactive
+                fallback={
+                  <div class="frame-status frame-status--fetching">
+                    <span class="frame-status__dot" aria-hidden="true" />
+                    <span>
+                      <strong>Request in progress</strong>
+                      <small>The motion response has not arrived yet.</small>
+                    </span>
+                  </div>
+                }
+              >
+                <div class="frame-status frame-status--waiting">
+                  <span class="frame-status__dot" aria-hidden="true" />
+                  <span>
+                    <strong>Not requested</strong>
+                    <small>The browser has not requested the motion route.</small>
+                  </span>
+                </div>
+              </LazyFrame>
+            </div>
+          </article>
+        </div>
+      </section>
+    )
+  }
+}
+
+function ExhibitSection(handle: Handle<{ exhibit: Exhibit; index: number }>) {
+  return () => {
+    let { exhibit, index } = handle.props
+    let frameHref = getFrameHref(exhibit)
+    let ordinal = String(index + 1).padStart(2, '0')
+
+    return (
+      <section id={exhibit.id} mix={exhibitSectionStyle}>
+        <div mix={sectionGridStyle}>
+          <header mix={sectionHeaderStyle}>
+            <p mix={sectionIndexStyle}>
+              <span>{ordinal}</span>
+              <span>{categoryLabel(exhibit.kind)}</span>
+            </p>
+            <h2 mix={sectionHeadingStyle}>{exhibit.title}</h2>
+            <p mix={sectionDescriptionStyle}>{exhibit.description}</p>
+            <code mix={routeStyle}>{frameHref}</code>
+          </header>
+
+          <div mix={frameShellStyle}>
+            <LazyFrame
+              src={frameHref}
+              fallback={
+                <div class="frame-status frame-status--fetching">
+                  <span class="frame-status__dot" aria-hidden="true" />
+                  <span>
+                    <strong>Request in progress</strong>
+                    <small>The Frame response has not arrived yet.</small>
+                  </span>
+                </div>
+              }
+            >
+              <div class="frame-status frame-status--waiting">
+                <span class="frame-status__dot" aria-hidden="true" />
+                <span>
+                  <strong>Not requested</strong>
+                  <small>The browser will request it inside the preload margin.</small>
+                </span>
+              </div>
+            </LazyFrame>
+          </div>
+        </div>
+      </section>
+    )
+  }
+}
+
+function getFrameHref(exhibit: Exhibit): string {
+  switch (exhibit.kind) {
+    case 'html':
+      return routes.frames.html.href({ id: exhibit.id })
+    case 'ui':
+      return routes.frames.ui.href({ id: exhibit.id })
+    case 'interactive':
+      return routes.frames.interactive.href({ id: exhibit.id })
+  }
+}
+
+function categoryLabel(kind: Exhibit['kind']): string {
+  switch (kind) {
+    case 'html':
+      return 'Static HTML'
+    case 'ui':
+      return 'Server Remix UI'
+    case 'interactive':
+      return 'Remix UI + client entry'
+  }
+}
+
+const demoControlsStyle = css({
+  position: 'fixed',
+  zIndex: 20,
+  top: '16px',
+  right: '16px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  border: '1px solid var(--control-border)',
+  borderRadius: '10px',
+  padding: '8px',
+  backgroundColor: 'var(--control-bg)',
+  boxShadow: '0 6px 20px var(--control-shadow)',
+  color: 'var(--control-text)',
+  transition: 'background-color 160ms ease, border-color 160ms ease, color 160ms ease',
+  '@media (max-width: 560px)': {
+    top: '8px',
+    right: '8px',
+    left: '8px',
+    justifyContent: 'space-between',
+  },
+})
+
+const latencyToggleStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '14px',
+  '@media (max-width: 560px)': {
+    gap: '10px',
+    '& small': {
+      display: 'none',
+    },
+  },
+})
+
+const latencyStatusStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+})
+
+const latencyDotStyle = css({
+  flex: '0 0 auto',
+  width: '9px',
+  height: '9px',
+  borderRadius: '50%',
+})
+
+const latencyDotEnabledStyle = css({
+  backgroundColor: '#d4543f',
+  boxShadow: '0 0 0 5px rgba(212, 84, 63, 0.13)',
+})
+
+const latencyDotDisabledStyle = css({
+  backgroundColor: 'var(--control-muted)',
+})
+
+const latencyLabelStyle = css({
+  display: 'block',
+  fontSize: '12px',
+})
+
+const latencyDetailStyle = css({
+  display: 'block',
+  marginTop: '2px',
+  fontSize: '10px',
+  color: 'var(--control-muted)',
+})
+
+const latencyButtonStyle = css({
+  minHeight: '36px',
+  border: '1px solid var(--control-border)',
+  borderRadius: '6px',
+  padding: '7px 11px',
+  backgroundColor: 'var(--control-button-bg)',
+  color: 'var(--control-text)',
+  font: 'inherit',
+  fontSize: '11px',
+  fontWeight: 750,
+  cursor: 'pointer',
+  '&:hover': {
+    borderColor: 'var(--control-border-hover)',
+    backgroundColor: 'var(--control-button-hover)',
+  },
+  '&:focus-visible': {
+    outline: '3px solid var(--focus-ring)',
+    outlineOffset: '2px',
+  },
+})
+
+const heroStyle = css({
+  minHeight: 'max(100svh, 760px)',
+  display: 'grid',
+  alignItems: 'center',
+  padding: 'clamp(96px, 10vw, 132px) clamp(24px, 6vw, 76px) 72px',
+  backgroundColor: 'var(--hero-bg)',
+  color: 'var(--hero-text)',
+  transition: 'background-color 180ms ease',
+})
+
+const heroInnerStyle = css({
+  width: 'min(1120px, 100%)',
+  margin: '0 auto',
+})
+
+const heroHeadingStyle = css({
+  maxWidth: '980px',
+  margin: '0 0 32px',
+  fontSize: 'clamp(52px, 9vw, 112px)',
+  fontWeight: 760,
+  lineHeight: 0.92,
+  letterSpacing: '-0.065em',
+})
+
+const heroCopyStyle = css({
+  maxWidth: '680px',
+  margin: 0,
+  fontSize: 'clamp(18px, 2vw, 24px)',
+  lineHeight: 1.45,
+  color: 'var(--hero-muted)',
+  '& code': {
+    color: 'var(--focus-ring)',
+  },
+})
+
+const flowStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  margin: 'clamp(56px, 9vh, 88px) 0 0',
+  padding: 0,
+  borderTop: '1px solid var(--hero-rule)',
+  borderBottom: '1px solid var(--hero-rule)',
+  listStyle: 'none',
+  '& li + li': {
+    borderLeft: '1px solid var(--hero-rule)',
+  },
+  '@media (max-width: 760px)': {
+    gridTemplateColumns: '1fr',
+    '& li + li': {
+      borderTop: '1px solid var(--hero-rule)',
+      borderLeft: 0,
+    },
+  },
+})
+
+const flowItemStyle = css({
+  display: 'grid',
+  gridTemplateColumns: '28px 1fr',
+  gap: '14px',
+  minHeight: '112px',
+  alignItems: 'start',
+  padding: '22px 24px',
+  fontSize: '14px',
+  lineHeight: 1.5,
+  color: 'var(--hero-copy)',
+})
+
+const flowNumberStyle = css({
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '12px',
+  fontWeight: 700,
+  color: 'var(--focus-ring)',
+})
+
+const scrollCueStyle = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '14px',
+  marginTop: '52px',
+  borderBottom: '1px solid color-mix(in srgb, var(--hero-text) 40%, transparent)',
+  paddingBottom: '6px',
+  color: 'var(--hero-text)',
+  fontSize: '13px',
+  fontWeight: 700,
+  textDecoration: 'none',
+  '&:hover': {
+    borderColor: 'var(--focus-ring)',
+    color: 'var(--focus-ring)',
+  },
+})
+
+const mainStyle = css({
+  width: 'min(1120px, calc(100% - 40px))',
+  margin: '0 auto',
+})
+
+const introStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(280px, 0.8fr) minmax(280px, 1fr)',
+  gap: 'clamp(32px, 7vw, 96px)',
+  alignItems: 'start',
+  padding: '120px 0 72px',
+  '@media (max-width: 720px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+const introHeadingStyle = css({
+  maxWidth: '620px',
+  margin: 0,
+  fontSize: 'clamp(34px, 4.5vw, 58px)',
+  fontWeight: 700,
+  lineHeight: 1,
+  letterSpacing: '-0.045em',
+  color: 'var(--page-heading)',
+})
+
+const introCopyStyle = css({
+  maxWidth: '660px',
+  margin: 0,
+  fontSize: '17px',
+  lineHeight: 1.65,
+  color: 'var(--page-muted)',
+})
+
+const comparisonSectionStyle = css({
+  minHeight: '105svh',
+  display: 'grid',
+  alignContent: 'center',
+  gap: '52px',
+  padding: '120px 0',
+  scrollMarginTop: '84px',
+})
+
+const comparisonHeaderStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(280px, 0.9fr) minmax(280px, 0.65fr)',
+  alignItems: 'end',
+  gap: 'clamp(32px, 8vw, 112px)',
+  '@media (max-width: 760px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+const comparisonHeadingStyle = css({
+  maxWidth: '700px',
+  margin: 0,
+  fontSize: 'clamp(40px, 5.5vw, 68px)',
+  lineHeight: 1,
+  letterSpacing: '-0.05em',
+  color: 'var(--page-text)',
+})
+
+const comparisonDescriptionStyle = css({
+  '& p': {
+    margin: '0 0 18px',
+    fontSize: '15px',
+    lineHeight: 1.65,
+    color: 'var(--page-muted)',
+  },
+})
+
+const comparisonGridStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: '20px',
+  '@media (max-width: 900px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+const deliveryCardStyle = css({
+  minWidth: 0,
+  border: '1px solid var(--surface-border)',
+  borderRadius: '10px',
+  padding: 'clamp(12px, 2vw, 18px)',
+  backgroundColor: 'var(--surface-bg)',
+  transition: 'background-color 180ms ease, border-color 180ms ease',
+})
+
+const deliveryHeaderStyle = css({
+  minHeight: '104px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: '24px',
+  padding: '8px 8px 20px',
+  '@media (max-width: 520px)': {
+    flexDirection: 'column',
+    gap: '12px',
+  },
+})
+
+const deliveryHeadingStyle = css({
+  margin: 0,
+  fontSize: '22px',
+  lineHeight: 1.1,
+  letterSpacing: '-0.035em',
+  color: 'var(--page-heading)',
+})
+
+const deliveryDetailStyle = css({
+  maxWidth: '230px',
+  margin: 0,
+  fontSize: '12px',
+  lineHeight: 1.55,
+  color: 'var(--page-muted)',
+  '& strong': {
+    color: 'var(--page-heading)',
+  },
+})
+
+const exhibitSectionStyle = css({
+  minHeight: '100svh',
+  display: 'grid',
+  alignItems: 'center',
+  borderTop: '1px solid var(--page-rule)',
+  padding: '12vh 0',
+  scrollMarginTop: '84px',
+})
+
+const sectionGridStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(250px, 0.62fr) minmax(0, 1fr)',
+  alignItems: 'center',
+  gap: 'clamp(42px, 8vw, 116px)',
+  '@media (max-width: 820px)': {
+    gridTemplateColumns: '1fr',
+  },
+})
+
+const sectionHeaderStyle = css({
+  alignSelf: 'start',
+})
+
+const sectionIndexStyle = css({
+  display: 'flex',
+  gap: '14px',
+  margin: '0 0 22px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '11px',
+  lineHeight: 1.4,
+  color: 'var(--page-subtle)',
+  '& span:first-child': {
+    fontWeight: 700,
+    color: 'var(--page-heading)',
+  },
+})
+
+const sectionHeadingStyle = css({
+  margin: 0,
+  fontSize: 'clamp(34px, 4.6vw, 62px)',
+  lineHeight: 0.98,
+  letterSpacing: '-0.055em',
+  color: 'var(--page-text)',
+})
+
+const sectionDescriptionStyle = css({
+  margin: '22px 0 20px',
+  fontSize: '16px',
+  lineHeight: 1.65,
+  color: 'var(--page-muted)',
+})
+
+const routeStyle = css({
+  display: 'inline-block',
+  maxWidth: '100%',
+  overflow: 'hidden',
+  fontSize: '11px',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: 'var(--page-subtle)',
+})
+
+const frameShellStyle = css({
+  minWidth: 0,
+  minHeight: '320px',
+  border: '1px solid var(--surface-border)',
+  borderRadius: '10px',
+  padding: '6px',
+  backgroundColor: 'var(--frame-shell-bg)',
+  '& .frame-status': {
+    minHeight: '304px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '14px',
+    border: '1px dashed var(--placeholder-border)',
+    borderRadius: '6px',
+    padding: '24px',
+    backgroundColor: 'var(--placeholder-bg)',
+    color: 'var(--placeholder-text)',
+  },
+  '& .frame-status__dot': {
+    flex: '0 0 auto',
+    width: '10px',
+    height: '10px',
+    borderRadius: '50%',
+    backgroundColor: 'var(--placeholder-dot)',
+  },
+  '& .frame-status strong': {
+    display: 'block',
+    fontSize: '13px',
+    color: 'var(--placeholder-heading)',
+  },
+  '& .frame-status small': {
+    display: 'block',
+    marginTop: '4px',
+    fontSize: '11px',
+    lineHeight: 1.5,
+  },
+  '& .frame-status--fetching .frame-status__dot': {
+    backgroundColor: '#d4543f',
+    boxShadow: '0 0 0 6px rgba(212, 84, 63, 0.12)',
+  },
+  '& .plain-frame': {
+    minHeight: '304px',
+    border: '1px solid var(--plain-border)',
+    borderRadius: '6px',
+    padding: 'clamp(24px, 4vw, 42px)',
+    backgroundColor: 'var(--plain-bg)',
+    color: 'var(--plain-text)',
+  },
+  '& .plain-frame__header': {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '24px',
+    marginBottom: '28px',
+  },
+  '& .plain-frame__label, & .plain-frame__time': {
+    margin: 0,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: '11px',
+    color: 'var(--plain-muted)',
+  },
+  '& .plain-frame h3': {
+    maxWidth: '620px',
+    margin: 0,
+    fontFamily: 'Georgia, Times New Roman, serif',
+    fontSize: 'clamp(25px, 3vw, 38px)',
+    fontWeight: 500,
+    lineHeight: 1.12,
+    letterSpacing: '-0.025em',
+  },
+  '& .plain-frame ul': {
+    display: 'grid',
+    gap: '9px',
+    margin: '28px 0',
+    paddingLeft: '21px',
+    fontSize: '14px',
+    lineHeight: 1.5,
+    color: 'var(--plain-list)',
+  },
+  '& .plain-frame__note': {
+    margin: 0,
+    borderTop: '1px solid var(--plain-rule)',
+    paddingTop: '16px',
+    fontSize: '11px',
+    lineHeight: 1.5,
+    color: 'var(--plain-muted)',
+  },
+})
+
+const footerStyle = css({
+  minHeight: '55svh',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '80px 24px',
+  backgroundColor: 'var(--footer-bg)',
+  textAlign: 'center',
+  color: 'var(--footer-text)',
+  transition: 'background-color 180ms ease, color 180ms ease',
+})
+
+const footerHeadingStyle = css({
+  maxWidth: '860px',
+  margin: 0,
+  fontSize: 'clamp(38px, 6vw, 76px)',
+  lineHeight: 0.98,
+  letterSpacing: '-0.055em',
+})
+
+const footerLinkStyle = css({
+  marginTop: '42px',
+  borderBottom: '1px solid var(--footer-muted)',
+  paddingBottom: '5px',
+  color: 'var(--footer-text)',
+  fontSize: '13px',
+  fontWeight: 700,
+  textDecoration: 'none',
+  '&:hover': {
+    borderColor: 'var(--footer-text)',
+  },
+})

--- a/demos/lazy-frames/app/actions/home.tsx
+++ b/demos/lazy-frames/app/actions/home.tsx
@@ -147,23 +147,9 @@ function DeliveryComparison() {
               <LazyFrame
                 src={frameHref}
                 pauseAnimationsWhenInactive
-                fallback={
-                  <div class="frame-status frame-status--fetching">
-                    <span class="frame-status__dot" aria-hidden="true" />
-                    <span>
-                      <strong>Request in progress</strong>
-                      <small>The motion response has not arrived yet.</small>
-                    </span>
-                  </div>
-                }
+                fallback={<FrameStatus phase="fetching" />}
               >
-                <div class="frame-status frame-status--waiting">
-                  <span class="frame-status__dot" aria-hidden="true" />
-                  <span>
-                    <strong>Not requested</strong>
-                    <small>The browser has not requested the motion route.</small>
-                  </span>
-                </div>
+                <FrameStatus phase="waiting" />
               </LazyFrame>
             </div>
           </article>
@@ -193,29 +179,32 @@ function ExhibitSection(handle: Handle<{ exhibit: Exhibit; index: number }>) {
           </header>
 
           <div mix={frameShellStyle}>
-            <LazyFrame
-              src={frameHref}
-              fallback={
-                <div class="frame-status frame-status--fetching">
-                  <span class="frame-status__dot" aria-hidden="true" />
-                  <span>
-                    <strong>Request in progress</strong>
-                    <small>The Frame response has not arrived yet.</small>
-                  </span>
-                </div>
-              }
-            >
-              <div class="frame-status frame-status--waiting">
-                <span class="frame-status__dot" aria-hidden="true" />
-                <span>
-                  <strong>Not requested</strong>
-                  <small>The browser will request it inside the preload margin.</small>
-                </span>
-              </div>
+            <LazyFrame src={frameHref} fallback={<FrameStatus phase="fetching" />}>
+              <FrameStatus phase="waiting" />
             </LazyFrame>
           </div>
         </div>
       </section>
+    )
+  }
+}
+
+function FrameStatus(handle: Handle<{ phase: 'waiting' | 'fetching' }>) {
+  return () => {
+    let fetching = handle.props.phase === 'fetching'
+
+    return (
+      <p>
+        <span aria-hidden="true" />
+        <span>
+          <strong>{fetching ? 'Request in progress' : 'Not requested'}</strong>
+          <small>
+            {fetching
+              ? 'The Frame response has not arrived yet.'
+              : 'The browser will request this Frame inside the preload margin.'}
+          </small>
+        </span>
+      </p>
     )
   }
 }
@@ -613,39 +602,38 @@ const frameShellStyle = css({
   borderRadius: '10px',
   padding: '6px',
   backgroundColor: 'var(--frame-shell-bg)',
-  '& .frame-status': {
+  // Placeholder mixins cannot cross the LazyFrame client boundary, so style its fixed structure
+  // from the server-rendered shell.
+  '& > div > p': {
     minHeight: '304px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     gap: '14px',
+    margin: 0,
     border: '1px dashed var(--placeholder-border)',
     borderRadius: '6px',
     padding: '24px',
     backgroundColor: 'var(--placeholder-bg)',
     color: 'var(--placeholder-text)',
   },
-  '& .frame-status__dot': {
+  '& > div > p > span:first-child': {
     flex: '0 0 auto',
     width: '10px',
     height: '10px',
     borderRadius: '50%',
     backgroundColor: 'var(--placeholder-dot)',
   },
-  '& .frame-status strong': {
+  '& > div > p strong': {
     display: 'block',
     fontSize: '13px',
     color: 'var(--placeholder-heading)',
   },
-  '& .frame-status small': {
+  '& > div > p small': {
     display: 'block',
     marginTop: '4px',
     fontSize: '11px',
     lineHeight: 1.5,
-  },
-  '& .frame-status--fetching .frame-status__dot': {
-    backgroundColor: '#d4543f',
-    boxShadow: '0 0 0 6px rgba(212, 84, 63, 0.12)',
   },
   '& .plain-frame': {
     minHeight: '304px',
@@ -655,13 +643,13 @@ const frameShellStyle = css({
     backgroundColor: 'var(--plain-bg)',
     color: 'var(--plain-text)',
   },
-  '& .plain-frame__header': {
+  '& .plain-frame > header': {
     display: 'flex',
     justifyContent: 'space-between',
     gap: '24px',
     marginBottom: '28px',
   },
-  '& .plain-frame__label, & .plain-frame__time': {
+  '& .plain-frame > header p': {
     margin: 0,
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
     fontSize: '11px',
@@ -685,7 +673,7 @@ const frameShellStyle = css({
     lineHeight: 1.5,
     color: 'var(--plain-list)',
   },
-  '& .plain-frame__note': {
+  '& .plain-frame > p:last-child': {
     margin: 0,
     borderTop: '1px solid var(--plain-rule)',
     paddingTop: '16px',

--- a/demos/lazy-frames/app/actions/public/entry.ts
+++ b/demos/lazy-frames/app/actions/public/entry.ts
@@ -1,0 +1,21 @@
+import { run } from 'remix/ui'
+
+const app = run({
+  async loadModule(moduleUrl, exportName) {
+    let moduleExports: unknown = await import(moduleUrl)
+    if (moduleExports === null || typeof moduleExports !== 'object') {
+      throw new Error(`Module "${moduleUrl}" has no named exports`)
+    }
+
+    let component = Reflect.get(moduleExports, exportName)
+    if (typeof component !== 'function') {
+      throw new Error(`Unknown component: ${moduleUrl}#${exportName}`)
+    }
+
+    return component
+  },
+})
+
+app.ready().catch((error: unknown) => {
+  console.error('Lazy Frame adoption failed:', error)
+})

--- a/demos/lazy-frames/app/app.test.e2e.ts
+++ b/demos/lazy-frames/app/app.test.e2e.ts
@@ -1,0 +1,199 @@
+import * as assert from 'remix/assert'
+import { createTestServer } from 'remix/node-fetch-server/test'
+import { describe, it } from 'remix/test'
+
+import { motionArtifact } from './data/exhibits.ts'
+import { router } from './router.ts'
+import { routes } from './routes.ts'
+
+describe('lazy frames in the browser', () => {
+  it('persists the global latency toggle and applies it to browser requests', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
+    let framePath = routes.frames.ui.href({ id: 'signal-board' })
+
+    await page.goto(routes.home.href())
+    await page.getByRole('button', { name: 'Enable' }).click()
+    await page.getByText('Global latency on', { exact: true }).waitFor()
+
+    let enabledTiming = await page.evaluate(async (href) => {
+      let response = await fetch(href)
+      return response.headers.get('Server-Timing')
+    }, framePath)
+    assert.equal(enabledTiming, 'demo-latency;dur=20')
+
+    await page.getByRole('button', { name: 'Disable' }).click()
+    await page.getByText('Global latency off', { exact: true }).waitFor()
+
+    let disabledTiming = await page.evaluate(async (href) => {
+      let response = await fetch(href)
+      return response.headers.get('Server-Timing')
+    }, framePath)
+    assert.equal(disabledTiming, null)
+  })
+
+  it('themes every inserted response shape from the document root without refetching', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
+    let frameRequests = 0
+
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname.startsWith('/frames/')) frameRequests++
+    })
+
+    await page.goto(routes.home.href())
+
+    let plainFrame = page.locator('#field-notes .plain-frame')
+    await page.locator('#field-notes').scrollIntoViewIfNeeded()
+    await plainFrame.waitFor()
+
+    let uiFrame = page.locator('#signal-board article')
+    await page.locator('#signal-board').scrollIntoViewIfNeeded()
+    await uiFrame.waitFor()
+
+    let interactiveFrame = page.locator('#idea-counter article')
+    await page.locator('#idea-counter').scrollIntoViewIfNeeded()
+    await interactiveFrame.waitFor()
+    await page
+      .locator('#idea-counter')
+      .getByRole('button', { name: 'Increment local count' })
+      .click()
+    await page.getByText('Local count: 13', { exact: true }).waitFor()
+
+    let eagerMotionArtifact = page.locator('[data-delivery="eager"] [data-motion-artifact]')
+    let lightMotionBackground = await eagerMotionArtifact.evaluate(
+      (node) => getComputedStyle(node).backgroundImage,
+    )
+    let lightPlainBackground = await plainFrame.evaluate(
+      (node) => getComputedStyle(node).backgroundColor,
+    )
+    let lightUiBackground = await uiFrame.evaluate((node) => getComputedStyle(node).backgroundColor)
+    let lightInteractiveBackground = await interactiveFrame.evaluate(
+      (node) => getComputedStyle(node).backgroundColor,
+    )
+    let requestsBeforeThemeChange = frameRequests
+
+    await page.getByRole('button', { name: 'Switch to dark mode' }).click()
+    await page.locator('html[data-theme="dark"]').waitFor()
+    await page.waitForTimeout(220)
+
+    assert.notEqual(
+      await eagerMotionArtifact.evaluate((node) => getComputedStyle(node).backgroundImage),
+      lightMotionBackground,
+    )
+    assert.notEqual(
+      await plainFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
+      lightPlainBackground,
+    )
+    assert.notEqual(
+      await uiFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
+      lightUiBackground,
+    )
+    assert.notEqual(
+      await interactiveFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
+      lightInteractiveBackground,
+    )
+    assert.equal(frameRequests, requestsBeforeThemeChange)
+    assert.equal(await page.getByText('Local count: 13', { exact: true }).count(), 1)
+
+    await page.reload()
+    assert.equal(await page.locator('html').getAttribute('data-theme'), 'dark')
+  })
+
+  it('renders a motion artifact eagerly and requests the same artifact lazily', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
+    let framePath = routes.frames.html.href({ id: motionArtifact.id })
+    let browserRequests = 0
+
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === framePath) browserRequests++
+    })
+
+    await page.goto(routes.home.href())
+    let eagerArtifact = page.locator(
+      `[data-delivery="eager"] [data-motion-artifact="${motionArtifact.id}"]`,
+    )
+    let lazyExample = page.locator('[data-delivery="lazy"]')
+
+    await eagerArtifact.waitFor()
+    await lazyExample.waitFor()
+    await page.waitForTimeout(100)
+
+    assert.equal(browserRequests, 0)
+    assert.equal(
+      await lazyExample.locator(`[data-motion-artifact="${motionArtifact.id}"]`).count(),
+      0,
+    )
+
+    await lazyExample.scrollIntoViewIfNeeded()
+    let lazyArtifact = lazyExample.locator(`[data-motion-artifact="${motionArtifact.id}"]`)
+    await lazyArtifact.waitFor()
+
+    assert.equal(browserRequests, 1)
+    assert.equal(await lazyExample.locator('style').count(), 1)
+    let orbiter = lazyArtifact.locator('.edition-orbit__orbit')
+    assert.equal(
+      await orbiter.evaluate((node) => getComputedStyle(node).animationName),
+      'lazy-frames-motion-orbit',
+    )
+    assert.equal(
+      await orbiter.evaluate((node) => getComputedStyle(node).animationPlayState),
+      'running',
+    )
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.waitForFunction(() => {
+      let node = document.querySelector('[data-delivery="lazy"] .edition-orbit__orbit')
+      return node !== null && getComputedStyle(node).animationPlayState === 'paused'
+    })
+
+    await lazyExample.scrollIntoViewIfNeeded()
+    await page.waitForFunction(() => {
+      let node = document.querySelector('[data-delivery="lazy"] .edition-orbit__orbit')
+      return node !== null && getComputedStyle(node).animationPlayState === 'running'
+    })
+    assert.equal(
+      await orbiter.evaluate((node) => getComputedStyle(node).animationPlayState),
+      'running',
+    )
+    assert.equal(browserRequests, 1)
+  })
+
+  it('requests a distant frame once, retains it, and hydrates its client component', async (t) => {
+    let server = await createTestServer(router.fetch)
+    let page = await t.serve(server)
+    let framePath = routes.frames.interactive.href({ id: 'retained-counter' })
+    let frameRequests = 0
+
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === framePath) frameRequests++
+    })
+
+    await page.goto(routes.home.href())
+    let lazyExample = page.locator('#retained-counter')
+    await lazyExample.waitFor()
+    await page.waitForTimeout(100)
+
+    assert.equal(frameRequests, 0)
+
+    await lazyExample.scrollIntoViewIfNeeded()
+    let frameContent = page.locator('#retained-counter article')
+    await frameContent.waitFor()
+    await page.getByText('Client component ready', { exact: true }).waitFor()
+
+    assert.equal(frameRequests, 1)
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.waitForTimeout(100)
+    assert.equal(await frameContent.count(), 1)
+
+    await lazyExample.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(100)
+    assert.equal(frameRequests, 1)
+    assert.equal(await frameContent.count(), 1)
+
+    await page
+      .locator('#retained-counter')
+      .getByRole('button', { name: 'Increment local count' })
+      .click()
+    await page.getByText('Local count: 25', { exact: true }).waitFor()
+  })
+})

--- a/demos/lazy-frames/app/app.test.e2e.ts
+++ b/demos/lazy-frames/app/app.test.e2e.ts
@@ -7,137 +7,25 @@ import { router } from './router.ts'
 import { routes } from './routes.ts'
 
 describe('lazy frames in the browser', () => {
-  it('persists the global latency toggle and applies it to browser requests', async (t) => {
+  it('loads a Frame once and pauses its animation offscreen', async (t) => {
     let page = await t.serve(await createTestServer(router.fetch))
-    let framePath = routes.frames.ui.href({ id: 'signal-board' })
-
-    await page.goto(routes.home.href())
-    await page.getByRole('button', { name: 'Enable' }).click()
-    await page.getByText('Global latency on', { exact: true }).waitFor()
-
-    let enabledTiming = await page.evaluate(async (href) => {
-      let response = await fetch(href)
-      return response.headers.get('Server-Timing')
-    }, framePath)
-    assert.equal(enabledTiming, 'demo-latency;dur=20')
-
-    await page.getByRole('button', { name: 'Disable' }).click()
-    await page.getByText('Global latency off', { exact: true }).waitFor()
-
-    let disabledTiming = await page.evaluate(async (href) => {
-      let response = await fetch(href)
-      return response.headers.get('Server-Timing')
-    }, framePath)
-    assert.equal(disabledTiming, null)
-  })
-
-  it('themes every inserted response shape from the document root without refetching', async (t) => {
-    let page = await t.serve(await createTestServer(router.fetch))
+    let framePath = routes.frames.html.href({ id: motionArtifact.id })
     let frameRequests = 0
 
     page.on('request', (request) => {
-      if (new URL(request.url()).pathname.startsWith('/frames/')) frameRequests++
+      if (new URL(request.url()).pathname === framePath) frameRequests++
     })
 
     await page.goto(routes.home.href())
-
-    let plainFrame = page.locator('#field-notes .plain-frame')
-    await page.locator('#field-notes').scrollIntoViewIfNeeded()
-    await plainFrame.waitFor()
-
-    let uiFrame = page.locator('#signal-board article')
-    await page.locator('#signal-board').scrollIntoViewIfNeeded()
-    await uiFrame.waitFor()
-
-    let interactiveFrame = page.locator('#idea-counter article')
-    await page.locator('#idea-counter').scrollIntoViewIfNeeded()
-    await interactiveFrame.waitFor()
-    await page
-      .locator('#idea-counter')
-      .getByRole('button', { name: 'Increment local count' })
-      .click()
-    await page.getByText('Local count: 13', { exact: true }).waitFor()
-
-    let eagerMotionArtifact = page.locator('[data-delivery="eager"] [data-motion-artifact]')
-    let lightMotionBackground = await eagerMotionArtifact.evaluate(
-      (node) => getComputedStyle(node).backgroundImage,
-    )
-    let lightPlainBackground = await plainFrame.evaluate(
-      (node) => getComputedStyle(node).backgroundColor,
-    )
-    let lightUiBackground = await uiFrame.evaluate((node) => getComputedStyle(node).backgroundColor)
-    let lightInteractiveBackground = await interactiveFrame.evaluate(
-      (node) => getComputedStyle(node).backgroundColor,
-    )
-    let requestsBeforeThemeChange = frameRequests
-
-    await page.getByRole('button', { name: 'Switch to dark mode' }).click()
-    await page.locator('html[data-theme="dark"]').waitFor()
-    await page.waitForTimeout(220)
-
-    assert.notEqual(
-      await eagerMotionArtifact.evaluate((node) => getComputedStyle(node).backgroundImage),
-      lightMotionBackground,
-    )
-    assert.notEqual(
-      await plainFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
-      lightPlainBackground,
-    )
-    assert.notEqual(
-      await uiFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
-      lightUiBackground,
-    )
-    assert.notEqual(
-      await interactiveFrame.evaluate((node) => getComputedStyle(node).backgroundColor),
-      lightInteractiveBackground,
-    )
-    assert.equal(frameRequests, requestsBeforeThemeChange)
-    assert.equal(await page.getByText('Local count: 13', { exact: true }).count(), 1)
-
-    await page.reload()
-    assert.equal(await page.locator('html').getAttribute('data-theme'), 'dark')
-  })
-
-  it('renders a motion artifact eagerly and requests the same artifact lazily', async (t) => {
-    let page = await t.serve(await createTestServer(router.fetch))
-    let framePath = routes.frames.html.href({ id: motionArtifact.id })
-    let browserRequests = 0
-
-    page.on('request', (request) => {
-      if (new URL(request.url()).pathname === framePath) browserRequests++
-    })
-
-    await page.goto(routes.home.href())
-    let eagerArtifact = page.locator(
-      `[data-delivery="eager"] [data-motion-artifact="${motionArtifact.id}"]`,
-    )
     let lazyExample = page.locator('[data-delivery="lazy"]')
-
-    await eagerArtifact.waitFor()
     await lazyExample.waitFor()
     await page.waitForTimeout(100)
 
-    assert.equal(browserRequests, 0)
-    assert.equal(
-      await lazyExample.locator(`[data-motion-artifact="${motionArtifact.id}"]`).count(),
-      0,
-    )
+    assert.equal(frameRequests, 0)
 
     await lazyExample.scrollIntoViewIfNeeded()
-    let lazyArtifact = lazyExample.locator(`[data-motion-artifact="${motionArtifact.id}"]`)
-    await lazyArtifact.waitFor()
-
-    assert.equal(browserRequests, 1)
-    assert.equal(await lazyExample.locator('style').count(), 1)
-    let orbiter = lazyArtifact.locator('.edition-orbit__orbit')
-    assert.equal(
-      await orbiter.evaluate((node) => getComputedStyle(node).animationName),
-      'lazy-frames-motion-orbit',
-    )
-    assert.equal(
-      await orbiter.evaluate((node) => getComputedStyle(node).animationPlayState),
-      'running',
-    )
+    await lazyExample.locator('[data-motion-artifact]').waitFor()
+    assert.equal(frameRequests, 1)
 
     await page.evaluate(() => window.scrollTo(0, 0))
     await page.waitForFunction(() => {
@@ -150,16 +38,12 @@ describe('lazy frames in the browser', () => {
       let node = document.querySelector('[data-delivery="lazy"] .edition-orbit__orbit')
       return node !== null && getComputedStyle(node).animationPlayState === 'running'
     })
-    assert.equal(
-      await orbiter.evaluate((node) => getComputedStyle(node).animationPlayState),
-      'running',
-    )
-    assert.equal(browserRequests, 1)
+
+    assert.equal(frameRequests, 1)
   })
 
-  it('requests a distant frame once, retains it, and hydrates its client component', async (t) => {
-    let server = await createTestServer(router.fetch)
-    let page = await t.serve(server)
+  it('changes theme without requesting an inserted Frame again', async (t) => {
+    let page = await t.serve(await createTestServer(router.fetch))
     let framePath = routes.frames.interactive.href({ id: 'retained-counter' })
     let frameRequests = 0
 
@@ -168,32 +52,17 @@ describe('lazy frames in the browser', () => {
     })
 
     await page.goto(routes.home.href())
-    let lazyExample = page.locator('#retained-counter')
-    await lazyExample.waitFor()
-    await page.waitForTimeout(100)
-
-    assert.equal(frameRequests, 0)
-
+    let lazyExample = page.locator('main > section').last()
     await lazyExample.scrollIntoViewIfNeeded()
-    let frameContent = page.locator('#retained-counter article')
-    await frameContent.waitFor()
-    await page.getByText('Client component ready', { exact: true }).waitFor()
+    let frame = lazyExample.locator('article')
+    await frame.waitFor()
 
     assert.equal(frameRequests, 1)
 
-    await page.evaluate(() => window.scrollTo(0, 0))
-    await page.waitForTimeout(100)
-    assert.equal(await frameContent.count(), 1)
+    await page.locator('button[aria-label]').click()
+    await page.locator('html[data-theme="dark"]').waitFor()
 
-    await lazyExample.scrollIntoViewIfNeeded()
-    await page.waitForTimeout(100)
     assert.equal(frameRequests, 1)
-    assert.equal(await frameContent.count(), 1)
-
-    await page
-      .locator('#retained-counter')
-      .getByRole('button', { name: 'Increment local count' })
-      .click()
-    await page.getByText('Local count: 25', { exact: true }).waitFor()
+    assert.equal(await frame.count(), 1)
   })
 })

--- a/demos/lazy-frames/app/data/exhibits.ts
+++ b/demos/lazy-frames/app/data/exhibits.ts
@@ -1,0 +1,128 @@
+interface ExhibitBase {
+  id: string
+  title: string
+  description: string
+}
+
+export interface HtmlExhibit extends ExhibitBase {
+  kind: 'html'
+}
+
+export interface UiExhibit extends ExhibitBase {
+  kind: 'ui'
+  metric: string
+  metricLabel: string
+  trend: string
+  details: string[]
+}
+
+export interface InteractiveExhibit extends ExhibitBase {
+  kind: 'interactive'
+  initialCount: number
+  actionLabel: string
+  prompt: string
+  accent: 'coral' | 'violet' | 'teal'
+}
+
+export type Exhibit = HtmlExhibit | UiExhibit | InteractiveExhibit
+
+export const motionArtifact = {
+  id: 'edition-orbit',
+  title: 'Edition orbit',
+} as const
+
+export const exhibits: Exhibit[] = [
+  {
+    kind: 'html',
+    id: 'field-notes',
+    title: 'Stream a checked-in fragment',
+    description: 'A file response supplies Frame content without invoking the Remix UI renderer.',
+  },
+  {
+    kind: 'ui',
+    id: 'signal-board',
+    title: 'Three kinds of Frame response',
+    description:
+      'A server-rendered component returns Remix UI, generated CSS, and request-time data.',
+    metric: '3',
+    metricLabel: 'Response types in this demo',
+    trend: 'All three use the same LazyFrame boundary.',
+    details: ['HTML streamed from disk', 'Server-rendered Remix UI', 'Remix UI + client entry'],
+  },
+  {
+    kind: 'interactive',
+    id: 'idea-counter',
+    title: 'Hydrate a client component',
+    description: 'The Frame response contains a client entry that hydrates after insertion.',
+    initialCount: 12,
+    actionLabel: 'Increment local count',
+    prompt: 'This counter is a client component inside the Frame response.',
+    accent: 'violet',
+  },
+  {
+    kind: 'html',
+    id: 'packing-list',
+    title: 'Keep the file route explicit',
+    description: 'Known route IDs map to checked-in files; unknown IDs return a 404 response.',
+  },
+  {
+    kind: 'ui',
+    id: 'studio-schedule',
+    title: 'Load before the viewport arrives',
+    description: 'The preload distance is configurable without changing the Frame response.',
+    metric: '320 px',
+    metricLabel: 'Default vertical preload margin',
+    trend: 'Applied above and below the viewport.',
+    details: [
+      'One-shot load observer',
+      'Configurable rootMargin',
+      'No request before intersection',
+    ],
+  },
+  {
+    kind: 'interactive',
+    id: 'theme-state',
+    title: 'Keep state through a theme change',
+    description: 'Local client state arrives only after this Frame approaches the viewport.',
+    initialCount: 31,
+    actionLabel: 'Increment local count',
+    prompt: 'Document theme changes do not remount this client component.',
+    accent: 'coral',
+  },
+  {
+    kind: 'html',
+    id: 'reading-list',
+    title: 'Frame content joins the document',
+    description:
+      'Static HTML can inherit parent styles and theme tokens without a component runtime.',
+  },
+  {
+    kind: 'ui',
+    id: 'release-health',
+    title: 'Load once, keep the Frame',
+    description:
+      'The Frame response contains server-rendered components and their generated styles.',
+    metric: '1×',
+    metricLabel: 'Frame mount per section',
+    trend: 'Leaving the viewport does not unmount it.',
+    details: [
+      'Loaded DOM stays in place',
+      'Scrolling back makes no request',
+      'Local client state stays intact',
+    ],
+  },
+  {
+    kind: 'interactive',
+    id: 'retained-counter',
+    title: 'Scroll away and come back',
+    description: 'The last Frame inserts and hydrates a client component near the end of the page.',
+    initialCount: 24,
+    actionLabel: 'Increment local count',
+    prompt: 'Leaving the viewport does not unmount this client component.',
+    accent: 'teal',
+  },
+]
+
+export function getExhibit(id: string): Exhibit | undefined {
+  return exhibits.find((exhibit) => exhibit.id === id)
+}

--- a/demos/lazy-frames/app/middleware/asset-entry.ts
+++ b/demos/lazy-frames/app/middleware/asset-entry.ts
@@ -1,0 +1,34 @@
+import * as path from 'node:path'
+import { getContext } from 'remix/middleware/async-context'
+import { createContextKey, type Middleware } from 'remix/router'
+
+import { assets } from '../utils/assets.ts'
+
+interface AssetEntry {
+  scriptSrc: string
+  scriptPreloads: string[]
+}
+
+const assetEntryKey = createContextKey<AssetEntry>()
+const defaultScriptEntry = path.resolve(import.meta.dirname, '../actions/public/entry.ts')
+
+export function loadAssetEntry(
+  scriptEntry = defaultScriptEntry,
+): Middleware<{ key: typeof assetEntryKey; value: AssetEntry }> {
+  return async (context, next) => {
+    let [scriptSrc, scriptPreloads] = await Promise.all([
+      assets.getHref(scriptEntry),
+      assets.getPreloads(scriptEntry).catch((error) => {
+        console.error(error)
+        return []
+      }),
+    ])
+
+    context.set(assetEntryKey, { scriptSrc, scriptPreloads })
+    return next()
+  }
+}
+
+export function getAssetEntry(): AssetEntry {
+  return getContext().get(assetEntryKey)
+}

--- a/demos/lazy-frames/app/middleware/demo-latency.ts
+++ b/demos/lazy-frames/app/middleware/demo-latency.ts
@@ -1,0 +1,62 @@
+import { createCookie } from 'remix/cookie'
+import { createContextKey, type Middleware } from 'remix/router'
+
+export interface DemoLatency {
+  enabled: boolean
+  duration: number
+}
+
+export const demoLatencyContext = createContextKey<DemoLatency>()
+
+const demoLatencyCookie = createCookie('lazy-frames-latency', {
+  httpOnly: true,
+  maxAge: 60 * 60 * 24 * 365,
+  path: '/',
+  sameSite: 'Lax',
+})
+
+const defaultDuration = process.env.NODE_ENV === 'test' ? 20 : 520
+
+export function demoLatency(
+  duration = defaultDuration,
+): Middleware<{ key: typeof demoLatencyContext; value: DemoLatency }> {
+  return async (context, next) => {
+    let enabled = (await demoLatencyCookie.parse(context.headers.get('Cookie'))) === '1'
+    context.set(demoLatencyContext, { enabled, duration })
+
+    if (enabled) {
+      await delay(duration, context.request.signal)
+    }
+
+    let response = await next()
+    response.headers.append('Vary', 'Cookie')
+    if (enabled) {
+      response.headers.append('Server-Timing', `demo-latency;dur=${duration}`)
+    }
+    return response
+  }
+}
+
+export function serializeDemoLatency(enabled: boolean): Promise<string> {
+  return demoLatencyCookie.serialize(enabled ? '1' : '', enabled ? undefined : { maxAge: 0 })
+}
+
+function delay(duration: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+
+  return new Promise((resolve, reject) => {
+    let timeout = setTimeout(finish, duration)
+
+    function finish() {
+      signal.removeEventListener('abort', abort)
+      resolve()
+    }
+
+    function abort() {
+      clearTimeout(timeout)
+      reject(signal.reason)
+    }
+
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}

--- a/demos/lazy-frames/app/middleware/theme.ts
+++ b/demos/lazy-frames/app/middleware/theme.ts
@@ -1,0 +1,22 @@
+import { createCookie } from 'remix/cookie'
+import { createContextKey, type Middleware } from 'remix/router'
+
+import { isTheme, themeCookieMaxAge, themeCookieName, type Theme } from '../ui/public/theme.ts'
+
+export const themeContext = createContextKey<Theme>()
+
+const themeCookie = createCookie(themeCookieName, {
+  decode: (value) => value,
+  encode: (value) => value,
+  maxAge: themeCookieMaxAge,
+  path: '/',
+  sameSite: 'Lax',
+})
+
+export function loadTheme(): Middleware<{ key: typeof themeContext; value: Theme }> {
+  return async (context, next) => {
+    let value = await themeCookie.parse(context.headers.get('Cookie'))
+    context.set(themeContext, isTheme(value) ? value : 'light')
+    return next()
+  }
+}

--- a/demos/lazy-frames/app/router.test.ts
+++ b/demos/lazy-frames/app/router.test.ts
@@ -12,11 +12,11 @@ describe('lazy frame routes', () => {
     let document = await response.text()
 
     assert.equal(response.status, 200)
-    assert.equal(count(document, 'class="frame-status frame-status--waiting"'), exhibits.length + 1)
+    assert.equal(count(document, '>Not requested<'), exhibits.length + 1)
     assert.equal(count(document, `data-motion-artifact="${motionArtifact.id}"`), 1)
     assert.equal(count(document, '@keyframes lazy-frames-motion-orbit'), 1)
     assert.equal(document.includes('class="plain-frame"'), false)
-    assert.match(document, /The browser will request it inside the preload margin/)
+    assert.match(document, /The browser will request this Frame inside the preload margin/)
   })
 
   it('server-renders the saved color theme', async () => {

--- a/demos/lazy-frames/app/router.test.ts
+++ b/demos/lazy-frames/app/router.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'remix/assert'
+import { describe, it } from 'remix/test'
+
+import { exhibits, motionArtifact } from './data/exhibits.ts'
+import { router } from './router.ts'
+import { routes } from './routes.ts'
+import { themeCookieName } from './ui/public/theme.ts'
+
+describe('lazy frame routes', () => {
+  it('server-renders the eager artifact while leaving lazy frames unresolved', async () => {
+    let response = await router.fetch(new Request(`http://localhost${routes.home.href()}`))
+    let document = await response.text()
+
+    assert.equal(response.status, 200)
+    assert.equal(count(document, 'class="frame-status frame-status--waiting"'), exhibits.length + 1)
+    assert.equal(count(document, `data-motion-artifact="${motionArtifact.id}"`), 1)
+    assert.equal(count(document, '@keyframes lazy-frames-motion-orbit'), 1)
+    assert.equal(document.includes('class="plain-frame"'), false)
+    assert.match(document, /The browser will request it inside the preload margin/)
+  })
+
+  it('server-renders the saved color theme', async () => {
+    let response = await router.fetch(
+      new Request(`http://localhost${routes.home.href()}`, {
+        headers: { Cookie: `${themeCookieName}=dark` },
+      }),
+    )
+    let document = await response.text()
+
+    assert.equal(response.status, 200)
+    assert.match(document, /<html[^>]+data-theme="dark"/)
+    assert.match(document, /<body[^>]+data-theme="dark"/)
+  })
+
+  it('stores the global latency toggle in a cookie and delays subsequent routes', async () => {
+    let toggleResponse = await router.fetch(
+      new Request(`http://localhost${routes.latency.href()}`, {
+        method: 'POST',
+        body: new URLSearchParams({ enabled: 'true' }),
+      }),
+    )
+
+    assert.equal(toggleResponse.status, 303)
+    assert.equal(toggleResponse.headers.get('Location'), routes.home.href())
+
+    let setCookie = toggleResponse.headers.get('Set-Cookie')
+    assert.ok(setCookie)
+    let cookie = toCookieHeader(setCookie)
+    let headers = { Cookie: cookie }
+
+    let homeResponse = await router.fetch(
+      new Request(`http://localhost${routes.home.href()}`, { headers }),
+    )
+    let frameResponse = await router.fetch(
+      new Request(`http://localhost${routes.frames.html.href({ id: 'field-notes' })}`, {
+        headers,
+      }),
+    )
+
+    assert.equal(homeResponse.headers.get('Server-Timing'), 'demo-latency;dur=20')
+    assert.equal(frameResponse.headers.get('Server-Timing'), 'demo-latency;dur=20')
+    assert.match(await homeResponse.text(), /Global latency on/)
+  })
+
+  it('serves plain HTML, Remix UI, and interactive Remix UI frame bodies', async () => {
+    let htmlResponse = await router.fetch(
+      new Request(`http://localhost${routes.frames.html.href({ id: 'field-notes' })}`),
+    )
+    let uiResponse = await router.fetch(
+      new Request(`http://localhost${routes.frames.ui.href({ id: 'signal-board' })}`),
+    )
+    let interactiveResponse = await router.fetch(
+      new Request(`http://localhost${routes.frames.interactive.href({ id: 'retained-counter' })}`),
+    )
+
+    assert.match(htmlResponse.headers.get('Content-Type') ?? '', /^text\/html/)
+    let htmlFragment = await htmlResponse.text()
+    assert.match(htmlFragment, /class="plain-frame"/)
+    assert.match(htmlFragment, /field-notes\.html/)
+    assert.match(htmlFragment, /openLazyFile\(\)/)
+    assert.match(await uiResponse.text(), /Response types in this demo/)
+
+    let interactiveHtml = await interactiveResponse.text()
+    assert.match(interactiveHtml, /Leaving the viewport does not unmount/)
+    assert.match(interactiveHtml, /Hydrating client component/)
+  })
+})
+
+function toCookieHeader(setCookie: string): string {
+  let separator = setCookie.indexOf(';')
+  return separator === -1 ? setCookie : setCookie.slice(0, separator)
+}
+
+function count(value: string, match: string): number {
+  return value.split(match).length - 1
+}

--- a/demos/lazy-frames/app/router.test.ts
+++ b/demos/lazy-frames/app/router.test.ts
@@ -1,53 +1,42 @@
 import * as assert from 'remix/assert'
 import { describe, it } from 'remix/test'
 
-import { exhibits, motionArtifact } from './data/exhibits.ts'
+import { motionArtifact } from './data/exhibits.ts'
 import { router } from './router.ts'
 import { routes } from './routes.ts'
 import { themeCookieName } from './ui/public/theme.ts'
 
 describe('lazy frame routes', () => {
-  it('server-renders the eager artifact while leaving lazy frames unresolved', async () => {
+  it('server-renders the eager artifact once', async () => {
     let response = await router.fetch(new Request(`http://localhost${routes.home.href()}`))
     let document = await response.text()
 
     assert.equal(response.status, 200)
-    assert.equal(count(document, '>Not requested<'), exhibits.length + 1)
-    assert.equal(count(document, `data-motion-artifact="${motionArtifact.id}"`), 1)
-    assert.equal(count(document, '@keyframes lazy-frames-motion-orbit'), 1)
-    assert.equal(document.includes('class="plain-frame"'), false)
-    assert.match(document, /The browser will request this Frame inside the preload margin/)
+    assert.equal(document.split(`data-motion-artifact="${motionArtifact.id}"`).length - 1, 1)
   })
 
-  it('server-renders the saved color theme', async () => {
+  it('server-renders the saved theme', async () => {
     let response = await router.fetch(
       new Request(`http://localhost${routes.home.href()}`, {
         headers: { Cookie: `${themeCookieName}=dark` },
       }),
     )
-    let document = await response.text()
 
-    assert.equal(response.status, 200)
-    assert.match(document, /<html[^>]+data-theme="dark"/)
-    assert.match(document, /<body[^>]+data-theme="dark"/)
+    assert.match(await response.text(), /<html[^>]+data-theme="dark"/)
   })
 
-  it('stores the global latency toggle in a cookie and delays subsequent routes', async () => {
+  it('applies the latency cookie to subsequent requests', async () => {
     let toggleResponse = await router.fetch(
       new Request(`http://localhost${routes.latency.href()}`, {
         method: 'POST',
         body: new URLSearchParams({ enabled: 'true' }),
       }),
     )
-
-    assert.equal(toggleResponse.status, 303)
-    assert.equal(toggleResponse.headers.get('Location'), routes.home.href())
-
     let setCookie = toggleResponse.headers.get('Set-Cookie')
-    assert.ok(setCookie)
-    let cookie = toCookieHeader(setCookie)
-    let headers = { Cookie: cookie }
 
+    assert.ok(setCookie)
+
+    let headers = { Cookie: setCookie.slice(0, setCookie.indexOf(';')) }
     let homeResponse = await router.fetch(
       new Request(`http://localhost${routes.home.href()}`, { headers }),
     )
@@ -59,10 +48,9 @@ describe('lazy frame routes', () => {
 
     assert.equal(homeResponse.headers.get('Server-Timing'), 'demo-latency;dur=20')
     assert.equal(frameResponse.headers.get('Server-Timing'), 'demo-latency;dur=20')
-    assert.match(await homeResponse.text(), /Global latency on/)
   })
 
-  it('serves plain HTML, Remix UI, and interactive Remix UI frame bodies', async () => {
+  it('serves each Frame response type as HTML', async () => {
     let htmlResponse = await router.fetch(
       new Request(`http://localhost${routes.frames.html.href({ id: 'field-notes' })}`),
     )
@@ -73,24 +61,13 @@ describe('lazy frame routes', () => {
       new Request(`http://localhost${routes.frames.interactive.href({ id: 'retained-counter' })}`),
     )
 
-    assert.match(htmlResponse.headers.get('Content-Type') ?? '', /^text\/html/)
-    let htmlFragment = await htmlResponse.text()
-    assert.match(htmlFragment, /class="plain-frame"/)
-    assert.match(htmlFragment, /field-notes\.html/)
-    assert.match(htmlFragment, /openLazyFile\(\)/)
-    assert.match(await uiResponse.text(), /Response types in this demo/)
-
-    let interactiveHtml = await interactiveResponse.text()
-    assert.match(interactiveHtml, /Leaving the viewport does not unmount/)
-    assert.match(interactiveHtml, /Hydrating client component/)
+    assertHtmlResponse(htmlResponse)
+    assertHtmlResponse(uiResponse)
+    assertHtmlResponse(interactiveResponse)
   })
 })
 
-function toCookieHeader(setCookie: string): string {
-  let separator = setCookie.indexOf(';')
-  return separator === -1 ? setCookie : setCookie.slice(0, separator)
-}
-
-function count(value: string, match: string): number {
-  return value.split(match).length - 1
+function assertHtmlResponse(response: Response) {
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('Content-Type') ?? '', /^text\/html/)
 }

--- a/demos/lazy-frames/app/router.ts
+++ b/demos/lazy-frames/app/router.ts
@@ -1,0 +1,39 @@
+import { asyncContext } from 'remix/middleware/async-context'
+import { logger } from 'remix/middleware/logger'
+import { render } from 'remix/middleware/render'
+import { createMiddleware, createRouter, type MiddlewareContext } from 'remix/router'
+
+import rootController from './actions/controller.tsx'
+import { framesController } from './actions/frames/controller.tsx'
+import { loadAssetEntry } from './middleware/asset-entry.ts'
+import { demoLatency } from './middleware/demo-latency.ts'
+import { loadTheme } from './middleware/theme.ts'
+import { routes } from './routes.ts'
+import { assets } from './utils/assets.ts'
+
+const appMiddleware = createMiddleware(
+  asyncContext(),
+  loadTheme(),
+  demoLatency(),
+  loadAssetEntry(),
+  render({ assets }),
+)
+type AppContext = MiddlewareContext<typeof appMiddleware>
+
+declare module 'remix/router' {
+  interface RouterTypes {
+    context: AppContext
+  }
+}
+
+const middleware = []
+
+if (process.env.NODE_ENV === 'development') {
+  middleware.push(logger())
+}
+
+middleware.push(...appMiddleware)
+
+export const router = createRouter<AppContext>({ middleware })
+router.map(routes, rootController)
+router.map(routes.frames, framesController)

--- a/demos/lazy-frames/app/routes.ts
+++ b/demos/lazy-frames/app/routes.ts
@@ -1,0 +1,14 @@
+import { get, post, route } from 'remix/routes'
+
+export const assetsBase = '/assets'
+
+export const routes = route({
+  assets: get(`${assetsBase}/*path`),
+  home: get('/'),
+  latency: post('/demo-latency'),
+  frames: route('frames', {
+    html: get('html/:id'),
+    ui: get('ui/:id'),
+    interactive: get('interactive/:id'),
+  }),
+})

--- a/demos/lazy-frames/app/ui/document.tsx
+++ b/demos/lazy-frames/app/ui/document.tsx
@@ -1,0 +1,184 @@
+import { css, type Handle, type RemixNode } from 'remix/ui'
+
+import { getAssetEntry } from '../middleware/asset-entry.ts'
+import type { Theme } from './public/theme.ts'
+
+interface DocumentProps {
+  title: string
+  theme: Theme
+  children?: RemixNode
+}
+
+export function Document(handle: Handle<DocumentProps>) {
+  return () => {
+    let { title, theme, children } = handle.props
+    let { scriptSrc, scriptPreloads } = getAssetEntry()
+
+    return (
+      <html lang="en" data-theme={theme}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta
+            name="description"
+            content="A long-page demo that mounts Remix Frames as they approach the viewport."
+          />
+          <title>{title}</title>
+          {scriptPreloads.map((href) => (
+            <link key={href} rel="modulepreload" href={href} />
+          ))}
+          <script async type="module" src={scriptSrc} />
+        </head>
+        <body id="top" data-theme={theme} mix={bodyStyle}>
+          {children}
+        </body>
+      </html>
+    )
+  }
+}
+
+const bodyStyle = css({
+  '--page-bg': '#f3eee4',
+  '--page-text': '#25241e',
+  '--page-heading': '#282720',
+  '--page-muted': '#686257',
+  '--page-subtle': '#81786b',
+  '--page-rule': '#c8c0b2',
+  '--surface-bg': 'rgba(255, 253, 249, 0.74)',
+  '--surface-border': '#d7d0c4',
+  '--frame-shell-bg': 'rgba(255, 255, 255, 0.46)',
+  '--placeholder-bg': 'rgba(247, 243, 235, 0.72)',
+  '--placeholder-border': '#bbb1a1',
+  '--placeholder-text': '#6e665b',
+  '--placeholder-heading': '#3e3a32',
+  '--placeholder-dot': '#aaa091',
+  '--plain-bg': '#fffdf8',
+  '--plain-border': '#d5cec2',
+  '--plain-text': '#2d2b25',
+  '--plain-list': '#555044',
+  '--plain-muted': '#81786b',
+  '--plain-rule': '#e2dcd2',
+  '--control-bg': 'rgba(255, 253, 249, 0.92)',
+  '--control-text': '#14201e',
+  '--control-muted': '#68736e',
+  '--control-border': '#b8c0bb',
+  '--control-border-hover': '#66746d',
+  '--control-button-bg': '#ffffff',
+  '--control-button-hover': '#f4f7f4',
+  '--control-shadow': 'rgba(20, 32, 30, 0.14)',
+  '--hero-bg': '#14201e',
+  '--hero-text': '#f3f0e7',
+  '--hero-muted': '#c7d4ce',
+  '--hero-rule': 'rgba(243, 240, 231, 0.16)',
+  '--hero-copy': '#dfe7e2',
+  '--focus-ring': '#f4cf71',
+  '--footer-bg': '#d9e5db',
+  '--footer-text': '#183029',
+  '--footer-muted': '#557066',
+  '--server-frame-bg': '#15201e',
+  '--server-frame-text': '#eff8ee',
+  '--server-frame-muted': '#a6b6b1',
+  '--server-frame-copy': '#c7d4d0',
+  '--server-frame-detail': '#dfe9e5',
+  '--server-frame-rule': 'rgba(239, 248, 238, 0.16)',
+  '--server-frame-accent': '#9ed89b',
+  '--server-frame-highlight': '#f4cf71',
+  '--interactive-bg': '#fffdf9',
+  '--interactive-text': '#1f1930',
+  '--interactive-muted': '#655f78',
+  '--interactive-subtle': '#756d85',
+  '--interactive-accent': '#7557c8',
+  '--interactive-pending': '#b8afc9',
+  '--interactive-border': '#d9d0e4',
+  '--interactive-button-border': '#cbc3d9',
+  '--interactive-button-text': '#453d59',
+  '--interactive-button-hover': '#f6f2fa',
+  '--theme-motion-coral': '#ff785a',
+  '--theme-motion-cream': '#fff7e8',
+  '--theme-motion-lime': '#c9f27b',
+  '--theme-motion-bg-start': '#1c3942',
+  '--theme-motion-bg-end': '#182c35',
+  '--theme-motion-glow': 'rgba(201, 242, 123, 0.2)',
+  '--theme-motion-border': 'rgba(255, 247, 232, 0.22)',
+  '--theme-motion-ring': 'rgba(255, 247, 232, 0.34)',
+  '--theme-motion-ring-soft': 'rgba(255, 247, 232, 0.2)',
+  '--theme-motion-caption': 'rgba(255, 247, 232, 0.7)',
+  margin: 0,
+  backgroundColor: 'var(--page-bg)',
+  color: 'var(--page-text)',
+  colorScheme: 'light',
+  fontFamily:
+    'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+  textRendering: 'optimizeLegibility',
+  '&[data-theme="dark"]': {
+    '--page-bg': '#0d1614',
+    '--page-text': '#e9eee8',
+    '--page-heading': '#f2f5ef',
+    '--page-muted': '#adb8b1',
+    '--page-subtle': '#929f97',
+    '--page-rule': '#394740',
+    '--surface-bg': 'rgba(24, 35, 32, 0.82)',
+    '--surface-border': '#36443f',
+    '--frame-shell-bg': 'rgba(28, 42, 38, 0.78)',
+    '--placeholder-bg': 'rgba(19, 30, 27, 0.78)',
+    '--placeholder-border': '#506059',
+    '--placeholder-text': '#a8b5ae',
+    '--placeholder-heading': '#edf2ec',
+    '--placeholder-dot': '#718078',
+    '--plain-bg': '#17221f',
+    '--plain-border': '#3a4943',
+    '--plain-text': '#edf2ec',
+    '--plain-list': '#bdc8c1',
+    '--plain-muted': '#96a49c',
+    '--plain-rule': '#34423d',
+    '--control-bg': 'rgba(18, 29, 26, 0.94)',
+    '--control-text': '#f0f4ef',
+    '--control-muted': '#a9b6af',
+    '--control-border': '#52615b',
+    '--control-border-hover': '#8b9b93',
+    '--control-button-bg': '#24332f',
+    '--control-button-hover': '#30423c',
+    '--control-shadow': 'rgba(0, 0, 0, 0.34)',
+    '--hero-bg': '#080f0e',
+    '--hero-muted': '#b9c9c2',
+    '--hero-rule': 'rgba(243, 240, 231, 0.13)',
+    '--footer-bg': '#13241f',
+    '--footer-text': '#e5efe7',
+    '--footer-muted': '#96b1a6',
+    '--server-frame-bg': '#20342e',
+    '--server-frame-muted': '#b3c5bd',
+    '--server-frame-copy': '#d1ddd7',
+    '--server-frame-detail': '#edf4ef',
+    '--server-frame-rule': 'rgba(239, 248, 238, 0.2)',
+    '--server-frame-accent': '#a7e1a3',
+    '--server-frame-highlight': '#f4d581',
+    '--interactive-bg': '#211d2a',
+    '--interactive-text': '#f4effa',
+    '--interactive-muted': '#c7badd',
+    '--interactive-subtle': '#b7abc8',
+    '--interactive-accent': '#bda7ff',
+    '--interactive-pending': '#766d85',
+    '--interactive-border': '#554a63',
+    '--interactive-button-border': '#6d607d',
+    '--interactive-button-text': '#e4dcef',
+    '--interactive-button-hover': '#31293d',
+    '--theme-motion-coral': '#c94f3b',
+    '--theme-motion-cream': '#17302e',
+    '--theme-motion-lime': '#4f6f31',
+    '--theme-motion-bg-start': '#edf1df',
+    '--theme-motion-bg-end': '#cbded6',
+    '--theme-motion-glow': 'rgba(102, 144, 65, 0.24)',
+    '--theme-motion-border': 'rgba(23, 48, 46, 0.2)',
+    '--theme-motion-ring': 'rgba(23, 48, 46, 0.3)',
+    '--theme-motion-ring-soft': 'rgba(23, 48, 46, 0.17)',
+    '--theme-motion-caption': 'rgba(23, 48, 46, 0.72)',
+    colorScheme: 'dark',
+  },
+  '& *': {
+    boxSizing: 'border-box',
+  },
+  '& ::selection': {
+    backgroundColor: 'var(--focus-ring)',
+    color: '#14201e',
+  },
+})

--- a/demos/lazy-frames/app/ui/public/lazy-frame.tsx
+++ b/demos/lazy-frames/app/ui/public/lazy-frame.tsx
@@ -1,0 +1,89 @@
+import {
+  Frame,
+  clientEntry,
+  css,
+  ref,
+  type Handle,
+  type RemixElement,
+  type RemixNode,
+} from 'remix/ui'
+
+export type LazyFrameProps = {
+  src: string
+  rootMargin?: string
+  pauseAnimationsWhenInactive?: boolean
+  fallback?: RemixElement | string | number | boolean | null
+  children?: RemixNode
+}
+
+/**
+ * Defers mounting a Frame until its stable host approaches the viewport.
+ *
+ * `children` render on the server and before intersection. Once observed, the Frame mounts and its
+ * own `fallback` covers the network request. Once mounted, the Frame remains in the document when
+ * it leaves the viewport. Set `pauseAnimationsWhenInactive` to track its visibility after loading
+ * and pause descendant CSS animations without removing the Frame. Keeping those phases separate
+ * lets callers compose placeholders without coupling viewport policy to presentation.
+ */
+export const LazyFrame = clientEntry(
+  import.meta.url,
+  function LazyFrame(handle: Handle<LazyFrameProps>) {
+    let requested = false
+    let active = false
+
+    let observe = ref((node, signal) => {
+      let loadObserver = new IntersectionObserver(
+        (entries) => {
+          if (requested || signal.aborted || !entries.some((entry) => entry.isIntersecting)) return
+
+          requested = true
+          loadObserver.disconnect()
+          handle.update()
+        },
+        { rootMargin: handle.props.rootMargin ?? '320px 0px' },
+      )
+      let stageObserver: IntersectionObserver | undefined
+      if (handle.props.pauseAnimationsWhenInactive) {
+        stageObserver = new IntersectionObserver((entries) => {
+          let nextActive = entries.some((entry) => entry.isIntersecting)
+          if (active === nextActive || signal.aborted) return
+
+          active = nextActive
+          handle.update()
+        })
+        stageObserver.observe(node)
+      }
+
+      loadObserver.observe(node)
+      signal.addEventListener(
+        'abort',
+        () => {
+          loadObserver.disconnect()
+          stageObserver?.disconnect()
+        },
+        { once: true },
+      )
+    })
+
+    return () => (
+      <div
+        mix={[
+          observe,
+          handle.props.pauseAnimationsWhenInactive &&
+            !active &&
+            css({
+              '& *, & *::before, & *::after': {
+                animationPlayState: 'paused !important',
+              },
+            }),
+        ]}
+      >
+        {requested ? (
+          <Frame src={handle.props.src} fallback={handle.props.fallback} />
+        ) : (
+          handle.props.children
+        )}
+      </div>
+    )
+  },
+)

--- a/demos/lazy-frames/app/ui/public/theme-toggle.tsx
+++ b/demos/lazy-frames/app/ui/public/theme-toggle.tsx
@@ -1,0 +1,73 @@
+import { clientEntry, css, on, type Handle } from 'remix/ui'
+
+import { themeCookieMaxAge, themeCookieName, type Theme } from './theme.ts'
+
+type ThemeToggleProps = {
+  theme: Theme
+}
+
+export const ThemeToggle = clientEntry(
+  import.meta.url,
+  function ThemeToggle(handle: Handle<ThemeToggleProps>) {
+    let theme = handle.props.theme
+
+    return () => {
+      let nextTheme: Theme = theme === 'light' ? 'dark' : 'light'
+
+      return (
+        <button
+          type="button"
+          aria-label={`Switch to ${nextTheme} mode`}
+          mix={[
+            themeToggleStyle,
+            on('click', () => {
+              theme = nextTheme
+              document.documentElement.dataset.theme = theme
+              document.body.dataset.theme = theme
+              document.cookie = `${themeCookieName}=${theme}; Max-Age=${themeCookieMaxAge}; Path=/; SameSite=Lax`
+              handle.update()
+            }),
+          ]}
+        >
+          <span aria-hidden="true" mix={themeIconStyle}>
+            {theme === 'light' ? '☾' : '☀'}
+          </span>
+          <span>{nextTheme} mode</span>
+        </button>
+      )
+    }
+  },
+)
+
+const themeToggleStyle = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  minHeight: '36px',
+  border: '1px solid var(--control-border)',
+  borderRadius: '6px',
+  padding: '7px 12px',
+  backgroundColor: 'var(--control-button-bg)',
+  color: 'var(--control-text)',
+  font: 'inherit',
+  fontSize: '11px',
+  fontWeight: 750,
+  textTransform: 'capitalize',
+  whiteSpace: 'nowrap',
+  cursor: 'pointer',
+  transition: 'background-color 160ms ease, border-color 160ms ease, color 160ms ease',
+  '&:hover': {
+    borderColor: 'var(--control-border-hover)',
+    backgroundColor: 'var(--control-button-hover)',
+  },
+  '&:focus-visible': {
+    outline: '3px solid var(--focus-ring)',
+    outlineOffset: '2px',
+  },
+})
+
+const themeIconStyle = css({
+  fontSize: '16px',
+  lineHeight: 1,
+})

--- a/demos/lazy-frames/app/ui/public/theme.ts
+++ b/demos/lazy-frames/app/ui/public/theme.ts
@@ -1,0 +1,8 @@
+export type Theme = 'light' | 'dark'
+
+export const themeCookieName = 'lazy-frames-theme'
+export const themeCookieMaxAge = 60 * 60 * 24 * 365
+
+export function isTheme(value: string | null): value is Theme {
+  return value === 'light' || value === 'dark'
+}

--- a/demos/lazy-frames/app/utils/assets.ts
+++ b/demos/lazy-frames/app/utils/assets.ts
@@ -1,0 +1,24 @@
+import * as path from 'node:path'
+import { createAssetServer } from 'remix/assets'
+
+import { assetsBase } from '../routes.ts'
+
+const isDevelopment = process.env.NODE_ENV === 'development'
+
+export const assets = createAssetServer({
+  basePath: assetsBase,
+  rootDir: path.resolve(import.meta.dirname, '../../../..'),
+  allowFiles: ['demos/lazy-frames/app/routes.ts', 'demos/lazy-frames/app/**/public/**'],
+  allowPackages: ['remix'],
+  denyFiles: ['demos/lazy-frames/app/**/*.test.*'],
+  mounts: {
+    app: 'demos/lazy-frames/app',
+    packages: 'packages',
+  },
+  sourceMaps: isDevelopment ? 'external' : undefined,
+  minify: !isDevelopment,
+  fingerprint: isDevelopment
+    ? undefined
+    : { buildId: process.env.GITHUB_SHA || String(Date.now()) },
+  watch: false,
+})

--- a/demos/lazy-frames/package.json
+++ b/demos/lazy-frames/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",
-    "start": "node --import remix/node-tsx server.ts",
+    "start": "NODE_ENV=production node --import remix/node-tsx server.ts",
     "test": "NODE_ENV=test remix test",
     "typecheck": "tsc --noEmit"
   }

--- a/demos/lazy-frames/package.json
+++ b/demos/lazy-frames/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "lazy-frames-demo",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24.3.0"
+  },
+  "dependencies": {
+    "remix": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/dom-navigation": "^1.0.7",
+    "@types/node": "catalog:",
+    "playwright": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "dev": "NODE_ENV=development node --watch --import remix/node-tsx server.ts",
+    "start": "node --import remix/node-tsx server.ts",
+    "test": "NODE_ENV=test remix test",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/demos/lazy-frames/server.ts
+++ b/demos/lazy-frames/server.ts
@@ -1,0 +1,38 @@
+import * as http from 'node:http'
+import { createRequestListener } from 'remix/node-fetch-server'
+
+import { router } from './app/router.ts'
+import { assets } from './app/utils/assets.ts'
+
+const server = http.createServer(
+  createRequestListener(async (request: Request) => {
+    try {
+      return await router.fetch(request)
+    } catch (error) {
+      if (!(request.signal.aborted && error === request.signal.reason)) {
+        console.error(error)
+      }
+      return new Response('Internal Server Error', { status: 500 })
+    }
+  }),
+)
+
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 44100
+
+server.listen(port, () => {
+  console.log(`Lazy Frames demo is running on http://localhost:${port}`)
+})
+
+let shuttingDown = false
+
+function shutdown() {
+  if (shuttingDown) return
+  shuttingDown = true
+  server.close(() => {
+    void assets.close().finally(() => process.exit(0))
+  })
+  server.closeAllConnections()
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)

--- a/demos/lazy-frames/tsconfig.json
+++ b/demos/lazy-frames/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
+    "types": ["node", "dom-navigation"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "remix/ui"
+  },
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  demos/lazy-frames:
+    dependencies:
+      remix:
+        specifier: workspace:*
+        version: link:../../packages/remix
+    devDependencies:
+      '@types/dom-navigation':
+        specifier: ^1.0.7
+        version: 1.0.7
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
+      playwright:
+        specifier: 'catalog:'
+        version: 1.60.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   demos/social-auth:
     dependencies:
       remix:


### PR DESCRIPTION
Adds a long-page Frames demo that defers browser requests until content approaches the viewport. The reusable `LazyFrame` client component owns the observer and mounting lifecycle while callers provide their own waiting and fetching states.

- compares an eager, server-rendered `Frame` with lazy browser delivery of the same HTML/CSS motion response
- demonstrates checked-in HTML files, server-rendered Remix UI, and Remix UI containing client entries
- retains loaded Frames when they leave the viewport and optionally pauses descendant animations while offscreen
- themes existing Frame content from the parent document without refetching or losing client state
- sends `no-store` in development and publicly caches Frame responses in production
- includes cookie-backed request latency controls and focused browser coverage for delivery, theming, motion, and retention

```tsx
<LazyFrame
  src={routes.frames.ui.href({ id: 'signal-board' })}
  fallback={<p>Request in progress</p>}
>
  <p>Not requested</p>
</LazyFrame>
```

The demo also includes a checked-in motion artifact and a `pauseAnimationsWhenInactive` option for content that should stop animating outside the viewport.

