### PR TITLE
Support global virtual stores in the asset server via `.modules.yaml`

### DIFF
--- a/packages/assets/.changes/patch.mount-package-manager-virtual-store.md
+++ b/packages/assets/.changes/patch.mount-package-manager-virtual-store.md
@@ -1,0 +1,3 @@
+Fixed serving packages that a package manager installs outside `rootDir`, such as pnpm's global virtual store, which previously failed the first request with `IMPORT_OUTSIDE_MOUNTS`
+
+The asset server now reads the store location from the nearest `node_modules/.modules.yaml` and mounts it internally under `/__@remix/virtual-store`. A store that a configured mount already covers, such as pnpm's default `node_modules/.pnpm`, is left alone.

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -164,6 +164,8 @@ let assetServer = createAssetServer({
 })
 ```
 
+Package managers that install outside `rootDir`, such as pnpm's global virtual store, are handled without configuration: the asset server reads the store location from the nearest `node_modules/.modules.yaml` and mounts it internally so those package files still resolve to public URLs. A store that a configured mount already covers, such as pnpm's default `node_modules/.pnpm`, is left alone.
+
 ### File watching
 
 The file system is watched by default so source changes are picked up without requiring a server restart.

--- a/packages/assets/src/lib/asset-server.test.ts
+++ b/packages/assets/src/lib/asset-server.test.ts
@@ -24,6 +24,10 @@ import type { ModuleLoader } from './loaders.ts'
 type FingerprintOptions = NonNullable<AssetServerOptions['fingerprint']>
 
 const packageRoot = path.resolve(import.meta.dirname, '../..')
+const virtualStorePackageDir =
+  '@remix-run+__allowed-package@1.0.0/node_modules/@remix-run/__allowed-package'
+const virtualStorePackageUrlPath =
+  '%40remix-run%2B__allowed-package%401.0.0/node_modules/%40remix-run/__allowed-package/index.ts'
 
 function createAssetServerForTest(
   options: Omit<AssetServerOptions<AssetRequestTransformMap>, 'basePath'> & {
@@ -307,6 +311,28 @@ async function withTsconfigTransformCase(
 
     await fs.rm(caseDir, { recursive: true, force: true })
   }
+}
+
+// Links the only copy of a package into `projectDir` from a store directory, the way a package
+// manager's virtual store does.
+async function writeVirtualStorePackage(projectDir: string, storeDir: string): Promise<void> {
+  await writeJson(storeDir, `${virtualStorePackageDir}/package.json`, {
+    name: '@remix-run/__allowed-package',
+    type: 'module',
+    exports: {
+      '.': './index.ts',
+    },
+  })
+  await write(storeDir, `${virtualStorePackageDir}/index.ts`, 'export const value = true')
+  await symlinkDirectory(
+    path.join(storeDir, virtualStorePackageDir),
+    path.join(projectDir, 'node_modules/@remix-run/__allowed-package'),
+  )
+  await write(
+    projectDir,
+    'app/entry.ts',
+    'import { value } from "@remix-run/__allowed-package"\nexport { value }',
+  )
 }
 
 describe('asset-server', () => {
@@ -6488,6 +6514,118 @@ describe('asset-server', () => {
         '/assets/app/node_modules/.pnpm/%40remix-run%2B__allowed-package%401.0.0/node_modules/%40remix-run/__allowed-package/index.ts',
       ),
     )
+  })
+
+  it('serves a virtual store outside rootDir listed in node_modules/.modules.yaml', async () => {
+    let projectDir = await makeTmpDir()
+    let storeDir = await makeTmpDir()
+    try {
+      await writeVirtualStorePackage(projectDir, storeDir)
+      let relativeStoreDir = normalizeWindowsPath(
+        path.relative(path.join(projectDir, 'node_modules'), storeDir),
+      )
+      await write(
+        projectDir,
+        'node_modules/.modules.yaml',
+        `hoistPattern:\n  - '*'\nvirtualStoreDir: ${relativeStoreDir}\nvirtualStoreDirMaxLength: 120\n`,
+      )
+      let assetServer = createAssetServerForTest({
+        allowFiles: ['app/entry.ts'],
+        allowPackages: ['@remix-run/__allowed-package'],
+        rootDir: projectDir,
+      })
+
+      let servedUrls = await assertRecursivelyServedImports(assetServer, ['/assets/app/entry.ts'])
+      assert.ok(
+        servedUrls.has(`/assets/__@remix/virtual-store/${virtualStorePackageUrlPath}`),
+        `Expected the store package to be served, got ${[...servedUrls].join(', ')}`,
+      )
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+      await fs.rm(storeDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads an absolute virtual store directory from a JSON node_modules/.modules.yaml', async () => {
+    let projectDir = await makeTmpDir()
+    let storeDir = await makeTmpDir()
+    try {
+      await writeVirtualStorePackage(projectDir, storeDir)
+      await writeJson(projectDir, 'node_modules/.modules.yaml', {
+        virtualStoreDir: storeDir,
+        virtualStoreDirMaxLength: 120,
+      })
+      let assetServer = createAssetServerForTest({
+        allowFiles: ['app/entry.ts'],
+        allowPackages: ['@remix-run/__allowed-package'],
+        rootDir: projectDir,
+      })
+
+      let servedUrls = await assertRecursivelyServedImports(assetServer, ['/assets/app/entry.ts'])
+      assert.ok(
+        servedUrls.has(`/assets/__@remix/virtual-store/${virtualStorePackageUrlPath}`),
+        `Expected the store package to be served, got ${[...servedUrls].join(', ')}`,
+      )
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+      await fs.rm(storeDir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves a package outside every mount unserved without a node_modules/.modules.yaml', async () => {
+    let projectDir = await makeTmpDir()
+    let storeDir = await makeTmpDir()
+    try {
+      await writeVirtualStorePackage(projectDir, storeDir)
+      let receivedError: unknown
+      let assetServer = createAssetServerForTest({
+        allowFiles: ['app/entry.ts'],
+        allowPackages: ['@remix-run/__allowed-package'],
+        rootDir: projectDir,
+        onError(error) {
+          receivedError = error
+        },
+      })
+
+      let response = await get(assetServer, '/assets/app/entry.ts')
+      assert.ok(response)
+      await assertInternalServerError(response)
+      assert.ok(isAssetServerCompilationError(receivedError))
+      assert.equal(receivedError.code, 'IMPORT_OUTSIDE_MOUNTS')
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+      await fs.rm(storeDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not mount a virtual store that a configured mount already covers', async () => {
+    let projectDir = await makeTmpDir()
+    try {
+      await writeVirtualStorePackage(projectDir, path.join(projectDir, 'node_modules/.pnpm'))
+      await write(
+        projectDir,
+        'node_modules/.modules.yaml',
+        'virtualStoreDir: .pnpm\nvirtualStoreDirMaxLength: 120\n',
+      )
+      let assetServer = createAssetServerForTest({
+        allowFiles: ['app/entry.ts'],
+        allowPackages: ['@remix-run/__allowed-package'],
+        rootDir: projectDir,
+      })
+
+      let servedUrls = await assertRecursivelyServedImports(assetServer, ['/assets/app/entry.ts'])
+      assert.ok(
+        servedUrls.has(`/assets/npm/.pnpm/${virtualStorePackageUrlPath}`),
+        `Expected the store package to be served from the npm mount, got ${[...servedUrls].join(', ')}`,
+      )
+      assert.equal(
+        await get(assetServer, `/assets/__@remix/virtual-store/${virtualStorePackageUrlPath}`),
+        null,
+        'Expected no virtual store mount for a store the npm mount already covers',
+      )
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true })
+    }
   })
 
   it('does not allow other installed copies of transitive dependencies by package name', async () => {

--- a/packages/assets/src/lib/asset-server.ts
+++ b/packages/assets/src/lib/asset-server.ts
@@ -31,6 +31,7 @@ import type { AssetTarget, ResolvedScriptTarget, ResolvedStyleTarget } from './t
 import { createAssetServerWatcher } from './watch.ts'
 import { createAssetInspector, type AssetDetails } from './inspection.ts'
 import type { AssetServerWatcher, ChokidarWatcher } from './watch.ts'
+import { getVirtualStoreMountConfigs } from './virtual-store.ts'
 
 interface AssetServerWatchOptions {
   /**
@@ -1068,6 +1069,7 @@ function resolveAssetServerOptions<transforms extends AssetRequestTransformMap>(
         rootDir,
       },
       ...getInjectedPackageMountConfigs(),
+      ...getVirtualStoreMountConfigs({ mounts, rootDir }),
     ]),
     sourceMapSourcePaths: options.sourceMapSourcePaths ?? 'url',
     sourceMaps: options.sourceMaps,

--- a/packages/assets/src/lib/routes.ts
+++ b/packages/assets/src/lib/routes.ts
@@ -137,7 +137,7 @@ function normalizeMountUrlRoot(urlRoot: string): string {
   return url.pathname.replace(/\/+$/, '') || '/'
 }
 
-function resolveMountFileRoot(rootDir: string, fileRoot: string): string {
+export function resolveMountFileRoot(rootDir: string, fileRoot: string): string {
   let resolvedRoot = resolveFilePath(rootDir, fileRoot)
 
   try {

--- a/packages/assets/src/lib/virtual-store.ts
+++ b/packages/assets/src/lib/virtual-store.ts
@@ -1,0 +1,124 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  getFilePathBaseName,
+  getFilePathDirectory,
+  normalizeFilePath,
+  resolveFilePath,
+} from './paths.ts'
+import { resolveMountFileRoot } from './routes.ts'
+
+const modulesStateFileName = '.modules.yaml'
+const virtualStoreBasePath = '/__@remix/virtual-store'
+const virtualStoreDirLineRE = /^virtualStoreDir:[ \t]*(.+)$/m
+
+// pnpm's global virtual store links packages from a machine-wide directory, so package realpaths
+// land outside `rootDir` and would otherwise have no public URL. The store location comes from
+// `node_modules/.modules.yaml`, which pnpm rewrites on every install.
+export function getVirtualStoreMountConfigs(options: {
+  mounts: Readonly<Record<string, string>>
+  rootDir: string
+}): {
+  mounts: Record<string, string>
+  rootDir: string
+}[] {
+  let virtualStoreDir = findVirtualStoreDir(options.rootDir)
+  if (virtualStoreDir === null) return []
+  // A store inside a mount, such as pnpm's default `node_modules/.pnpm`, already has URLs.
+  if (isWithinMounts(virtualStoreDir, options)) return []
+
+  return [
+    {
+      mounts: {
+        [virtualStoreBasePath]: getFilePathBaseName(virtualStoreDir),
+      },
+      rootDir: getFilePathDirectory(virtualStoreDir),
+    },
+  ]
+}
+
+function findVirtualStoreDir(rootDir: string): string | null {
+  let directory = normalizeFilePath(rootDir)
+
+  // Workspace members share the workspace root's file, so walk up to the nearest one.
+  while (true) {
+    let modulesDir = `${directory}/node_modules`
+    let modulesState = readModulesState(`${modulesDir}/${modulesStateFileName}`)
+    if (modulesState !== null) {
+      let virtualStoreDir = readVirtualStoreDir(modulesState)
+      if (virtualStoreDir === null) return null
+      return realpathDirectory(resolveFilePath(modulesDir, virtualStoreDir))
+    }
+
+    let parentDirectory = normalizeFilePath(path.dirname(directory))
+    if (parentDirectory === directory) return null
+    directory = parentDirectory
+  }
+}
+
+function readVirtualStoreDir(modulesState: string): string | null {
+  // pnpm 10.34 and later write JSON, earlier versions write YAML, and package managers that
+  // mirror the global virtual store write either one. Reading the one scalar this needs keeps
+  // both formats working without a YAML parser.
+  try {
+    let parsedState = JSON.parse(modulesState) as unknown
+    if (parsedState === null || typeof parsedState !== 'object') return null
+
+    let virtualStoreDir = (parsedState as Record<string, unknown>).virtualStoreDir
+    return typeof virtualStoreDir === 'string' ? virtualStoreDir : null
+  } catch {
+    let match = virtualStoreDirLineRE.exec(modulesState)
+    return match === null ? null : unquoteScalar(match[1].trim())
+  }
+}
+
+function unquoteScalar(value: string): string {
+  let quote = value[0]
+  if (value.length > 1 && (quote === "'" || quote === '"') && value.endsWith(quote)) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+function isWithinMounts(
+  directory: string,
+  options: {
+    mounts: Readonly<Record<string, string>>
+    rootDir: string
+  },
+): boolean {
+  return Object.values(options.mounts).some((fileRoot) => {
+    let mountRoot = resolveMountFileRoot(options.rootDir, fileRoot)
+    return directory === mountRoot || directory.startsWith(`${mountRoot}/`)
+  })
+}
+
+function readModulesState(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf-8')
+  } catch (error) {
+    if (isPathNotFoundError(error)) return null
+    throw error
+  }
+}
+
+function realpathDirectory(filePath: string): string | null {
+  try {
+    let realPath = fs.realpathSync(filePath)
+    return fs.statSync(realPath).isDirectory() ? normalizeFilePath(realPath) : null
+  } catch (error) {
+    if (isPathNotFoundError(error)) return null
+    throw error
+  }
+}
+
+function isPathNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    ((error as NodeJS.ErrnoException).code === 'ENOENT' ||
+      (error as NodeJS.ErrnoException).code === 'ENOTDIR')
+  )
+}


### PR DESCRIPTION
Closes https://github.com/remix-run/remix/issues/11793

With pnpm's global virtual store (`enable-global-virtual-store=true`) every package real path lies outside `rootDir`, no mount covers it, and the first request fails with `IMPORT_OUTSIDE_MOUNTS`. [Nub](https://nubjs.com), whose package manager uses a machine-global store by default, hits the same failure with a stock Remix 3 app; that is where this was found.

`createAssetServer()` now reads the store location from the nearest `node_modules/.modules.yaml` (JSON and YAML forms, no new dependency), as Vite does, and mounts it under `/__@remix/virtual-store` when no configured mount covers it. User mounts win; the default `.pnpm` store adds nothing; access control and watch mode are unchanged.

Four tests; the linked pnpm reproduction returns 200.