### PR TITLE
Reset forwarded URL metadata in fetch proxy

### DIFF
--- a/packages/fetch-proxy/.changes/patch.reset-forwarded-headers.md
+++ b/packages/fetch-proxy/.changes/patch.reset-forwarded-headers.md
@@ -1,0 +1,1 @@
+Replace existing forwarding URL metadata when `xForwardedHeaders` is enabled so proxied requests consistently describe the current incoming request URL.

--- a/packages/fetch-proxy/README.md
+++ b/packages/fetch-proxy/README.md
@@ -37,6 +37,19 @@ let title = text.match(/<title>([^<]+)<\/title>/)[1]
 assert(title.includes('Remix'))
 ```
 
+## Forwarding Headers
+
+Set `xForwardedHeaders: true` to set `X-Forwarded-Proto`, `X-Forwarded-Host`, and
+`X-Forwarded-Port` from the incoming request URL. When enabled, the proxy removes the `Forwarded`
+header and replaces any existing values for these three headers so the target receives a single set
+of URL metadata from the current proxy request.
+
+```ts
+let proxy = createFetchProxy('https://remix.run', {
+  xForwardedHeaders: true,
+})
+```
+
 ## Encoding and Framing Headers
 
 Since proxying is done via `fetch` rather than raw HTTP messages, some encoding and framing headers need to be removed.

--- a/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.test.ts
@@ -197,7 +197,7 @@ describe('fetch proxy', () => {
     assert.equal(request.headers.get('Accept-Encoding'), null)
   })
 
-  it('appends X-Forwarded headers when desired', async () => {
+  it('sets X-Forwarded headers when desired', async () => {
     let { request } = await testProxy(
       new Request('http://shopify.com:8080/search?q=remix'),
       'https://remix.run:3000/dest',
@@ -211,7 +211,31 @@ describe('fetch proxy', () => {
     assert.equal(request.headers.get('X-Forwarded-Port'), '8080')
   })
 
-  it('appends default X-Forwarded-Port values when request URLs omit ports', async () => {
+  it('replaces incoming forwarding metadata when X-Forwarded headers are enabled', async () => {
+    let { request } = await testProxy(
+      new Request('http://shopify.com:8080/search?q=remix', {
+        headers: {
+          Forwarded: 'for=203.0.113.43; proto=https; host=example.com',
+          'X-Forwarded-For': '203.0.113.43',
+          'X-Forwarded-Host': 'example.com',
+          'X-Forwarded-Port': '443',
+          'X-Forwarded-Proto': 'https',
+        },
+      }),
+      'https://remix.run:3000/dest',
+      {
+        xForwardedHeaders: true,
+      },
+    )
+
+    assert.equal(request.headers.get('Forwarded'), null)
+    assert.equal(request.headers.get('X-Forwarded-For'), '203.0.113.43')
+    assert.equal(request.headers.get('X-Forwarded-Proto'), 'http')
+    assert.equal(request.headers.get('X-Forwarded-Host'), 'shopify.com:8080')
+    assert.equal(request.headers.get('X-Forwarded-Port'), '8080')
+  })
+
+  it('sets default X-Forwarded-Port values when request URLs omit ports', async () => {
     let { request: httpRequest } = await testProxy(
       new Request('http://shopify.com/search?q=remix'),
       'https://remix.run:3000/dest',

--- a/packages/fetch-proxy/src/lib/fetch-proxy.ts
+++ b/packages/fetch-proxy/src/lib/fetch-proxy.ts
@@ -25,8 +25,9 @@ export interface FetchProxyOptions {
    */
   rewriteCookiePath?: boolean
   /**
-   * Set `true` to add `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port`
-   * headers to the proxied request.
+   * Set `true` to set `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port`
+   * headers on the proxied request from the incoming request URL. Existing values are replaced,
+   * and the `Forwarded` header is removed.
    *
    * @default false
    */
@@ -80,9 +81,10 @@ export function createFetchProxy(target: string | URL, options?: FetchProxyOptio
     proxyHeaders.delete('Host')
     proxyHeaders.delete('Accept-Encoding')
     if (xForwardedHeaders) {
-      proxyHeaders.append('X-Forwarded-Proto', url.protocol.replace(/:$/, ''))
-      proxyHeaders.append('X-Forwarded-Host', url.host)
-      proxyHeaders.append('X-Forwarded-Port', getForwardedPort(url))
+      proxyHeaders.delete('Forwarded')
+      proxyHeaders.set('X-Forwarded-Proto', url.protocol.replace(/:$/, ''))
+      proxyHeaders.set('X-Forwarded-Host', url.host)
+      proxyHeaders.set('X-Forwarded-Port', getForwardedPort(url))
     }
 
     let proxyInit: RequestInit = {


### PR DESCRIPTION
Ensure `createFetchProxy` emits a single authoritative set of URL forwarding headers when `xForwardedHeaders` is enabled. This keeps downstream request URL construction aligned with the current `Request` URL when the input already carries forwarding metadata.

- Replace existing `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-Port` values instead of extending them
- Remove `Forwarded` so it does not take precedence over the URL metadata generated by the proxy
- Preserve `X-Forwarded-For` and the existing pass-through behavior when `xForwardedHeaders` is disabled
- Document the option contract and cover requests containing prior forwarding metadata
