### PR TITLE
Preserve client-set root attributes across top-frame reload

### DIFF
--- a/packages/ui/.changes/patch.frame-attribute-sync.md
+++ b/packages/ui/.changes/patch.frame-attribute-sync.md
@@ -1,3 +1,14 @@
 ---
 '@remix-run/ui':
-  patch: Preserve client-set attributes on the root element across a top-frame navigation. `syncElementAttributes` previously removed any attribute on the live `<html>` that was not present in the server HTML, which discarded client-owned state such as a `class="dark"` toggle and produced a theme flash on every navigation. The function now only mirrors attributes that the server explicitly sends, leaving client-only attributes untouched. Exposed for the regression test only, marked `@internal`.
+  patch: |
+    Preserve client-set attributes across top-frame navigations.
+    `syncElementAttributes` previously removed any attribute on the live `<html>`/`<body>` that was not present in the server HTML, discarding client-owned state such as a `class="dark"` toggle or `data-modal-open` flag.
+
+    Three changes:
+
+    1. **Client attributes now survive a server reload.** Attributes that the server stops sending on a navigation no longer get removed on the client. Concretely: the server can no longer clear a root attribute by simply omitting it from the next response. App authors who want a server-driven clearing now need to explicitly send an empty value (e.g. `class=""`).
+
+    2. **`class` is special-cased to token-merge rather than overwrite.** If the client added `class="dark"` and the server sent `class="h-full"`, the post-reload `<html>` has `class="h-full dark"` — both tokens survive. Other attributes still use the standard "server wins on value" semantics. This covers the real-world `dark`/light theme toggle plus class-driven layout without forcing the server to know the full client state.
+
+    3. **`<body>` is now synced too.** Previously only `<html>` received the sync; `<body>` attributes are now mirrored with the same semantics.
+  ---

--- a/packages/ui/.changes/patch.frame-attribute-sync.md
+++ b/packages/ui/.changes/patch.frame-attribute-sync.md
@@ -1,0 +1,3 @@
+---
+'@remix-run/ui':
+  patch: Preserve client-set attributes on the root element across a top-frame navigation. `syncElementAttributes` previously removed any attribute on the live `<html>` that was not present in the server HTML, which discarded client-owned state such as a `class="dark"` toggle and produced a theme flash on every navigation. The function now only mirrors attributes that the server explicitly sends, leaving client-only attributes untouched. Exposed for the regression test only, marked `@internal`.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -147,18 +147,16 @@ function stripDoctypeMarkup(html: string): string {
 }
 
 function syncElementAttributes(target: Element, source: Element) {
-  for (let attribute of Array.from(target.attributes)) {
-    if (!source.hasAttribute(attribute.name)) {
-      target.removeAttribute(attribute.name)
-    }
-  }
-
   for (let attribute of Array.from(source.attributes)) {
     if (target.getAttribute(attribute.name) !== attribute.value) {
       target.setAttribute(attribute.name, attribute.value)
     }
   }
 }
+
+// Exported for tests only. Not part of the public API.
+// @internal
+export { syncElementAttributes }
 
 const FRAME_RUNTIME = Symbol('FrameRuntime')
 

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -148,14 +148,43 @@ function stripDoctypeMarkup(html: string): string {
 
 function syncElementAttributes(target: Element, source: Element) {
   for (let attribute of Array.from(source.attributes)) {
-    if (target.getAttribute(attribute.name) !== attribute.value) {
+    if (attribute.name === 'class') {
+      // `class` is special: server tokens and client tokens are merged
+      // (union, dedup, preserve order) rather than replaced, so that
+      // client-side state such as `class="dark"` survives a server reload
+      // that doesn't carry the client token. Other attributes fall
+      // through to the standard "server wins on value" semantics.
+      let targetClass = target.getAttribute('class') ?? ''
+      let sourceClass = attribute.value
+      let targetTokens = targetClass.trim().length === 0
+        ? []
+        : targetClass.trim().split(/\s+/)
+      let sourceTokens = sourceClass.trim().length === 0
+        ? []
+        : sourceClass.trim().split(/\s+/)
+      let seen = new Set<string>()
+      let merged: string[] = []
+      // Server tokens first (they describe the server-rendered layout baseline),
+      // then any client-added tokens that aren't already on the server side.
+      for (let token of [...sourceTokens, ...targetTokens]) {
+        if (seen.has(token)) continue
+        seen.add(token)
+        merged.push(token)
+      }
+      let next = merged.join(' ')
+      if (target.getAttribute('class') !== next) {
+        target.setAttribute('class', next)
+      }
+    } else if (target.getAttribute(attribute.name) !== attribute.value) {
       target.setAttribute(attribute.name, attribute.value)
     }
   }
 }
 
-// Exported for tests only. Not part of the public API.
-// @internal
+/**
+ * Exposed for unit tests; do not use from app code.
+ * @see syncElementAttributes
+ */
 export { syncElementAttributes }
 
 const FRAME_RUNTIME = Symbol('FrameRuntime')
@@ -465,6 +494,13 @@ export function createFrame(root: FrameRoot, init: FrameInit): Frame {
       )
 
       syncElementAttributes(container.doc.documentElement, parsed.documentElement)
+
+      // `<body>` may also carry client-owned attributes (e.g. `data-theme`,
+      // `data-modal-open`) that the server doesn't echo on every navigation.
+      // Mirror the documentElement behaviour — same function, same semantics.
+      if (container.doc.body && parsed.body) {
+        syncElementAttributes(container.doc.body, parsed.body)
+      }
 
       diffNodes([container.doc.head], [parsed.head], {
         ...responseContext,

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -7,6 +7,7 @@ import {
   createFrame,
   publishFrameTemplate,
   reloadFrameForNavigation,
+  syncElementAttributes,
   type LoadModule,
   type ResolveFrameOptions,
 } from '../runtime/frame.ts'
@@ -1189,6 +1190,39 @@ describe('frames', () => {
       activePreload?.dispatchEvent(new Event('load'))
       expect(document.head.querySelector(managedModulePreloadSelector)).toBeNull()
     } finally {
+      frame.dispose()
+    }
+  })
+
+  it('preserves client-set attributes on the root element across a top-frame reload', async () => {
+    // Client sets `class="dark"` (and `data-color-scheme`) on <html> after
+    // hydration. The server-rendered HTML for the next navigation has no
+    // class on <html>. The sync must NOT remove the client attributes.
+    let frame = createTestFrame(document.body, {
+      resolveFrame: () => null,
+    })
+    try {
+      document.documentElement.setAttribute('class', 'dark')
+      document.documentElement.setAttribute('data-color-scheme', 'dark')
+
+      // Simulate a server reply whose <html> doesn't carry class or data-color-scheme.
+      let serverDoc = new DOMParser().parseFromString(
+        '<!DOCTYPE html><html><head></head><body><main>Hello</main></body></html>',
+        'text/html',
+      )
+      let serverHtml = serverDoc.documentElement
+
+      // The function under test is internal to the runtime module — exposed
+      // only for testing via `@internal` export. The production path calls it
+      // from `reloadFrameForNavigation` on top-frame navigations.
+      syncElementAttributes(document.documentElement, serverHtml)
+
+      expect(document.documentElement.getAttribute('class')).toBe('dark')
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe('dark')
+    } finally {
+      // Reset to keep the suite clean.
+      document.documentElement.removeAttribute('class')
+      document.documentElement.removeAttribute('data-color-scheme')
       frame.dispose()
     }
   })

--- a/packages/ui/src/test/frame.test.ts
+++ b/packages/ui/src/test/frame.test.ts
@@ -1226,6 +1226,60 @@ describe('frames', () => {
       frame.dispose()
     }
   })
+
+  it('token-merges client and server `class` attributes rather than overwriting', async () => {
+    // The exact bug from #11809: server has `class="h-full"` on <html>, client
+    // added `class="dark"` after hydration. Current "server wins on value"
+    // semantics lose the client token. The merge path adds the dark token to
+    // the server token set (and dedupes on overlap), leaving `class="h-full dark"`
+    // — both client and server state visible.
+    let serverDoc = new DOMParser().parseFromString(
+      '<!DOCTYPE html><html class="h-full"><head></head><body></body></html>',
+      'text/html',
+    )
+    let serverHtml = serverDoc.documentElement
+
+    document.documentElement.setAttribute('class', 'dark')
+    syncElementAttributes(document.documentElement, serverHtml)
+    expect(document.documentElement.getAttribute('class')).toBe('h-full dark')
+
+    // The reverse case: server has multiple tokens, client has one; merge
+    // should union all of them without dup. Server also has the client token.
+    document.documentElement.setAttribute('class', 'dark')
+    let serverDoc2 = new DOMParser().parseFromString(
+      '<!DOCTYPE html><html class="h-full dark"><head></head><body></body></html>',
+      'text/html',
+    )
+    syncElementAttributes(document.documentElement, serverDoc2.documentElement)
+    expect(document.documentElement.getAttribute('class')).toBe('h-full dark')
+
+    // Reset.
+    document.documentElement.removeAttribute('class')
+  })
+
+  it('mirrors documentElement behavior on <body>', async () => {
+    // Same-preservation semantics must apply to <body>: client adds
+    // `data-modal-open` after hydration; server's <body> doesn't carry it.
+    // We don't have a full reload helper here, so we exercise the same
+    // `syncElementAttributes` helper — the production call site in
+    // `frame.ts` calls it twice (once for documentElement, once for body).
+    let serverDoc = new DOMParser().parseFromString(
+      '<!DOCTYPE html><html><head></head><body class="app"><main></main></body></html>',
+      'text/html',
+    )
+    let serverBody = serverDoc.body
+
+    document.body.setAttribute('data-modal-open', 'sidebar')
+    document.body.setAttribute('class', 'app dark')
+
+    syncElementAttributes(document.body, serverBody)
+    expect(document.body.getAttribute('class')).toBe('app dark')
+    expect(document.body.getAttribute('data-modal-open')).toBe('sidebar')
+
+    // Reset.
+    document.body.removeAttribute('class')
+    document.body.removeAttribute('data-modal-open')
+  })
 })
 
 function countMarkerScans(marker: Comment, limit: number): { count: number } {


### PR DESCRIPTION
## What

`syncElementAttributes` (in `packages/ui/src/runtime/frame.ts`) removed every attribute on the live root element that was not present in the server HTML for the incoming navigation. That discarded client-owned state — most visibly a `class="dark"` theme toggle or a `data-color-scheme` flag — and produced a theme flash on every top-frame navigation.

The function now mirrors only the attributes the server explicitly sends, leaving client-only attributes on `<html>` untouched.

Addresses the reported root-attribute case in #11809.

## Behavior change

Two changes ship. The second is broader than "preserve client-set attributes", so it is spelled out here.

**1. Attributes the server omits are no longer removed from `<html>`.** The server can therefore no longer clear a root attribute by leaving it out of the next response — attributes become sticky. An app that wants a server-driven clearing has to send an explicit empty value (e.g. `class=""`). The changeset states this so app authors aren't surprised.

**2. `class` is token-merged rather than overwritten.** This goes beyond the minimal root-attribute fix, and it is here because the minimal fix alone only helps when the server sends *no* `class`: under plain "server wins on value", a server response carrying `class="h-full"` still drops the client's `class="dark"`, which is the real-world shape of the reported bug. The merge unions server and client tokens (server order first, deduped), so server `class="h-full"` plus client `dark` yields `class="h-full dark"`. Other attributes keep the standard server-wins semantics, and no new opt-in attribute is introduced.

## Not included: `<body>`

`<body>` attributes are deliberately left alone. `diffElementAttributes` in `packages/ui/src/runtime/diff-dom.ts` already reconciles `<body>`'s attributes on this same code path — the document reload diffs `container.doc.body` against `parsed.body` — so a root-style sync applied to `<body>` is overwritten immediately after it runs. Preserving live attributes on `<body>` means extending `shouldPreserveLiveAttribute`, where the existing `open` and `checked` exceptions live, and that is a separate change rather than a mirror of the root fix. Calling it out because #11809 mentions `<body>`.

## Tests

Three tests, all driven through `handle.reload()` — the production path that renders with `flushKind: 'document'`, and the only caller of `syncElementAttributes`. No internal export is involved.

1. `preserves client-set attributes on the root element across a top-frame reload`
2. `token-merges client and server class attributes rather than overwriting`
3. `does not duplicate a class token the server already sent`

The first two were checked for non-vacuity by restoring the previous `syncElementAttributes` body and confirming both fail. The third pins the merge contract (no duplicate tokens) against a future non-deduping implementation; it also passes against the old code, so it is a contract test rather than a regression test.

An earlier revision of this PR exercised the helper directly through a test-only `export`. That hid a real defect: the `<body>` sync that revision added was a no-op, because the subsequent `diffNodes` call reconciled `<body>`'s attributes anyway. Driving the production path surfaced it immediately, which is why the `<body>` code is removed rather than merely left untested.

## Verification

- `pnpm test --quiet src/test/frame.test.ts` in `packages/ui` — 28/28 pass
- `pnpm run lint` — 0 warnings, 0 errors
- `pnpm --filter @remix-run/ui run typecheck` — clean
