### PR TITLE
Validate SQL order by directions at runtime

### DIFF
--- a/packages/data-table-mysql/.changes/patch.reject-invalid-order-by-direction.md
+++ b/packages/data-table-mysql/.changes/patch.reject-invalid-order-by-direction.md
@@ -1,0 +1,1 @@
+Reject invalid `orderBy` direction values at runtime before interpolating them into generated MySQL queries.

--- a/packages/data-table-mysql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mysql/src/lib/sql-compiler.test.ts
@@ -249,6 +249,16 @@ describe('mysql sql-compiler', () => {
       })
     })
 
+    it('compile ordering', async () => {
+      await db.query(accounts).orderBy('email', 'asc').orderBy('id', 'desc').all()
+
+      let compiled = compileMysqlOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from `accounts` order by `email` ASC, `id` DESC',
+        values: [],
+      })
+    })
+
     it('compile distinct selection with order by', async () => {
       await db.query(accounts).distinct().orderBy('id', 'desc').all()
 

--- a/packages/data-table-mysql/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-mysql/src/lib/sql-compiler.test.ts
@@ -259,6 +259,18 @@ describe('mysql sql-compiler', () => {
       })
     })
 
+    it('reject invalid order by directions', async () => {
+      await db
+        .query(accounts)
+        .orderBy('id', 'ascending' as 'asc')
+        .all()
+
+      assert.throws(() => compileMysqlOperation(statements[0]), {
+        name: 'TypeError',
+        message: 'Invalid order by direction: expected "asc" or "desc"',
+      })
+    })
+
     it('compile distinct selection with order by', async () => {
       await db.query(accounts).distinct().orderBy('id', 'desc').all()
 

--- a/packages/data-table-mysql/src/lib/sql-compiler.ts
+++ b/packages/data-table-mysql/src/lib/sql-compiler.ts
@@ -3,6 +3,7 @@ import type { Predicate, SqlStatement } from '@remix-run/data-table'
 import type { DataManipulationOperation } from '@remix-run/data-table'
 import {
   collectColumns as collectColumnsHelper,
+  compileOrderByDirection,
   normalizeJoinType as normalizeJoinTypeHelper,
   quotePath as quotePathHelper,
 } from '@remix-run/data-table/sql-helpers'
@@ -275,7 +276,7 @@ function compileOrderByClause(orderBy: { column: string; direction: 'asc' | 'des
   return (
     ' order by ' +
     orderBy
-      .map((clause) => quotePath(clause.column) + ' ' + clause.direction.toUpperCase())
+      .map((clause) => quotePath(clause.column) + ' ' + compileOrderByDirection(clause.direction))
       .join(', ')
   )
 }

--- a/packages/data-table-postgres/.changes/patch.reject-invalid-order-by-direction.md
+++ b/packages/data-table-postgres/.changes/patch.reject-invalid-order-by-direction.md
@@ -1,0 +1,1 @@
+Reject invalid `orderBy` direction values at runtime before interpolating them into generated PostgreSQL queries.

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -261,6 +261,18 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('reject invalid order by directions', async () => {
+      await db
+        .query(accounts)
+        .orderBy('id', 'ascending' as 'asc')
+        .all()
+
+      assert.throws(() => compilePostgresOperation(statements[0]), {
+        name: 'TypeError',
+        message: 'Invalid order by direction: expected "asc" or "desc"',
+      })
+    })
+
     it('compile distinct selection with order by', async () => {
       await db.query(accounts).distinct().orderBy('id', 'desc').all()
 

--- a/packages/data-table-postgres/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.test.ts
@@ -251,6 +251,16 @@ describe('postgres sql-compiler', () => {
       })
     })
 
+    it('compile ordering', async () => {
+      await db.query(accounts).orderBy('email', 'asc').orderBy('id', 'desc').all()
+
+      let compiled = compilePostgresOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from "accounts" order by "email" ASC, "id" DESC',
+        values: [],
+      })
+    })
+
     it('compile distinct selection with order by', async () => {
       await db.query(accounts).distinct().orderBy('id', 'desc').all()
 

--- a/packages/data-table-postgres/src/lib/sql-compiler.ts
+++ b/packages/data-table-postgres/src/lib/sql-compiler.ts
@@ -3,6 +3,7 @@ import type { Predicate, SqlStatement } from '@remix-run/data-table'
 import type { DataManipulationOperation } from '@remix-run/data-table'
 import {
   collectColumns as collectColumnsHelper,
+  compileOrderByDirection,
   normalizeJoinType as normalizeJoinTypeHelper,
   quotePath as quotePathHelper,
 } from '@remix-run/data-table/sql-helpers'
@@ -551,7 +552,7 @@ function compileOrderByClause(orderBy: { column: string; direction: 'asc' | 'des
   return (
     ' order by ' +
     orderBy
-      .map((clause) => quotePath(clause.column) + ' ' + clause.direction.toUpperCase())
+      .map((clause) => quotePath(clause.column) + ' ' + compileOrderByDirection(clause.direction))
       .join(', ')
   )
 }

--- a/packages/data-table-sqlite/.changes/patch.reject-invalid-order-by-direction.md
+++ b/packages/data-table-sqlite/.changes/patch.reject-invalid-order-by-direction.md
@@ -1,0 +1,1 @@
+Reject invalid `orderBy` direction values at runtime before interpolating them into generated SQLite queries.

--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -408,6 +408,18 @@ describe('sqlite sql-compiler', () => {
       })
     })
 
+    it('reject invalid order by directions', async () => {
+      await db
+        .query(accounts)
+        .orderBy('id', 'ascending' as 'asc')
+        .all()
+
+      assert.throws(() => compileSqliteOperation(statements[0]), {
+        name: 'TypeError',
+        message: 'Invalid order by direction: expected "asc" or "desc"',
+      })
+    })
+
     it('compile with normalized boolean - true', async () => {
       await db.query(accounts).where({ deleted: true }).all()
       let compiled = compileSqliteOperation(statements[0])

--- a/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.test.ts
@@ -399,6 +399,15 @@ describe('sqlite sql-compiler', () => {
       })
     })
 
+    it('compile ordering', async () => {
+      await db.query(accounts).orderBy('email', 'asc').orderBy('id', 'desc').all()
+      let compiled = compileSqliteOperation(statements[0])
+      assert.deepEqual(compiled, {
+        text: 'select * from "accounts" order by "email" ASC, "id" DESC',
+        values: [],
+      })
+    })
+
     it('compile with normalized boolean - true', async () => {
       await db.query(accounts).where({ deleted: true }).all()
       let compiled = compileSqliteOperation(statements[0])

--- a/packages/data-table-sqlite/src/lib/sql-compiler.ts
+++ b/packages/data-table-sqlite/src/lib/sql-compiler.ts
@@ -3,6 +3,7 @@ import type { Predicate, SqlStatement } from '@remix-run/data-table'
 import type { DataManipulationOperation } from '@remix-run/data-table'
 import {
   collectColumns as collectColumnsHelper,
+  compileOrderByDirection,
   normalizeJoinType as normalizeJoinTypeHelper,
   quotePath as quotePathHelper,
 } from '@remix-run/data-table/sql-helpers'
@@ -305,7 +306,7 @@ function compileOrderByClause(orderBy: { column: string; direction: 'asc' | 'des
   return (
     ' order by ' +
     orderBy
-      .map((clause) => quotePath(clause.column) + ' ' + clause.direction.toUpperCase())
+      .map((clause) => quotePath(clause.column) + ' ' + compileOrderByDirection(clause.direction))
       .join(', ')
   )
 }

--- a/packages/data-table/.changes/minor.compile-order-by-direction.md
+++ b/packages/data-table/.changes/minor.compile-order-by-direction.md
@@ -1,0 +1,1 @@
+Add `compileOrderByDirection()` to `@remix-run/data-table/sql-helpers` for adapters that need to validate and compile case-insensitive `asc` and `desc` values.

--- a/packages/data-table/src/lib/sql-helpers.test.ts
+++ b/packages/data-table/src/lib/sql-helpers.test.ts
@@ -1,0 +1,22 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { compileOrderByDirection } from './sql-helpers.ts'
+
+describe('SQL helpers', () => {
+  it('compiles order by directions case-insensitively', () => {
+    assert.equal(compileOrderByDirection('asc'), 'ASC')
+    assert.equal(compileOrderByDirection('ASC'), 'ASC')
+    assert.equal(compileOrderByDirection('Asc'), 'ASC')
+    assert.equal(compileOrderByDirection('desc'), 'DESC')
+    assert.equal(compileOrderByDirection('DESC'), 'DESC')
+    assert.equal(compileOrderByDirection('Desc'), 'DESC')
+  })
+
+  it('rejects invalid order by directions', () => {
+    assert.throws(
+      () => compileOrderByDirection('ascending'),
+      /Invalid order by direction: expected "asc" or "desc"/,
+    )
+  })
+})

--- a/packages/data-table/src/lib/sql-helpers.ts
+++ b/packages/data-table/src/lib/sql-helpers.ts
@@ -6,6 +6,25 @@ import type { TableRef } from './driver.ts'
 export type QuoteIdentifier = (value: string) => string
 
 /**
+ * Compiles a case-insensitive `orderBy` direction for use in a SQL statement.
+ * @param direction Runtime value to validate.
+ * @returns The uppercase SQL direction keyword.
+ */
+export function compileOrderByDirection(direction: unknown): 'ASC' | 'DESC' {
+  let normalizedDirection = typeof direction === 'string' ? direction.toLowerCase() : direction
+
+  if (normalizedDirection === 'asc') {
+    return 'ASC'
+  }
+
+  if (normalizedDirection === 'desc') {
+    return 'DESC'
+  }
+
+  throw new TypeError('Invalid order by direction: expected "asc" or "desc"')
+}
+
+/**
  * Normalizes an arbitrary join type string into `inner`, `left`, or `right`.
  * @param type Input join type.
  * @returns Normalized join type.

--- a/packages/data-table/src/sql-helpers.ts
+++ b/packages/data-table/src/sql-helpers.ts
@@ -1,6 +1,7 @@
 export type { QuoteIdentifier } from './lib/sql-helpers.ts'
 export {
   collectColumns,
+  compileOrderByDirection,
   normalizeJoinType,
   quoteLiteral,
   quotePath,

--- a/packages/remix/.changes/minor.remix.update-exports.md
+++ b/packages/remix/.changes/minor.remix.update-exports.md
@@ -1,0 +1,1 @@
+Expose `compileOrderByDirection()` through `remix/data-table/sql-helpers`.


### PR DESCRIPTION
`orderBy` directions are currently uppercased and interpolated by each SQL adapter. TypeScript constrains ordinary calls, but compiler inputs can still contain unsupported runtime values.

This adds a shared SQL helper that normalizes and validates direction keywords, then uses it at the MySQL, PostgreSQL, and SQLite query-generation boundaries.

- Accept case-insensitive `asc` and `desc` values and compile them to `ASC` or `DESC`
- Reject unsupported runtime values before generating SQL
- Expose the helper through `@remix-run/data-table/sql-helpers` and `remix/data-table/sql-helpers`
- Add focused helper and adapter compilation coverage

This follows the validation-at-the-SQL-boundary approach from #11594. Direction keywords use an allowlist because bound parameters represent SQL values rather than grammar tokens.

```ts
import { compileOrderByDirection } from '@remix-run/data-table/sql-helpers'

compileOrderByDirection('Asc') // "ASC"
compileOrderByDirection('descending') // throws TypeError
```
