### PR TITLE
Wait for frame adoption after HMR page reloads

### DIFF
--- a/packages/ui-hmr/test/hmr.test.e2e.tsx
+++ b/packages/ui-hmr/test/hmr.test.e2e.tsx
@@ -905,6 +905,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       ].join('\n'),
     })
     let server: NodeHmrTestServer | undefined
+    let startup = Promise.withResolvers<void>()
 
     try {
       server = await startNodeHmrFixtureServer(fixture)
@@ -921,6 +922,18 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
 
       let clientFieldPath = path.join(fixture.rootDir, 'app/ClientField.tsx')
       let clientFieldSource = await fs.readFile(clientFieldPath, 'utf-8')
+      // Keep the new page's client code from running until its HTML is visible.
+      await page.route(
+        '**/assets/app/entry.tsx*',
+        async (route) => {
+          await startup.promise
+          await route.continue()
+        },
+        { times: 1 },
+      )
+      let entryRequested = page.waitForRequest('**/assets/app/entry.tsx*', {
+        timeout: browserStartupTimeout,
+      })
       let reloaded = waitForNavigation(page)
       let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await fs.writeFile(
@@ -935,12 +948,19 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
           ),
       )
 
-      await reloaded
+      await Promise.all([reloaded, entryRequested])
+      await waitForText(page, '[data-testid="server-client-label"]', 'Client: before')
+      assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
+      startup.resolve()
       await adopted
-      await waitForText(page, '[data-testid="server-client-label"]', 'Client: after export removal')
+      assert.equal(
+        await page.locator('[data-testid="server-client-label"]').textContent(),
+        'Client: after export removal',
+      )
       assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
       assert.equal(server.readyCount, 1)
     } finally {
+      startup.resolve()
       await server?.close()
       await fixture.close()
     }

--- a/packages/ui-hmr/test/hmr.test.e2e.tsx
+++ b/packages/ui-hmr/test/hmr.test.e2e.tsx
@@ -595,11 +595,13 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       let entryPath = path.join(fixture.rootDir, 'app/entry.tsx')
       let entrySource = await fs.readFile(entryPath, 'utf-8')
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await fs.writeFile(
         entryPath,
         entrySource.replace('Frame adoption failed:', 'Updated frame adoption failed:'),
       )
       await reloaded
+      await adopted
       await waitForText(page, '[data-testid="server-message"]', 'Server: before')
       assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
       assert.equal(server.readyCount, 1)
@@ -675,6 +677,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       let clientFieldPath = path.join(fixture.rootDir, 'app/ClientField.tsx')
       let clientFieldSource = await fs.readFile(clientFieldPath, 'utf-8')
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await fs.writeFile(
         clientFieldPath,
         [
@@ -687,6 +690,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(page, '[data-testid="server-client-label"]', 'Client: after export add')
       assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
       assert.equal(server.readyCount, 1)
@@ -918,6 +922,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       let clientFieldPath = path.join(fixture.rootDir, 'app/ClientField.tsx')
       let clientFieldSource = await fs.readFile(clientFieldPath, 'utf-8')
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await fs.writeFile(
         clientFieldPath,
         clientFieldSource
@@ -931,6 +936,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(page, '[data-testid="server-client-label"]', 'Client: after export removal')
       assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
       assert.equal(server.readyCount, 1)
@@ -960,6 +966,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       let clientFieldPath = path.join(fixture.rootDir, 'app/ClientField.tsx')
       let clientFieldSource = await fs.readFile(clientFieldPath, 'utf-8')
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await fs.writeFile(
         clientFieldPath,
         [
@@ -970,6 +977,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(
         page,
         '[data-testid="server-client-label"]',
@@ -1003,6 +1011,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       await page.locator('[data-testid="document-field"]').fill('document before reload')
 
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await write(
         fixture.rootDir,
         'app/ClientField.tsx',
@@ -1010,6 +1019,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(
         page,
         '[data-testid="server-client-label"]',
@@ -1043,6 +1053,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       await page.locator('[data-testid="document-field"]').fill('document before reload')
 
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await write(
         fixture.rootDir,
         'app/ClientField.tsx',
@@ -1053,6 +1064,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(
         page,
         '[data-testid="server-client-label"]',
@@ -1133,6 +1145,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       await page.locator('[data-testid="document-field"]').fill('document before reload')
 
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await write(
         fixture.rootDir,
         'app/ClientField.tsx',
@@ -1143,6 +1156,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(page, '[data-testid="server-client-label"]', 'Client: after object export')
       assert.equal(await page.locator('[data-testid="document-field"]').inputValue(), '')
       assert.equal(server.readyCount, 1)
@@ -1209,6 +1223,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       await page.locator('[data-testid="document-field"]').fill('document before reload')
 
       let reloaded = waitForNavigation(page)
+      let adopted = waitForConsoleMessage(page, 'Frame adoption complete')
       await write(
         fixture.rootDir,
         'app/client-message.tsx',
@@ -1222,6 +1237,7 @@ describe('ui-hmr e2e', { skip: isBun }, () => {
       )
 
       await reloaded
+      await adopted
       await waitForText(
         page,
         '[data-testid="server-client-label"]',


### PR DESCRIPTION
The Windows Firefox job on #11830 failed after an HMR reload because the test started its five-second text check before the new page finished loading its client code. The reload completed, but frame adoption had not finished.

Wait for the signal from `app.ready()` in the eight remaining Node HMR page-reload tests before checking text or form state. This uses the existing 15-second startup timeout and follows the shared-module reload tests updated in #11829.

The export-removal test holds the reloaded entry script until navigation completes and the server-rendered HTML is visible. It then releases the script, waits for frame adoption, and checks the updated text directly. This forces startup to happen after navigation on every run, without a fixed delay.
