### PR TITLE
Stabilize traversal scroll restoration E2E tests

### DIFF
--- a/demos/frames/app/scroll-anchoring.test.e2e.ts
+++ b/demos/frames/app/scroll-anchoring.test.e2e.ts
@@ -31,17 +31,13 @@ describe('scroll anchoring', () => {
       `Expected the detail page to scroll, got ${detailScrollPosition}`,
     )
 
-    await Promise.all([
-      page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            window.navigation.addEventListener('navigatesuccess', () => resolve(), { once: true })
-          }),
-      ),
-      page.goBack(),
-    ])
+    await page.goBack()
     await page.getByText('Anchoring row 48', { exact: true }).waitFor()
     await reproduction.getByRole('button', { name: 'Hydration check: 1', exact: true }).waitFor()
+    await page.waitForFunction(
+      ({ expected, tolerance }) => Math.abs(window.scrollY - expected) < tolerance,
+      { expected: scrollPosition, tolerance: 50 },
+    )
     let restoredPosition = await page.evaluate(() => window.scrollY)
 
     assert.ok(

--- a/demos/frames/app/scroll-restoration.test.e2e.ts
+++ b/demos/frames/app/scroll-restoration.test.e2e.ts
@@ -30,17 +30,13 @@ describe('scroll restoration', () => {
       detailScrollPosition > 100,
       `Expected the detail page to scroll, got ${detailScrollPosition}`,
     )
-    await Promise.all([
-      page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            window.navigation.addEventListener('navigatesuccess', () => resolve(), { once: true })
-          }),
-      ),
-      page.goBack(),
-    ])
+    await page.goBack()
     await page.getByText('List row 48', { exact: true }).waitFor()
     await reproduction.getByRole('button', { name: 'Hydration check: 1', exact: true }).waitFor()
+    await page.waitForFunction(
+      ({ expected, tolerance }) => Math.abs(window.scrollY - expected) < tolerance,
+      { expected: scrollPosition, tolerance: 50 },
+    )
     let restoredPosition = await page.evaluate(() => window.scrollY)
 
     assert.ok(


### PR DESCRIPTION
The traversal scroll E2E tests currently keep a `page.evaluate()` promise alive while triggering Back navigation. When the page execution context changes, Playwright fails before the tests can assert the scroll restoration behavior. This occurred in [this Check PR job](https://github.com/remix-run/remix/actions/runs/34379128965/job/102559321780?pr=11833).

- Wait for Back navigation normally, then poll the observable restored scroll position using the existing tolerance.
- Apply the same synchronization to both scroll anchoring and scroll restoration reproductions.
- Retain the restored DOM and hydration-state checks so an unexpected document reload still fails the tests.
