### PR TITLE
Define handle.update behavior before commit and during render

### DIFF
--- a/docs/guides/app/actions/docs/chapters/05-interactivity.md
+++ b/docs/guides/app/actions/docs/chapters/05-interactivity.md
@@ -211,6 +211,11 @@ props.
 Calling `handle.update()` schedules work and returns a promise. Await it when the next step needs the
 updated DOM:
 
+Call it from an event handler, queued task, subscription, timer, or other work that runs after the
+component commits. Calling it before the initial commit or during rendering throws an error. If
+rendering discovers work that should run after the commit, schedule that work with
+`handle.queueTask()`.
+
 ```tsx
 import { on, ref } from "remix/ui";
 import type { Handle } from "remix/ui";

--- a/docs/guides/app/actions/docs/chapters/05-interactivity.md
+++ b/docs/guides/app/actions/docs/chapters/05-interactivity.md
@@ -212,9 +212,10 @@ Calling `handle.update()` schedules work and returns a promise. Await it when th
 updated DOM:
 
 Call it from an event handler, queued task, subscription, timer, or other work that runs after the
-component commits. Calling it before the initial commit or during rendering throws an error. If
-rendering discovers work that should run after the commit, schedule that work with
-`handle.queueTask()`.
+component commits. Calling it during setup warns and skips the extra render because the initial
+render follows setup. Calling it during rendering, or before the initial commit from outside setup,
+throws an error. If rendering discovers work that should run after the commit, schedule that work
+with `handle.queueTask()`.
 
 ```tsx
 import { on, ref } from "remix/ui";

--- a/packages/ui/.changes/patch.handle-update-render-error.md
+++ b/packages/ui/.changes/patch.handle-update-render-error.md
@@ -1,0 +1,1 @@
+Report a descriptive component error when `handle.update()` is called before the initial commit or during rendering instead of surfacing an unhandled `scheduleUpdate not implemented` promise rejection (see #11642).

--- a/packages/ui/.changes/patch.handle-update-render-error.md
+++ b/packages/ui/.changes/patch.handle-update-render-error.md
@@ -1,1 +1,1 @@
-Report a descriptive component error when `handle.update()` is called before the initial commit or during rendering instead of surfacing an unhandled `scheduleUpdate not implemented` promise rejection (see #11642).
+Warn and skip the extra render when `handle.update()` is called during setup, and report a descriptive component error when it is called during rendering or before the initial commit from outside setup (see #11642).

--- a/packages/ui/docs/handle.md
+++ b/packages/ui/docs/handle.md
@@ -6,6 +6,8 @@ The `Handle` object provides the component's interface to the framework.
 
 Schedules a component update and returns a promise that resolves with an `AbortSignal` after the update completes.
 
+Call `handle.update()` from event handlers, queued tasks, subscriptions, timers, or other work that runs after the component commits. Calling it before the initial commit or during rendering throws an error; use `handle.queueTask()` when render discovers work that should run after the commit.
+
 ```tsx
 function Counter(handle: Handle) {
   let count = 0

--- a/packages/ui/docs/handle.md
+++ b/packages/ui/docs/handle.md
@@ -6,7 +6,7 @@ The `Handle` object provides the component's interface to the framework.
 
 Schedules a component update and returns a promise that resolves with an `AbortSignal` after the update completes.
 
-Call `handle.update()` from event handlers, queued tasks, subscriptions, timers, or other work that runs after the component commits. Calling it before the initial commit or during rendering throws an error; use `handle.queueTask()` when render discovers work that should run after the commit.
+Call `handle.update()` from event handlers, queued tasks, subscriptions, timers, or other work that runs after the component commits. Calling it during setup warns and skips the extra render because the initial render follows setup. Calling it during rendering, or before the initial commit from outside setup, throws an error. Use `handle.queueTask()` when render discovers work that should run after the commit.
 
 ```tsx
 function Counter(handle: Handle) {

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -32,10 +32,13 @@ export interface Handle<Props = Record<string, never>, ContextValue = NoContext>
 
   /**
    * Schedules an update for the component to render again. Returns a promise
-   * that resolves with an AbortSignal after the update completes. The signal
-   * is aborted when the component re-renders or is removed.
+   * that resolves with an AbortSignal after the update completes. Call this
+   * from an event handler, queued task, or other work that runs after the
+   * component commits. The signal is aborted when the component re-renders or
+   * is removed.
    *
    * @returns A promise that resolves with an AbortSignal after the update
+   * @throws If called before the initial commit or during rendering
    */
   update(): Promise<AbortSignal>
 
@@ -272,6 +275,7 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
   #renderController: AbortController | undefined
   #renderFn: RenderFn | undefined
   #removed = false
+  #phase: 'idle' | 'setup' | 'render' = 'idle'
   // The schedule target is stored as fields (updated each render) rather than
   // a closure so re-renders don't allocate a new function per component.
   #updateQueue: UpdateQueue | undefined
@@ -306,7 +310,13 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
 
     if (renderFn === undefined) {
       let initialize = this.#config.type as unknown as (handle: Handle<ElementProps, C>) => unknown
-      let result = initialize(this.#handle)
+      let result: unknown
+      this.#phase = 'setup'
+      try {
+        result = initialize(this.#handle)
+      } finally {
+        this.#phase = 'idle'
+      }
 
       if (!isRenderFn(result)) {
         let name = this.#config.type.name || 'Anonymous'
@@ -317,7 +327,15 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
       this.#renderFn = renderFn
     }
 
-    return [renderFn(), this.#dequeueTasks()]
+    let element: RemixNode
+    this.#phase = 'render'
+    try {
+      element = renderFn()
+    } finally {
+      this.#phase = 'idle'
+    }
+
+    return [element, this.#dequeueTasks()]
   }
 
   remove = (): Array<() => void> => {
@@ -352,16 +370,26 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
     return {
       id: this.#config.id,
       props: this.#props,
-      update: () =>
-        new Promise((resolve) => {
-          if (component.#removed) {
-            resolve(AbortSignal.abort())
-            return
-          }
+      update: () => {
+        if (component.#removed) return Promise.resolve(AbortSignal.abort())
 
+        let name = component.#config.type.name || 'Anonymous'
+        if (component.#phase !== 'idle') {
+          throw new Error(
+            `Cannot call handle.update() while ${name} is running its ${component.#phase} function. Call it from an event handler or handle.queueTask() instead.`,
+          )
+        }
+        if (component.#updateQueue === undefined) {
+          throw new Error(
+            `Cannot call handle.update() before ${name}'s initial render commits. Call it from an event handler or handle.queueTask() instead.`,
+          )
+        }
+
+        return new Promise((resolve) => {
           this.#tasks.push((signal) => resolve(signal))
           this.#scheduleUpdate()
-        }),
+        })
+      },
       queueTask: (task: Task) => {
         this.#tasks.push(task)
       },

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -35,10 +35,11 @@ export interface Handle<Props = Record<string, never>, ContextValue = NoContext>
    * that resolves with an AbortSignal after the update completes. Call this
    * from an event handler, queued task, or other work that runs after the
    * component commits. The signal is aborted when the component re-renders or
-   * is removed.
+   * is removed. Calling this during setup warns and skips the extra render;
+   * the promise resolves after the initial commit.
    *
    * @returns A promise that resolves with an AbortSignal after the update
-   * @throws If called before the initial commit or during rendering
+   * @throws If called during rendering or before the initial commit outside setup
    */
   update(): Promise<AbortSignal>
 
@@ -374,6 +375,14 @@ class ComponentRuntime<C = NoContext> implements ComponentHandle<C> {
         if (component.#removed) return Promise.resolve(AbortSignal.abort())
 
         let name = component.#config.type.name || 'Anonymous'
+        if (component.#phase === 'setup') {
+          console.warn(
+            `Ignored handle.update() while ${name} is running its setup function. The initial render includes setup changes.`,
+          )
+          return new Promise((resolve) => {
+            this.#tasks.push((signal) => resolve(signal))
+          })
+        }
         if (component.#phase !== 'idle') {
           throw new Error(
             `Cannot call handle.update() while ${name} is running its ${component.#phase} function. Call it from an event handler or handle.queueTask() instead.`,

--- a/packages/ui/src/test/vdom.components.test.tsx
+++ b/packages/ui/src/test/vdom.components.test.tsx
@@ -15,6 +15,31 @@ describe('vnode rendering', () => {
   describe('components', () => {
     it.todo('warns when render is called after component is removed')
 
+    it('updates from a task queued during the initial render', () => {
+      let container = document.createElement('div')
+
+      function App(handle: Handle) {
+        let value = 'initial'
+        let queued = false
+        return () => {
+          if (!queued) {
+            queued = true
+            handle.queueTask(() => {
+              value = 'updated'
+              handle.update()
+            })
+          }
+          return <p>{value}</p>
+        }
+      }
+
+      let root = createRoot(container)
+      root.render(<App />)
+      root.flush()
+
+      expect(container.innerHTML).toBe('<p>updated</p>')
+    })
+
     it('inserts a component', () => {
       let container = document.createElement('div')
       function App() {

--- a/packages/ui/src/test/vdom.errors.test.tsx
+++ b/packages/ui/src/test/vdom.errors.test.tsx
@@ -94,6 +94,50 @@ describe('vdom error handling', () => {
       expect(errorHandler).toHaveBeenCalledTimes(1)
       expect((errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error).toBe(error)
     })
+
+    it('reports handle.update() calls during setup', (t) => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let errorHandler = t.mock.fn()
+      root.addEventListener('error', errorHandler)
+
+      function SetupUpdate(handle: Handle) {
+        handle.update()
+        return () => <div>ok</div>
+      }
+
+      root.render(<SetupUpdate />)
+
+      expect(errorHandler).toHaveBeenCalledTimes(1)
+      let error = (errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error as Error
+      expect(error.message).toBe(
+        'Cannot call handle.update() while SetupUpdate is running its setup function. Call it from an event handler or handle.queueTask() instead.',
+      )
+    })
+
+    it("reports updates to a parent before the parent's initial render commits", (t) => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let errorHandler = t.mock.fn()
+      root.addEventListener('error', errorHandler)
+
+      function Child(handle: Handle<{ updateParent(): void }>) {
+        handle.props.updateParent()
+        return () => null
+      }
+
+      function Parent(handle: Handle) {
+        return () => <Child updateParent={() => handle.update()} />
+      }
+
+      root.render(<Parent />)
+
+      expect(errorHandler).toHaveBeenCalledTimes(1)
+      let error = (errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error as Error
+      expect(error.message).toBe(
+        "Cannot call handle.update() before Parent's initial render commits. Call it from an event handler or handle.queueTask() instead.",
+      )
+    })
   })
 
   describe('render errors', () => {
@@ -144,6 +188,28 @@ describe('vdom error handling', () => {
 
       expect(errorHandler).toHaveBeenCalledTimes(1)
       expect((errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error).toBe(error)
+    })
+
+    it('reports handle.update() calls during render', (t) => {
+      let container = document.createElement('div')
+      let root = createRoot(container)
+      let errorHandler = t.mock.fn()
+      root.addEventListener('error', errorHandler)
+
+      function RenderUpdate(handle: Handle) {
+        return () => {
+          handle.update()
+          return <div>ok</div>
+        }
+      }
+
+      root.render(<RenderUpdate />)
+
+      expect(errorHandler).toHaveBeenCalledTimes(1)
+      let error = (errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error as Error
+      expect(error.message).toBe(
+        'Cannot call handle.update() while RenderUpdate is running its render function. Call it from an event handler or handle.queueTask() instead.',
+      )
     })
   })
 
@@ -364,13 +430,14 @@ describe('vdom error handling', () => {
   })
 
   describe('cascading updates protection', () => {
-    it('dispatches error when handle.update() is called during render', async (t) => {
+    it('dispatches error for a cascading queued update loop', async (t) => {
       let container = document.createElement('div')
       let root = createRoot(container)
       let errorHandler = t.mock.fn()
       root.addEventListener('error', errorHandler)
 
       let renderCount = 0
+      let shouldLoop = false
       let triggerUpdate: () => void
 
       function InfiniteLoop(handle: Handle) {
@@ -379,8 +446,8 @@ describe('vdom error handling', () => {
         }
         return () => {
           renderCount++
-          if (renderCount > 1) {
-            handle.update()
+          if (shouldLoop) {
+            handle.queueTask(() => handle.update())
           }
           return <div>count: {renderCount}</div>
         }
@@ -391,6 +458,7 @@ describe('vdom error handling', () => {
       expect(container.innerHTML).toBe('<div>count: 1</div>')
       expect(renderCount).toBe(1)
 
+      shouldLoop = true
       triggerUpdate!()
       await new Promise((resolve) => setTimeout(resolve, 10))
 

--- a/packages/ui/src/test/vdom.errors.test.tsx
+++ b/packages/ui/src/test/vdom.errors.test.tsx
@@ -95,24 +95,31 @@ describe('vdom error handling', () => {
       expect((errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error).toBe(error)
     })
 
-    it('reports handle.update() calls during setup', (t) => {
+    it('warns and ignores handle.update() calls during setup', async (t) => {
       let container = document.createElement('div')
       let root = createRoot(container)
       let errorHandler = t.mock.fn()
+      let warnSpy = t.mock.method(console, 'warn', () => {})
       root.addEventListener('error', errorHandler)
+      let updatePromise: Promise<AbortSignal> | undefined
 
       function SetupUpdate(handle: Handle) {
-        handle.update()
+        updatePromise = handle.update()
         return () => <div>ok</div>
       }
 
       root.render(<SetupUpdate />)
 
-      expect(errorHandler).toHaveBeenCalledTimes(1)
-      let error = (errorHandler.mock.calls[0]!.arguments[0] as ErrorEvent).error as Error
-      expect(error.message).toBe(
-        'Cannot call handle.update() while SetupUpdate is running its setup function. Call it from an event handler or handle.queueTask() instead.',
+      expect(errorHandler).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0]?.arguments[0]).toBe(
+        'Ignored handle.update() while SetupUpdate is running its setup function. The initial render includes setup changes.',
       )
+      expect(container.innerHTML).toBe('<div>ok</div>')
+
+      if (updatePromise === undefined) throw new Error('Expected setup update promise')
+      let signal = await updatePromise
+      expect(signal.aborted).toBe(false)
     })
 
     it("reports updates to a parent before the parent's initial render commits", (t) => {


### PR DESCRIPTION
Calling `handle.update()` before a component's first commit could reject with the internal `scheduleUpdate not implemented` error. This gives those calls clear lifecycle behavior without installing the scheduler before the component is ready.

- Warn and skip the extra render when a component calls `handle.update()` during its own setup; the returned promise resolves after the initial commit
- Throw a descriptive synchronous error when it is called during render or when another component tries to update a parent that has not committed
- Point callers to event handlers and `handle.queueTask()` for post-commit updates
- Preserve the existing removed-component behavior and cascading-update protection
- Document and test each lifecycle case

Supersedes #11761.

Closes #11642
