### PR TITLE
Render HTML 3xx and 4xx responses in default frame resolver

### DIFF
--- a/packages/ui/.changes/patch.render-4xx-html-frames.md
+++ b/packages/ui/.changes/patch.render-4xx-html-frames.md
@@ -1,1 +1,1 @@
-Render `4xx` HTML responses from the default frame resolver so progressively enhanced form validation and error pages update the frame (see #11810).
+Render `3xx` and `4xx` HTML responses from the default frame resolver so progressively enhanced form validation and error pages update the frame. Match HTML content types regardless of case (see #11823).

--- a/packages/ui/.changes/patch.render-4xx-html-frames.md
+++ b/packages/ui/.changes/patch.render-4xx-html-frames.md
@@ -1,0 +1,1 @@
+Render `4xx` HTML responses from the default frame resolver so progressively enhanced form validation and error pages update the frame (see #11810).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -113,7 +113,11 @@ async function resolveFrame(src, options) {
     signal: options?.signal,
   })
 
-  if (!response.ok) {
+  if (
+    response.status >= 500 ||
+    (response.status >= 300 &&
+      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
+  ) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 
@@ -165,9 +169,7 @@ window.navigation?.addEventListener('navigate', (e) => e.stopImmediatePropagatio
 This prevents Remix from intercepting Navigation API events. Explicit frame reloads such as
 `handle.frame.reload()` continue to use the frame resolver.
 
-The default resolver rejects non-OK responses with an error containing their status and status text.
-A custom `resolveFrame` may return a `Response` with any status when it wants Remix UI to render the
-response body.
+The default resolver accepts `2xx` responses and `3xx` or `4xx` responses whose `Content-Type` includes `text/html`, ignoring case. It rejects other `3xx` or `4xx` responses and all `5xx` responses with an error containing their status and status text. A custom `resolveFrame` may return a `Response` with any status when it wants Remix UI to render the response body.
 
 Forms remain ordinary HTML forms before the runtime starts. Add `data-rmx-target` to reload a named frame, or `data-rmx-document` to require a full-document submission:
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -113,11 +113,8 @@ async function resolveFrame(src, options) {
     signal: options?.signal,
   })
 
-  if (
-    response.status >= 500 ||
-    (response.status >= 300 &&
-      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
-  ) {
+  let isHtml = response.headers.get('Content-Type')?.toLowerCase().includes('text/html')
+  if (response.status >= 500 || (response.status >= 300 && !isHtml)) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -187,11 +187,8 @@ async function resolveFrame(src, options) {
     signal: options?.signal,
   })
 
-  if (
-    response.status >= 500 ||
-    (response.status >= 300 &&
-      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
-  ) {
+  let isHtml = response.headers.get('Content-Type')?.toLowerCase().includes('text/html')
+  if (response.status >= 500 || (response.status >= 300 && !isHtml)) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -187,7 +187,11 @@ async function resolveFrame(src, options) {
     signal: options?.signal,
   })
 
-  if (!response.ok) {
+  if (
+    response.status >= 500 ||
+    (response.status >= 300 &&
+      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
+  ) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 
@@ -229,8 +233,7 @@ submissions use `URLSearchParams` for `application/x-www-form-urlencoded`, CRLF-
 additional headers, another body encoding, or a different response policy. Custom resolvers receive
 `signal` and `target`; non-GET form submissions also provide `formData`, `method`, and `encType`.
 
-The default resolver rejects non-OK responses. A custom resolver may return a `Response` with any
-status when it wants Remix UI to render the response body.
+The default resolver accepts `2xx` responses and `3xx` or `4xx` responses whose `Content-Type` includes `text/html`, ignoring case. It rejects other `3xx` or `4xx` responses and all `5xx` responses with an error containing their status and status text. A custom resolver may return a `Response` with any status when it wants Remix UI to render the response body.
 
 A client resolver may return frame content directly or return the fetched `Response`. Returning the
 response lets Remix stream its body. When `fetch()` followed a redirect during a top-frame navigation,

--- a/packages/ui/src/runtime/component.ts
+++ b/packages/ui/src/runtime/component.ts
@@ -148,8 +148,9 @@ export type FrameContent = ReadableStream<Uint8Array> | string | RemixNode
  * Value returned by a browser frame resolver.
  *
  * Response bodies are rendered as frame content regardless of status. The default browser resolver
- * rejects non-OK responses before returning them. When `fetch()` followed a redirect, the response's
- * final URL updates the frame source and browser URL for a top-frame navigation.
+ * accepts 2xx responses and 3xx or 4xx HTML responses. It rejects other 3xx or 4xx responses and all
+ * 5xx responses. When `fetch()` followed a redirect, the response's final URL updates the frame source
+ * and browser URL for a top-frame navigation.
  */
 export type FrameResolution = FrameContent | Response
 

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -114,7 +114,7 @@ async function defaultResolveFrame(src: string, options?: ResolveFrameOptions): 
 
   if (
     response.status >= 500 ||
-    (response.status >= 400 && !response.headers.get('Content-Type')?.includes('text/html'))
+    (response.status >= 300 && !response.headers.get('Content-Type')?.includes('text/html'))
   ) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -112,7 +112,10 @@ async function defaultResolveFrame(src: string, options?: ResolveFrameOptions): 
     signal: options?.signal,
   })
 
-  if (!response.ok) {
+  if (
+    response.status >= 500 ||
+    (response.status >= 400 && !response.headers.get('Content-Type')?.includes('text/html'))
+  ) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -112,11 +112,8 @@ async function defaultResolveFrame(src: string, options?: ResolveFrameOptions): 
     signal: options?.signal,
   })
 
-  if (
-    response.status >= 500 ||
-    (response.status >= 300 &&
-      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
-  ) {
+  let isHtml = response.headers.get('Content-Type')?.toLowerCase().includes('text/html')
+  if (response.status >= 500 || (response.status >= 300 && !isHtml)) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }
 

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -114,7 +114,8 @@ async function defaultResolveFrame(src: string, options?: ResolveFrameOptions): 
 
   if (
     response.status >= 500 ||
-    (response.status >= 300 && !response.headers.get('Content-Type')?.includes('text/html'))
+    (response.status >= 300 &&
+      !response.headers.get('Content-Type')?.toLowerCase().includes('text/html'))
   ) {
     throw new Error(`Failed to resolve frame: ${response.status} ${response.statusText}`.trimEnd())
   }

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -308,7 +308,7 @@ describe('run', () => {
         new Response(
           '<!DOCTYPE html><html><head></head><body><p role="alert">Name is required</p></body></html><!-- rmx:flush document -->',
           {
-            headers: { 'Content-Type': 'text/html' },
+            headers: { 'Content-Type': 'Text/HTML; charset=utf-8' },
             status: 422,
             statusText: 'Unprocessable Content',
           },
@@ -330,34 +330,6 @@ describe('run', () => {
     } finally {
       app.dispose()
     }
-  })
-
-  it('renders 4xx HTML responses with a mixed-case content type from the default resolver', async (t) => {
-    t.mock.method(
-      globalThis,
-      'fetch',
-      async () =>
-        new Response(
-          '<!DOCTYPE html><html><head></head><body><p role="alert">Name is required</p></body></html><!-- rmx:flush document -->',
-          {
-            headers: { 'Content-Type': 'Text/HTML; charset=utf-8' },
-            status: 422,
-            statusText: 'Unprocessable Content',
-          },
-        ),
-    )
-
-    let app = run({ loadModule: mock.fn() })
-    t.after(() => app.dispose())
-    await app.ready()
-    app.frames.top.src = '/account'
-
-    await reloadFrameForNavigation(app.frames.top, {
-      formData: new FormData(),
-      method: 'post',
-    }).finished
-
-    expect(document.querySelector('[role="alert"]')?.textContent).toBe('Name is required')
   })
 
   it('rejects non-HTML 4xx responses from the default resolver', async (t) => {

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -235,6 +235,71 @@ describe('run', () => {
     }
   })
 
+  it('renders 3xx HTML responses from the default resolver', async (t) => {
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><main id="choices">Multiple choices</main></body></html><!-- rmx:flush document -->',
+          {
+            headers: { 'Content-Type': 'text/html' },
+            status: 300,
+            statusText: 'Multiple Choices',
+          },
+        ),
+    )
+
+    let app = run({ loadModule: mock.fn() })
+    await app.ready()
+    app.frames.top.src = '/choices'
+
+    try {
+      await app.frames.top.reload()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(document.getElementById('choices')?.textContent).toBe('Multiple choices')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('rejects non-HTML 3xx responses from the default resolver', async (t) => {
+    document.body.innerHTML = '<main id="initial">Initial</main>'
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response('{"next":"/account"}', {
+          headers: { 'Content-Type': 'application/json' },
+          status: 300,
+          statusText: 'Multiple Choices',
+        }),
+    )
+
+    let app = run({ loadModule: mock.fn() })
+    let reportedError: unknown
+    app.addEventListener('error', (event) => {
+      reportedError = event.error
+    })
+
+    try {
+      await app.ready()
+      app.frames.top.src = '/choices'
+
+      await expect(app.frames.top.reload()).rejects.toThrow(
+        'Failed to resolve frame: 300 Multiple Choices',
+      )
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(reportedError).toBeInstanceOf(Error)
+      expect((reportedError as Error).message).toBe('Failed to resolve frame: 300 Multiple Choices')
+      expect(document.getElementById('initial')?.textContent).toBe('Initial')
+    } finally {
+      app.dispose()
+    }
+  })
+
   it('renders 4xx HTML responses from the default resolver', async (t) => {
     let fetchMock = t.mock.method(
       globalThis,

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -313,6 +313,45 @@ describe('run', () => {
     }
   })
 
+  it('rejects 5xx HTML responses from the default resolver', async (t) => {
+    document.body.innerHTML = '<main id="initial">Initial</main>'
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response('<main id="error">Internal Server Error</main>', {
+          headers: { 'Content-Type': 'text/html' },
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+    )
+
+    let app = run({ loadModule: mock.fn() })
+    let reportedError: unknown
+    app.addEventListener('error', (event) => {
+      reportedError = event.error
+    })
+
+    try {
+      await app.ready()
+      app.frames.top.src = '/account'
+
+      await expect(app.frames.top.reload()).rejects.toThrow(
+        'Failed to resolve frame: 500 Internal Server Error',
+      )
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(reportedError).toBeInstanceOf(Error)
+      expect((reportedError as Error).message).toBe(
+        'Failed to resolve frame: 500 Internal Server Error',
+      )
+      expect(document.getElementById('initial')?.textContent).toBe('Initial')
+      expect(document.getElementById('error')).toBeNull()
+    } finally {
+      app.dispose()
+    }
+  })
+
   it('encodes urlencoded form data with URLSearchParams by default', async (t) => {
     let formData = new FormData()
     formData.set('name', 'Ada Lovelace')

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -281,7 +281,7 @@ describe('run', () => {
       globalThis,
       'fetch',
       async () =>
-        new Response('<main id="error">Account not found</main>', {
+        new Response('Not Found', {
           headers: { 'Content-Type': 'text/plain' },
           status: 404,
           statusText: 'Not Found',
@@ -308,7 +308,6 @@ describe('run', () => {
       expect(reportedError).toBeInstanceOf(Error)
       expect((reportedError as Error).message).toBe('Failed to resolve frame: 404 Not Found')
       expect(document.getElementById('initial')?.textContent).toBe('Initial')
-      expect(document.getElementById('error')).toBeNull()
     } finally {
       app.dispose()
     }

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -235,7 +235,39 @@ describe('run', () => {
     }
   })
 
-  it('rejects non-OK responses from the default resolver without replacing frame content', async (t) => {
+  it('renders 4xx HTML responses from the default resolver', async (t) => {
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><p role="alert">Name is required</p></body></html><!-- rmx:flush document -->',
+          {
+            headers: { 'Content-Type': 'text/html' },
+            status: 422,
+            statusText: 'Unprocessable Content',
+          },
+        ),
+    )
+
+    let app = run({ loadModule: mock.fn() })
+    await app.ready()
+    app.frames.top.src = '/account'
+
+    try {
+      await reloadFrameForNavigation(app.frames.top, {
+        formData: new FormData(),
+        method: 'post',
+      }).finished
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(document.querySelector('[role="alert"]')?.textContent).toBe('Name is required')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('rejects non-HTML 4xx responses from the default resolver', async (t) => {
     document.body.innerHTML = '<main id="initial">Initial</main>'
     let unhandledRejections: unknown[] = []
     let onUnhandledRejection = (event: PromiseRejectionEvent) => {
@@ -250,6 +282,7 @@ describe('run', () => {
       'fetch',
       async () =>
         new Response('<main id="error">Account not found</main>', {
+          headers: { 'Content-Type': 'text/plain' },
           status: 404,
           statusText: 'Not Found',
         }),

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -332,6 +332,34 @@ describe('run', () => {
     }
   })
 
+  it('renders 4xx HTML responses with a mixed-case content type from the default resolver', async (t) => {
+    t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><p role="alert">Name is required</p></body></html><!-- rmx:flush document -->',
+          {
+            headers: { 'Content-Type': 'Text/HTML; charset=utf-8' },
+            status: 422,
+            statusText: 'Unprocessable Content',
+          },
+        ),
+    )
+
+    let app = run({ loadModule: mock.fn() })
+    t.after(() => app.dispose())
+    await app.ready()
+    app.frames.top.src = '/account'
+
+    await reloadFrameForNavigation(app.frames.top, {
+      formData: new FormData(),
+      method: 'post',
+    }).finished
+
+    expect(document.querySelector('[role="alert"]')?.textContent).toBe('Name is required')
+  })
+
   it('rejects non-HTML 4xx responses from the default resolver', async (t) => {
     document.body.innerHTML = '<main id="initial">Initial</main>'
     let unhandledRejections: unknown[] = []


### PR DESCRIPTION
The default browser `resolveFrame` treated every non-2xx response as a failure, preventing progressively enhanced submissions from rendering validation or authorization pages returned as HTML. It now distinguishes renderable HTML responses from transport and server failures while preserving Fetch's built-in redirect handling.

- Render surfaced `3xx` and `4xx` responses when their content type includes `text/html`
- Reject non-HTML `3xx` and `4xx` responses and all `5xx` responses
- Leave `2xx` handling unchanged; followed redirects continue to resolve using their final response

Closes #11810
