### PR TITLE
Stop HMR test process trees on Windows

### DIFF
--- a/packages/node-hmr/src/hmr.test.ts
+++ b/packages/node-hmr/src/hmr.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { spawn, type ChildProcess } from 'node:child_process'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 
 import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
@@ -15,6 +16,25 @@ const waitForTimeout = 5_000
 const fixtureServerReadyTimeout = isWindows ? 15_000 : waitForTimeout
 
 describe('node-hmr', () => {
+  it('stops the fixture child server during cleanup', async () => {
+    await using fixture = await createFixture({
+      'server.ts': getServerSource('./message.ts', 'getMessage()'),
+      'message.ts': 'export function getMessage() { return "hello" }',
+    })
+    let server = startFixtureServer(fixture.path)
+
+    try {
+      let ready = await server.waitForReady(0)
+      assert.equal(await fetchText(ready.port), 'hello')
+
+      await server.stop()
+
+      assert.throws(() => process.kill(ready.pid, 0), { code: 'ESRCH' })
+    } finally {
+      await server.stop()
+    }
+  })
+
   it('hot updates self-accepting modules without restarting the server', async () => {
     await using fixture = await createFixture({
       'server.ts': getServerSource('./message.ts', 'getMessage()'),
@@ -2281,6 +2301,12 @@ function parseHmrUrlEvent(line: string): { pid: number; url: string } | null {
 
 async function stopProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return
+
+  if (isWindows && child.pid !== undefined) {
+    // Windows does not run SIGTERM handlers, so stop the child server as well as its parent.
+    await promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+    return
+  }
 
   await new Promise<void>((resolve) => {
     // The HMR runner gives its child five seconds to exit before force-killing it.

--- a/packages/node-hmr/src/hmr.test.ts
+++ b/packages/node-hmr/src/hmr.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import { once } from 'node:events'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 
@@ -2304,7 +2305,10 @@ async function stopProcess(child: ChildProcess): Promise<void> {
 
   if (isWindows && child.pid !== undefined) {
     // Windows does not run SIGTERM handlers, so stop the child server as well as its parent.
-    await promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+    await Promise.all([
+      once(child, 'exit'),
+      promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F']),
+    ])
     return
   }
 

--- a/packages/ui-hmr/test/hmr.test.e2e.tsx
+++ b/packages/ui-hmr/test/hmr.test.e2e.tsx
@@ -4,6 +4,7 @@ import { describe, it } from '@remix-run/test'
 import type { TestContext } from '@remix-run/test'
 import { renderToStream } from '@remix-run/ui/server'
 import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import { once } from 'node:events'
 import * as fs from 'node:fs/promises'
 import * as http from 'node:http'
 import * as path from 'node:path'
@@ -2773,7 +2774,10 @@ async function stopProcess(child: ChildProcess): Promise<void> {
 
   if (process.platform === 'win32' && child.pid !== undefined) {
     // Windows does not run SIGTERM handlers, so stop the child server as well as its parent.
-    await promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+    await Promise.all([
+      once(child, 'exit'),
+      promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F']),
+    ])
     return
   }
 

--- a/packages/ui-hmr/test/hmr.test.e2e.tsx
+++ b/packages/ui-hmr/test/hmr.test.e2e.tsx
@@ -3,11 +3,12 @@ import { createHtmlResponse } from '@remix-run/response/html'
 import { describe, it } from '@remix-run/test'
 import type { TestContext } from '@remix-run/test'
 import { renderToStream } from '@remix-run/ui/server'
-import { spawn, type ChildProcess } from 'node:child_process'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as http from 'node:http'
 import * as path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 import { watch, type FSWatcher } from 'chokidar'
 import { createAssetServer, type AssetServer, type BrowserHmrChannel } from '@remix-run/assets'
 import { uiHmr } from '../src/assets.ts'
@@ -2769,6 +2770,12 @@ function parseProxyReadyEvent(line: string): { pid: number; port: number } | nul
 
 async function stopProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return
+
+  if (process.platform === 'win32' && child.pid !== undefined) {
+    // Windows does not run SIGTERM handlers, so stop the child server as well as its parent.
+    await promisify(execFile)('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+    return
+  }
 
   await new Promise<void>((resolve) => {
     let timeout = setTimeout(() => {


### PR DESCRIPTION
The Windows HMR test helpers stop their parent process with `SIGTERM`, which does not run shutdown handlers on Windows. This leaves child servers running after tests finish and adds resource pressure during the full suite.

Stop the full process tree with `taskkill /T /F` in the `node-hmr` and `ui-hmr` test helpers. Add a regression test that checks the child server is gone after fixture cleanup.

Found while checking main after #11706: [the Windows run hit `ERR_NO_BUFFER_SPACE`](https://github.com/remix-run/remix/actions/runs/34288154359/job/102270763015).
