### PR TITLE
Preserve the implicit CORS wildcard with credentials

### DIFF
--- a/packages/cors-middleware/.changes/minor.credentials-require-origin.md
+++ b/packages/cors-middleware/.changes/minor.credentials-require-origin.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `cors({ credentials: true })` now preserves the default `Access-Control-Allow-Origin: *` response. Applications that intentionally allow credentialed requests from any origin must configure `origin: '*'` explicitly; applications with a restricted origin policy should continue to configure an exact origin, pattern, array, or resolver.

--- a/packages/cors-middleware/README.md
+++ b/packages/cors-middleware/README.md
@@ -52,6 +52,8 @@ router.get('/api/projects', () => {
 - `true` to reflect the request origin
 - `(origin, context) => boolean | string` for dynamic policies
 
+When `origin` is omitted, it defaults to `'*'`. This implicit default is not reflected when credentials are enabled. Configure an explicit origin policy for credentialed cross-origin requests.
+
 ### Restrict Origins
 
 ```ts
@@ -152,7 +154,8 @@ let router = createRouter({
 ## Caveats
 
 - CORS is primarily a browser enforcement mechanism. Disallowed non-preflight requests still reach your handlers unless you add separate request validation.
-- When `credentials: true` is used with `origin: '*'`, the middleware reflects the request origin and adds `Vary: Origin` so the response stays cache-safe.
+- When `credentials: true` is used without an explicit `origin`, the middleware preserves the default `Access-Control-Allow-Origin: *` header. Browsers do not expose credentialed responses with a wildcard allowed origin, so configure an explicit origin policy to allow them.
+- When `credentials: true` is used with an explicit `origin: '*'`, the middleware reflects the request origin and adds `Vary: Origin` so the response stays cache-safe.
 - When `allowedHeaders` is a function, preflight responses vary on `Access-Control-Request-Headers` so caches do not reuse a response for a different requested-header set.
 - `preflightContinue` and `preflightStatusCode` only affect how preflight `OPTIONS` requests are handled. They do not change actual request authorization.
 

--- a/packages/cors-middleware/src/lib/cors.test.ts
+++ b/packages/cors-middleware/src/lib/cors.test.ts
@@ -25,9 +25,29 @@ describe('cors middleware', () => {
     assert.equal(response.headers.get('Vary'), null)
   })
 
-  it('reflects origin and adds Vary when credentials are enabled', async () => {
+  it('keeps the wildcard default when credentials are enabled', async () => {
     let router = createRouter({
       middleware: [cors({ credentials: true })],
+    })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch('https://remix.run/', {
+      headers: {
+        Origin: 'https://example.com',
+      },
+    })
+
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
+    assert.equal(response.headers.get('Access-Control-Allow-Credentials'), 'true')
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(!vary.has('Origin'))
+  })
+
+  it('reflects an explicit wildcard origin when credentials are enabled', async () => {
+    let router = createRouter({
+      middleware: [cors({ origin: '*', credentials: true })],
     })
 
     router.get('/', () => new Response('ok'))
@@ -301,7 +321,7 @@ describe('cors middleware', () => {
 
   it('merges CORS Vary values with an existing response Vary header', async () => {
     let router = createRouter({
-      middleware: [cors({ credentials: true })],
+      middleware: [cors({ origin: '*', credentials: true })],
     })
 
     router.get(

--- a/packages/cors-middleware/src/lib/cors.test.ts
+++ b/packages/cors-middleware/src/lib/cors.test.ts
@@ -94,6 +94,54 @@ describe('cors middleware', () => {
     assert.ok(vary.has('Access-Control-Request-Headers'))
   })
 
+  it('keeps the wildcard default for preflight requests with credentials', async () => {
+    let router = createRouter({
+      middleware: [cors({ credentials: true })],
+    })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'PATCH',
+      },
+    })
+
+    assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
+    assert.equal(response.headers.get('Access-Control-Allow-Credentials'), 'true')
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(!vary.has('Origin'))
+    assert.ok(vary.has('Access-Control-Request-Method'))
+  })
+
+  it('reflects an explicit wildcard origin for preflight requests with credentials', async () => {
+    let router = createRouter({
+      middleware: [cors({ origin: '*', credentials: true })],
+    })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'PATCH',
+      },
+    })
+
+    assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://example.com')
+    assert.equal(response.headers.get('Access-Control-Allow-Credentials'), 'true')
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(vary.has('Origin'))
+    assert.ok(vary.has('Access-Control-Request-Method'))
+  })
+
   it('continues preflight requests when preflightContinue is true', async () => {
     let router = createRouter({
       middleware: [cors({ preflightContinue: true })],

--- a/packages/cors-middleware/src/lib/cors.ts
+++ b/packages/cors-middleware/src/lib/cors.ts
@@ -53,6 +53,9 @@ export interface CorsOptions {
   /**
    * Allowed origins. Defaults to '*'.
    *
+   * The implicit default is not reflected when credentials are enabled. Configure an explicit
+   * origin policy for credentialed cross-origin requests.
+   *
    * - `true` reflects the request Origin
    * - `false` disables CORS headers
    * - `'*'` allows all origins
@@ -157,7 +160,7 @@ export function cors(options: CorsOptions = {}): Middleware {
     let vary = new Vary()
 
     let allowOriginHeader = allowedOrigin
-    if (allowCredentials && allowedOrigin === '*') {
+    if (allowCredentials && allowedOrigin === '*' && options.origin !== undefined) {
       allowOriginHeader = requestOrigin
     }
 


### PR DESCRIPTION
Credential handling currently changes the middleware's implicit wildcard origin behavior. This update keeps the documented wildcard default unless an origin policy is configured explicitly.

- Preserve `Access-Control-Allow-Origin: *` for `cors({ credentials: true })` when `origin` is omitted
- Continue reflecting the request origin for an explicitly configured wildcard
- Document the distinction and migration path for applications that need the previous behavior
