### PR TITLE
Preserve request checks across method overrides

### DIFF
--- a/packages/cop-middleware/.changes/patch.preserve-original-request-method.md
+++ b/packages/cop-middleware/.changes/patch.preserve-original-request-method.md
@@ -1,0 +1,1 @@
+Use the original request method for safe-method and method-specific bypass checks, so routing method overrides do not change request classification.

--- a/packages/cop-middleware/README.md
+++ b/packages/cop-middleware/README.md
@@ -28,7 +28,7 @@ let router = createRouter({
 
 ## Behavior
 
-For unsafe methods (`POST`, `PUT`, `PATCH`, `DELETE`), `cop()` follows the same broad model as Go's `CrossOriginProtection`:
+For requests whose original method is unsafe (`POST`, `PUT`, `PATCH`, `DELETE`), `cop()` follows the same broad model as Go's `CrossOriginProtection`. Routing middleware may change `context.method`, but method overrides do not change whether `cop()` checks the request:
 
 - Allow `Sec-Fetch-Site: same-origin`
 - Allow `Sec-Fetch-Site: none`
@@ -86,7 +86,7 @@ Trusted origins must be exact origin values in the form `scheme://host[:port]`.
 
 ## Insecure Bypass Patterns
 
-Bypass patterns intentionally weaken protection for specific endpoints. They support:
+Bypass patterns intentionally weaken protection for specific endpoints. Method prefixes match the original request method, even when routing middleware overrides `context.method`. They support:
 
 - Optional method prefixes, for example `POST /webhooks/{provider}`
 - Exact paths, for example `/healthz`

--- a/packages/cop-middleware/package.json
+++ b/packages/cop-middleware/package.json
@@ -34,6 +34,8 @@
   "devDependencies": {
     "@remix-run/assert": "workspace:*",
     "@remix-run/fetch-router": "workspace:*",
+    "@remix-run/form-data-middleware": "workspace:*",
+    "@remix-run/method-override-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"

--- a/packages/cop-middleware/src/lib/cop.test.ts
+++ b/packages/cop-middleware/src/lib/cop.test.ts
@@ -2,6 +2,8 @@ import * as assert from '@remix-run/assert'
 import { describe, it } from '@remix-run/test'
 
 import { createRouter } from '@remix-run/fetch-router'
+import { formData } from '@remix-run/form-data-middleware'
+import { methodOverride } from '@remix-run/method-override-middleware'
 
 import { cop } from './cop.ts'
 
@@ -148,6 +150,54 @@ describe('cop middleware', () => {
     )
 
     assert.equal(response.status, 200)
+  })
+
+  it('checks the original request method after a safe method override', async () => {
+    let router = createRouter({ middleware: [formData(), methodOverride(), cop()] })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch(
+      createRequest('/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Sec-Fetch-Site': 'cross-site',
+        },
+        body: '_method=GET',
+      }),
+    )
+
+    assert.equal(response.status, 403)
+    assert.equal(
+      await response.text(),
+      'Forbidden: cross-origin request detected from Sec-Fetch-Site header',
+    )
+  })
+
+  it('uses the original request method for method-specific bypass patterns', async () => {
+    let router = createRouter({
+      middleware: [formData(), methodOverride(), cop({ insecureBypassPatterns: ['GET /'] })],
+    })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch(
+      createRequest('/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Sec-Fetch-Site': 'cross-site',
+        },
+        body: '_method=GET',
+      }),
+    )
+
+    assert.equal(response.status, 403)
+    assert.equal(
+      await response.text(),
+      'Forbidden: cross-origin request detected from Sec-Fetch-Site header',
+    )
   })
 
   it('supports trusted origins', async () => {

--- a/packages/cop-middleware/src/lib/cop.test.ts
+++ b/packages/cop-middleware/src/lib/cop.test.ts
@@ -200,6 +200,28 @@ describe('cop middleware', () => {
     )
   })
 
+  it('allows bypass patterns matching the original method after an unsafe method override', async () => {
+    let router = createRouter({
+      middleware: [formData(), methodOverride(), cop({ insecureBypassPatterns: ['POST /'] })],
+    })
+
+    router.delete('/', () => new Response('Deleted'))
+
+    let response = await router.fetch(
+      createRequest('/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Sec-Fetch-Site': 'cross-site',
+        },
+        body: '_method=DELETE',
+      }),
+    )
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Deleted')
+  })
+
   it('supports trusted origins', async () => {
     let router = createTestRouter([
       cop({

--- a/packages/cop-middleware/src/lib/cop.ts
+++ b/packages/cop-middleware/src/lib/cop.ts
@@ -77,7 +77,7 @@ class CrossOriginProtection {
   }
 
   check(context: RequestContext): CopFailureReason | null {
-    if (isSafeMethod(context.method)) {
+    if (isSafeMethod(context.request.method.toUpperCase())) {
       return null
     }
 
@@ -310,7 +310,7 @@ function parseBypassSegment(
 }
 
 function matchesBypassPattern(pattern: BypassPattern, context: RequestContext): boolean {
-  if (pattern.method != null && pattern.method !== context.method) {
+  if (pattern.method != null && pattern.method !== context.request.method.toUpperCase()) {
     return false
   }
 

--- a/packages/csrf-middleware/.changes/patch.preserve-original-request-method.md
+++ b/packages/csrf-middleware/.changes/patch.preserve-original-request-method.md
@@ -1,0 +1,1 @@
+Use the original request method when deciding whether validation is required, so routing method overrides do not change request classification.

--- a/packages/csrf-middleware/README.md
+++ b/packages/csrf-middleware/README.md
@@ -59,7 +59,7 @@ Headers and form fields are the preferred transports. Query param fallback exist
 
 ## Origin Validation
 
-For unsafe methods (`POST`, `PUT`, `PATCH`, `DELETE`), the middleware validates request origin.
+For requests whose original method is unsafe (`POST`, `PUT`, `PATCH`, `DELETE`), the middleware validates the token and request origin. Routing middleware may change `context.method`, but method overrides do not change whether `csrf()` requires validation.
 
 - Default: same-origin validation when `Origin` or `Referer` is present
 - Custom: provide `origin` as string, regex, array, or function

--- a/packages/csrf-middleware/package.json
+++ b/packages/csrf-middleware/package.json
@@ -36,6 +36,7 @@
     "@remix-run/cookie": "workspace:*",
     "@remix-run/fetch-router": "workspace:*",
     "@remix-run/form-data-middleware": "workspace:*",
+    "@remix-run/method-override-middleware": "workspace:*",
     "@remix-run/session": "workspace:*",
     "@remix-run/session-middleware": "workspace:*",
     "@remix-run/test": "workspace:*",

--- a/packages/csrf-middleware/src/lib/csrf.test.ts
+++ b/packages/csrf-middleware/src/lib/csrf.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from '@remix-run/test'
 import { createCookie } from '@remix-run/cookie'
 import { createRouter } from '@remix-run/fetch-router'
 import { formData } from '@remix-run/form-data-middleware'
+import { methodOverride } from '@remix-run/method-override-middleware'
 import { createCookieSessionStorage } from '@remix-run/session/cookie-storage'
 import { session } from '@remix-run/session-middleware'
 
@@ -97,6 +98,56 @@ describe('csrf middleware', () => {
 
     assert.equal(response.status, 403)
     assert.equal(await response.text(), 'Forbidden: missing CSRF token')
+  })
+
+  it('checks the original request method after a safe method override', async () => {
+    let cookie = createCookie('__session', { secrets: ['secret1'] })
+    let storage = createCookieSessionStorage()
+
+    let router = createRouter({
+      middleware: [session(cookie, storage), formData(), methodOverride(), csrf()],
+    })
+
+    router.get('/', () => new Response('ok'))
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: '_method=GET',
+    })
+
+    assert.equal(response.status, 403)
+    assert.equal(await response.text(), 'Forbidden: missing CSRF token')
+  })
+
+  it('supports unsafe method overrides with a valid token', async () => {
+    let cookie = createCookie('__session', { secrets: ['secret1'] })
+    let storage = createCookieSessionStorage()
+
+    let router = createRouter({
+      middleware: [session(cookie, storage), formData(), methodOverride(), csrf()],
+    })
+
+    router.get('/token', (context) => new Response(getCsrfToken(context)))
+    router.delete('/', () => new Response('Deleted'))
+
+    let tokenResponse = await router.fetch('https://remix.run/token')
+    let token = await tokenResponse.text()
+
+    let postRequest = createRequest(tokenResponse, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `_method=DELETE&_csrf=${encodeURIComponent(token)}`,
+    })
+
+    let response = await router.fetch(postRequest)
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Deleted')
   })
 
   it('rejects unsafe requests with an invalid token', async () => {

--- a/packages/csrf-middleware/src/lib/csrf.ts
+++ b/packages/csrf-middleware/src/lib/csrf.ts
@@ -83,7 +83,7 @@ export interface CsrfOptions {
   headerNames?: readonly string[]
 
   /**
-   * Methods that do not require CSRF validation.
+   * Original request methods that do not require CSRF validation.
    *
    * @default ['GET', 'HEAD', 'OPTIONS']
    */
@@ -136,7 +136,7 @@ export function csrf(options: CsrfOptions = {}): Middleware {
 
     let expectedToken = getCsrfToken(context, tokenKey)
 
-    if (isSafeMethod(context.method, safeMethods)) {
+    if (isSafeMethod(context.request.method.toUpperCase(), safeMethods)) {
       return next()
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,6 +728,12 @@ importers:
       '@remix-run/assert':
         specifier: workspace:*
         version: link:../assert
+      '@remix-run/form-data-middleware':
+        specifier: workspace:*
+        version: link:../form-data-middleware
+      '@remix-run/method-override-middleware':
+        specifier: workspace:*
+        version: link:../method-override-middleware
       '@remix-run/test':
         specifier: workspace:*
         version: link:../test
@@ -778,6 +784,9 @@ importers:
       '@remix-run/form-data-middleware':
         specifier: workspace:*
         version: link:../form-data-middleware
+      '@remix-run/method-override-middleware':
+        specifier: workspace:*
+        version: link:../method-override-middleware
       '@remix-run/session-middleware':
         specifier: workspace:*
         version: link:../session-middleware


### PR DESCRIPTION
Routing middleware can change `context.method` before request-checking middleware runs. This keeps request classification tied to the transport method while preserving the overridden method for routing.

- Have `csrf()` and `cop()` classify safe requests from `context.request.method`
- Match method-specific `cop()` bypass patterns against the original request method
- Add integration coverage for safe and unsafe method overrides
- Document the original/effective method distinction and add patch change files
