### PR TITLE
Fall back to document navigation without sourceElement

### DIFF
--- a/packages/spa/src/lib/spa.test.browser.tsx
+++ b/packages/spa/src/lib/spa.test.browser.tsx
@@ -109,8 +109,8 @@ describe('run', () => {
   })
 
   it('renders an interactive fallback while the initial route loads', async (t) => {
-    let [routeResponse, resolveRouteResponse] = withResolvers<Response>()
-    let [requestStarted, resolveRequestStarted] = withResolvers<void>()
+    let routeResponse = Promise.withResolvers<Response>()
+    let requestStarted = Promise.withResolvers<void>()
     let sawReloadStart = false
     let fallbackAtRequest: string | undefined
     let reloadStartedAtRequest = false
@@ -144,8 +144,8 @@ describe('run', () => {
     let fetch = mock.fn(async () => {
       fallbackAtRequest = document.querySelector('button')?.textContent ?? undefined
       reloadStartedAtRequest = sawReloadStart
-      resolveRequestStarted()
-      return await routeResponse
+      requestStarted.resolve()
+      return await routeResponse.promise
     })
     let app = run({ fetch }, { fallback: <Fallback /> })
 
@@ -154,7 +154,7 @@ describe('run', () => {
     let readyPromise = app.ready().then(() => {
       ready = true
     })
-    await requestStarted
+    await requestStarted.promise
 
     expect(ready).toBe(false)
     expect(fallbackAtRequest).toBe('Loading: 0')
@@ -164,7 +164,7 @@ describe('run', () => {
     app.flush()
     expect(button?.textContent).toBe('Loading: 1')
 
-    resolveRouteResponse(spaResponse.create(<h1>Ready</h1>))
+    routeResponse.resolve(spaResponse.create(<h1>Ready</h1>))
     await readyPromise
 
     expect(ready).toBe(true)
@@ -173,7 +173,7 @@ describe('run', () => {
   })
 
   it('encodes text/plain form submissions with normalized line breaks', async (t) => {
-    let [submittedRequest, resolveSubmittedRequest] = withResolvers<Request>()
+    let submittedRequest = Promise.withResolvers<Request>()
     let requestCount = 0
     let router: Router = {
       async fetch(input, init) {
@@ -190,7 +190,7 @@ describe('run', () => {
           )
         }
 
-        resolveSubmittedRequest(request)
+        submittedRequest.resolve(request)
         return spaResponse.create(<h1>Submitted</h1>)
       },
     }
@@ -204,7 +204,7 @@ describe('run', () => {
     if (!form) throw new Error('Expected a form')
     form.requestSubmit()
 
-    let request = await submittedRequest
+    let request = await submittedRequest.promise
     expect(request.headers.get('Content-Type')).toBe('text/plain')
     expect(await request.text()).toBe('note=first\r\nsecond\r\ncity=Paris\r\n')
   })
@@ -243,11 +243,3 @@ describe('run', () => {
     expect(document.querySelector('h1')?.textContent).toBe('Redirected')
   })
 })
-
-function withResolvers<value>(): [Promise<value>, (value: value) => void] {
-  let resolve: (value: value) => void = () => {}
-  let promise = new Promise<value>((promiseResolve) => {
-    resolve = promiseResolve
-  })
-  return [promise, resolve]
-}

--- a/packages/ui/.changes/patch.navigation-source-support.md
+++ b/packages/ui/.changes/patch.navigation-source-support.md
@@ -1,0 +1,1 @@
+Use document navigations instead of frame-aware client navigation when the browser does not support `NavigateEvent.sourceElement`

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -102,6 +102,10 @@ await app.ready()
 This soft-navigation behavior applies even when the page only uses `clientEntry()` and does not
 render an explicit `<Frame>`.
 
+Frame navigation requires both `window.navigation` and `NavigateEvent.sourceElement`. Browsers
+missing either capability use document navigation for links, forms, and `navigate()`. Hydration and
+explicit frame reloads still work.
+
 The default resolver is equivalent to:
 
 ```js

--- a/packages/ui/src/animation/animate-layout-mixin.test.tsx
+++ b/packages/ui/src/animation/animate-layout-mixin.test.tsx
@@ -24,16 +24,13 @@ function createMockAnimation(
   keyframes: Keyframe[],
   options: KeyframeAnimationOptions,
 ): MockAnimation {
-  let resolveFinished!: () => void
-  let finished = new Promise<Animation>((_resolve) => {
-    resolveFinished = () => _resolve({} as Animation)
-  })
+  let finished = Promise.withResolvers<Animation>()
   return {
     keyframes,
     options,
     currentTime: 0,
     playState: 'running',
-    finished,
+    finished: finished.promise,
     pause() {
       this.playState = 'paused'
     },
@@ -43,7 +40,7 @@ function createMockAnimation(
     commitStyles() {},
     cancel() {
       this.playState = 'idle'
-      resolveFinished()
+      finished.resolve({} as Animation)
     },
   }
 }

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -82,7 +82,7 @@ export async function navigate(href: string, options?: NavigationOptions) {
     resetScroll: options?.resetScroll !== false,
     $rmx: true,
   } satisfies NavigationState
-  let navigation = window.navigation
+  let navigation = getInterceptableNavigation()
   if (!navigation) {
     if (options?.history === 'replace') {
       window.location.replace(href)
@@ -119,7 +119,7 @@ export function startNavigationListenerImpl(
     reloadFrame: typeof reloadFrameForNavigation
   },
 ) {
-  let navigation = window.navigation
+  let navigation = getInterceptableNavigation()
   if (!navigation) return
   let resolveFormNavigation = createFormNavigationResolver(signal)
 
@@ -246,6 +246,18 @@ export function startNavigationListenerImpl(
     },
     { signal },
   )
+}
+
+function getInterceptableNavigation(): Navigation | undefined {
+  let navigation = window.navigation
+  if (
+    !navigation ||
+    typeof NavigateEvent === 'undefined' ||
+    !('sourceElement' in NavigateEvent.prototype)
+  ) {
+    return
+  }
+  return navigation
 }
 
 function isRuntimeNavigation(info: unknown): info is NavigationState {

--- a/packages/ui/src/style/css-mixin.test.tsx
+++ b/packages/ui/src/style/css-mixin.test.tsx
@@ -210,14 +210,11 @@ describe('css mixin', () => {
     // A sibling mixin can persist the host node past unmount (e.g. exit
     // transitions). The css rule must keep styling the node until the
     // persistence teardown settles — only then may the refcount drop.
-    let releaseExit: (() => void) | undefined
-    let exitGate = new Promise<void>((resolve) => {
-      releaseExit = resolve
-    })
+    let exitGate = Promise.withResolvers<void>()
     let persistOnRemove = createMixin<Element>((handle) => {
       handle.addEventListener('beforeRemove', (event) => {
         ;(event as MixinBeforeRemoveEvent).persistNode(async () => {
-          await exitGate
+          await exitGate.promise
         })
       })
     })
@@ -244,8 +241,7 @@ describe('css mixin', () => {
     expect(getComputedStyle(div).color).toBe('rgb(77, 88, 99)')
 
     // Finish the exit: node is removed and the dynamic rule is released.
-    invariant(releaseExit)
-    releaseExit()
+    exitGate.resolve()
     await new Promise((resolve) => setTimeout(resolve, 0))
     root.flush()
 

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -172,25 +172,50 @@ describe('navigate', () => {
     let originalUrl = window.location.href
     let destination = new URL(originalUrl)
     destination.hash = 'document-navigation-fallback'
-    let originalHistoryLength = window.history.length
     stubGlobalField(t, 'navigation', undefined)
 
     try {
+      let navigated = new Promise<void>((resolve) => {
+        window.addEventListener('hashchange', () => resolve(), { once: true })
+      })
       await navigate(destination.href)
+      await navigated
       expect(window.location.href).toBe(destination.href)
-      expect(window.history.length).toBe(originalHistoryLength + 1)
     } finally {
       let wentBack = new Promise<void>((resolve) => {
         window.addEventListener('popstate', () => resolve(), { once: true })
       })
       window.history.back()
       await wentBack
+      expect(window.location.href).toBe(originalUrl)
 
       let wentForward = new Promise<void>((resolve) => {
         window.addEventListener('popstate', () => resolve(), { once: true })
       })
       window.history.forward()
       await wentForward
+      expect(window.location.href).toBe(destination.href)
+      window.history.replaceState(window.history.state, '', originalUrl)
+    }
+  })
+
+  it('falls back to document navigation when sourceElement is unavailable', async (t) => {
+    let originalUrl = window.location.href
+    let destination = new URL(originalUrl)
+    destination.hash = 'source-element-fallback'
+    let navigation = { navigate: mock.fn() }
+    stubGlobalField(t, 'navigation', navigation)
+    stubGlobalField(t, 'NavigateEvent', class extends Event {})
+
+    try {
+      let navigated = new Promise<void>((resolve) => {
+        window.addEventListener('hashchange', () => resolve(), { once: true })
+      })
+      await navigate(destination.href, { history: 'replace' })
+      await navigated
+      expect(window.location.href).toBe(destination.href)
+      expect(navigation.navigate).not.toHaveBeenCalled()
+    } finally {
       window.history.replaceState(window.history.state, '', originalUrl)
     }
   })
@@ -203,7 +228,11 @@ describe('navigate', () => {
     stubGlobalField(t, 'navigation', undefined)
 
     try {
+      let navigated = new Promise<void>((resolve) => {
+        window.addEventListener('hashchange', () => resolve(), { once: true })
+      })
       await navigate(destination.href, { history: 'replace' })
+      await navigated
       expect(window.location.href).toBe(destination.href)
       expect(window.history.length).toBe(originalHistoryLength)
     } finally {
@@ -219,6 +248,22 @@ describe('navigate', () => {
     startNavigationListener(controller.signal)
 
     expect(addDocumentListener).not.toHaveBeenCalled()
+    controller.abort()
+  })
+
+  it('skips navigation listeners when sourceElement is unavailable', (t) => {
+    let navigation = {
+      updateCurrentEntry: mock.fn(),
+      addEventListener: mock.fn(),
+    }
+    stubGlobalField(t, 'navigation', navigation)
+    stubGlobalField(t, 'NavigateEvent', class extends Event {})
+    let controller = new AbortController()
+
+    startNavigationListener(controller.signal)
+
+    expect(navigation.updateCurrentEntry).not.toHaveBeenCalled()
+    expect(navigation.addEventListener).not.toHaveBeenCalled()
     controller.abort()
   })
 

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -258,10 +258,12 @@ describe('navigate', () => {
     }
     stubGlobalField(t, 'navigation', navigation)
     stubGlobalField(t, 'NavigateEvent', class extends Event {})
+    let addDocumentListener = t.mock.method(document, 'addEventListener')
     let controller = new AbortController()
 
     startNavigationListener(controller.signal)
 
+    expect(addDocumentListener).not.toHaveBeenCalled()
     expect(navigation.updateCurrentEntry).not.toHaveBeenCalled()
     expect(navigation.addEventListener).not.toHaveBeenCalled()
     controller.abort()

--- a/packages/ui/src/test/utils.ts
+++ b/packages/ui/src/test/utils.ts
@@ -37,11 +37,6 @@ export function withResolvers<T = unknown>(): [
   (value: T) => void,
   (error: unknown) => void,
 ] {
-  let resolve!: (value: T) => void
-  let reject!: (error: unknown) => void
-  let promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
+  let { promise, resolve, reject } = Promise.withResolvers<T>()
   return [promise, resolve, reject]
 }

--- a/packages/ui/src/test/vdom.mixins.test.tsx
+++ b/packages/ui/src/test/vdom.mixins.test.tsx
@@ -590,7 +590,7 @@ describe('vnode mixins', () => {
     let reclaimedCalls = 0
     let removeCalls = 0
     let beforeRemoveCalls = 0
-    let resolvePending: (() => void) | null = null
+    let pending = Promise.withResolvers<void>()
 
     let withReclaimLifecycle = createMixin((handle) => {
       handle.addEventListener('insert', () => {
@@ -601,14 +601,10 @@ describe('vnode mixins', () => {
       })
       handle.addEventListener('beforeRemove', (event) => {
         beforeRemoveCalls++
-        event.persistNode(
-          (signal) =>
-            new Promise<void>((resolve) => {
-              let done = () => resolve()
-              resolvePending = done
-              signal.addEventListener('abort', done, { once: true })
-            }),
-        )
+        event.persistNode((signal) => {
+          signal.addEventListener('abort', () => pending.resolve(), { once: true })
+          return pending.promise
+        })
       })
       handle.addEventListener('remove', () => {
         removeCalls++
@@ -638,24 +634,17 @@ describe('vnode mixins', () => {
     expect(reclaimedCalls).toBe(1)
     expect(removeCalls).toBe(0)
 
-    if (resolvePending !== null) {
-      ;(resolvePending as () => void)()
-    }
+    pending.resolve()
   })
 
   it('defers host removal when beforeRemove.persistNode is used', async () => {
-    let releaseRemoval: (() => void) | null = null
+    let removal = Promise.withResolvers<void>()
     let beforeRemoveCalls = 0
     let removeCalls = 0
     let withDeferredRemove = createMixin((handle) => {
       handle.addEventListener('beforeRemove', (event) => {
         beforeRemoveCalls++
-        event.persistNode(
-          () =>
-            new Promise<void>((resolve) => {
-              releaseRemoval = () => resolve()
-            }),
-        )
+        event.persistNode(() => removal.promise)
       })
       handle.addEventListener('remove', () => {
         removeCalls++
@@ -678,12 +667,7 @@ describe('vnode mixins', () => {
     expect(removeCalls).toBe(0)
     expect(container.querySelector('#deferred-remove')).toBe(beforeRemove)
 
-    let release =
-      releaseRemoval ??
-      (() => {
-        throw new Error('expected deferred remove callback')
-      })
-    release()
+    removal.resolve()
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(removeCalls).toBe(1)
     expect(container.querySelector('#deferred-remove')).toBe(null)


### PR DESCRIPTION
Supersedes #11756 with a simpler compatibility policy: Remix only installs frame-aware Navigation API interception when the browser supports both `window.navigation` and `NavigateEvent.sourceElement`.

Browsers without either capability use `location.assign()` or `location.replace()` for programmatic navigation and retain native document navigation for links and forms. This keeps the older-Chromium behavior consistent with the existing Firefox and Safari fallback without global click capture, activation correlation, or stale-source state.

- Gate both listener installation and programmatic Navigation API usage on `NavigateEvent.sourceElement`
- Preserve native `formdata` capture for supported form navigations
- Cover missing-`sourceElement` document navigation and listener setup
- Stabilize document-navigation tests around asynchronous history events
- Retain the independent `Promise.withResolvers()` test cleanup from #11756

### Browser compatibility

The practical baseline for rendering and hydration remains May 13, 2024. The table lists the primary feature that binds each browser's lower bound in the current client packages; navigation enhancement support is intentionally separate from that baseline.

| Browser | Practical baseline | Release date | Primary binding feature | Navigation at baseline |
| --- | ---: | --- | --- | --- |
| Chrome | 123 | March 19, 2024 | CSS `light-dark()` | Document navigation; frame-aware SPA navigation from 135 |
| Edge | 123 | March 22, 2024 | CSS `light-dark()` | Document navigation; frame-aware SPA navigation from 135 |
| Firefox | 125 | April 16, 2024 | Popover API | Document navigation without both Navigation API capabilities |
| Safari / iOS Safari | 17.5 | May 13, 2024 | CSS `light-dark()` | Document navigation without both Navigation API capabilities |

`Promise.withResolvers()` does not raise this baseline: it is available in Chrome and Edge 119, Firefox 121, and Safari 17.4, and its uses in this PR are test-only.
