### PR TITLE
Require explicit column references in comparison predicates

### DIFF
--- a/packages/data-table-mysql/src/lib/driver.test.ts
+++ b/packages/data-table-mysql/src/lib/driver.test.ts
@@ -924,7 +924,7 @@ describe('mysql driver', () => {
     )
   })
 
-  it('compiles column-to-column comparisons from string references', async () => {
+  it('binds dotted strings in explicit column-to-column queries', async () => {
     let statements: Array<{ text: string; values: unknown[] }> = []
 
     let connection = {
@@ -941,13 +941,13 @@ describe('mysql driver', () => {
 
     await db
       .query(accounts)
-      .join(projects, eq('accounts.id', 'projects.account_id'))
-      .where(eq('accounts.email', 'ops@example.com'))
+      .join(projects, eq(accounts.id, projects.account_id))
+      .where(eq(accounts.email, 'accounts.email'))
       .count()
 
     assert.match(statements[0].text, /`accounts`\.`id`\s*=\s*`projects`\.`account_id`/)
     assert.match(statements[0].text, /`accounts`\.`email`\s*=\s*\?/)
-    assert.deepEqual(statements[0].values, ['ops@example.com'])
+    assert.deepEqual(statements[0].values, ['accounts.email'])
   })
 
   it('compiles cross-schema table references in joins', async () => {

--- a/packages/data-table-postgres/src/lib/driver.test.ts
+++ b/packages/data-table-postgres/src/lib/driver.test.ts
@@ -1040,7 +1040,7 @@ describe('postgres driver', () => {
     )
   })
 
-  it('compiles column-to-column comparisons from string references', async () => {
+  it('binds dotted strings in explicit column-to-column queries', async () => {
     let statements: Array<{ text: string; values: unknown[] | undefined }> = []
 
     let client = {
@@ -1061,13 +1061,13 @@ describe('postgres driver', () => {
 
     await db
       .query(accounts)
-      .join(projects, eq('accounts.id', 'projects.account_id'))
-      .where(eq('accounts.email', 'ops@example.com'))
+      .join(projects, eq(accounts.id, projects.account_id))
+      .where(eq(accounts.email, 'accounts.email'))
       .count()
 
     assert.match(statements[0].text, /"accounts"\."id"\s*=\s*"projects"\."account_id"/)
     assert.match(statements[0].text, /"accounts"\."email"\s*=\s*\$1/)
-    assert.deepEqual(statements[0].values, ['ops@example.com'])
+    assert.deepEqual(statements[0].values, ['accounts.email'])
   })
 
   it('compiles cross-schema table references in joins', async () => {

--- a/packages/data-table-sqlite/src/lib/driver.test.ts
+++ b/packages/data-table-sqlite/src/lib/driver.test.ts
@@ -838,7 +838,7 @@ describe('sqlite driver', () => {
     sqlite.close()
   })
 
-  it('supports column-to-column comparisons from string references', async () => {
+  it('binds dotted strings in explicit column-to-column queries', async () => {
     let sqlite = createNativeSqliteDatabase()
     sqlite.exec(
       'create table accounts (id integer primary key, email text not null, status text not null)',
@@ -855,11 +855,11 @@ describe('sqlite driver', () => {
 
     let count = await db
       .query(accounts)
-      .join(projects, eq('accounts.id', 'projects.account_id'))
-      .where(eq('accounts.email', 'a@example.com'))
+      .join(projects, eq(accounts.id, projects.account_id))
+      .where(eq(accounts.email, 'accounts.email'))
       .count()
 
-    assert.equal(count, 1)
+    assert.equal(count, 0)
     sqlite.close()
   })
 

--- a/packages/data-table/.changes/minor.explicit-column-comparisons.md
+++ b/packages/data-table/.changes/minor.explicit-column-comparisons.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Dotted string values passed to `eq()`, `ne()`, `gt()`, `gte()`, `lt()`, and `lte()` are now treated as scalar values. Use table column references, such as `eq(accounts.id, projects.account_id)`, for column-to-column comparisons.

--- a/packages/data-table/src/lib/database.test.ts
+++ b/packages/data-table/src/lib/database.test.ts
@@ -913,7 +913,7 @@ describe('writes and validation', () => {
       async function () {
         await db
           .query(accounts)
-          .join(projects, eq('accounts.id', 'projects.account_id'))
+          .join(projects, eq(accounts.id, projects.account_id))
           .update({ status: 'inactive' })
       },
       function (error: unknown) {

--- a/packages/data-table/src/lib/operators.test.ts
+++ b/packages/data-table/src/lib/operators.test.ts
@@ -50,7 +50,7 @@ const invoices = table({
 })
 
 describe('comparison predicates', () => {
-  it('treats qualified string values as column references', () => {
+  it('treats qualified string values as scalar values', () => {
     let predicate = eq('accounts.id', 'projects.account_id')
 
     assert.deepEqual(predicate, {
@@ -58,7 +58,28 @@ describe('comparison predicates', () => {
       operator: 'eq',
       column: 'accounts.id',
       value: 'projects.account_id',
-      valueType: 'column',
+      valueType: 'value',
+    })
+
+    assert.deepEqual(ne('accounts.id', 'projects.account_id'), {
+      ...predicate,
+      operator: 'ne',
+    })
+    assert.deepEqual(gt('accounts.id', 'projects.account_id'), {
+      ...predicate,
+      operator: 'gt',
+    })
+    assert.deepEqual(gte('accounts.id', 'projects.account_id'), {
+      ...predicate,
+      operator: 'gte',
+    })
+    assert.deepEqual(lt('accounts.id', 'projects.account_id'), {
+      ...predicate,
+      operator: 'lt',
+    })
+    assert.deepEqual(lte('accounts.id', 'projects.account_id'), {
+      ...predicate,
+      operator: 'lte',
     })
   })
 
@@ -271,7 +292,7 @@ describe('logical predicates', () => {
 
   it('collects columns across nested predicates', () => {
     let predicate = and(
-      eq('accounts.id', 'projects.account_id'),
+      eq(accounts.id, projects.account_id),
       or(
         between('accounts.id', 1, 5),
         and(isNull('projects.deleted_at'), notNull('accounts.email')),

--- a/packages/data-table/src/lib/operators.ts
+++ b/packages/data-table/src/lib/operators.ts
@@ -74,11 +74,8 @@ type WhereInputColumn<input extends WhereInput> =
  */
 export function eq<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function eq<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -92,11 +89,8 @@ export function eq(column: string | ColumnReferenceLike, value: unknown): Predic
  */
 export function ne<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function ne<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -110,11 +104,8 @@ export function ne(column: string | ColumnReferenceLike, value: unknown): Predic
  */
 export function gt<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function gt<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -128,11 +119,8 @@ export function gt(column: string | ColumnReferenceLike, value: unknown): Predic
  */
 export function gte<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function gte<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -146,11 +134,8 @@ export function gte(column: string | ColumnReferenceLike, value: unknown): Predi
  */
 export function lt<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function lt<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -164,11 +149,8 @@ export function lt(column: string | ColumnReferenceLike, value: unknown): Predic
  */
 export function lte<
   left extends ColumnInput<QualifiedColumnReference>,
-  right extends ColumnInput<QualifiedColumnReference>,
->(
-  column: left,
-  value: right & (right extends `${string}@${string}` ? never : right),
-): Predicate<PredicateColumn<left> | PredicateColumn<right>>
+  right extends ColumnReferenceLike<QualifiedColumnReference>,
+>(column: left, value: right): Predicate<PredicateColumn<left> | PredicateColumn<right>>
 export function lte<column extends string | ColumnReferenceLike>(
   column: column,
   value: unknown,
@@ -429,12 +411,12 @@ function createComparisonPredicate(
   let normalizedColumn = resolvePredicateColumn(column)
   let normalizedValue = resolveComparisonValue(value)
 
-  if (isQualifiedColumnReference(normalizedColumn) && isQualifiedColumnReference(normalizedValue)) {
+  if (isQualifiedColumnReference(normalizedColumn) && isColumnReference(value)) {
     return {
       type: 'comparison',
       operator,
       column: normalizedColumn,
-      value: normalizedValue,
+      value: normalizeColumnInput(value),
       valueType: 'column',
     }
   }

--- a/packages/data-table/src/lib/type-safety.test.ts
+++ b/packages/data-table/src/lib/type-safety.test.ts
@@ -417,7 +417,7 @@ describe('type safety', () => {
     // @ts-expect-error join predicate key must be from source or target table
     db.query(accounts).join(projects, eq('not_a_column', true))
     // @ts-expect-error right-hand column reference must be from source or target table
-    db.query(accounts).join(projects, eq(accounts.id, 'projects.not_a_column'))
+    db.query(accounts).join(projects, eq(accounts.id, tasks.id))
     // @ts-expect-error relation predicate key must be from relation target table
     accountProjects.where({ not_a_column: true })
   })

--- a/packages/data-table/test/driver-integration-contract.ts
+++ b/packages/data-table/test/driver-integration-contract.ts
@@ -93,7 +93,7 @@ export function runDriverIntegrationContract(options: IntegrationContractOptions
 
     let joined = await db
       .query(accounts)
-      .join(projects, eq('accounts.id', 'projects.account_id'))
+      .join(projects, eq(accounts.id, projects.account_id))
       .where(eq('projects.archived', false))
       .select({
         accountId: 'accounts.id',
@@ -121,7 +121,7 @@ export function runDriverIntegrationContract(options: IntegrationContractOptions
 
     let groupedCount = await db
       .query(accounts)
-      .join(projects, eq('accounts.id', 'projects.account_id'))
+      .join(projects, eq(accounts.id, projects.account_id))
       .where(eq('projects.archived', false))
       .groupBy('accounts.id')
       .having(eq('accounts.id', 1))

--- a/packages/remix/.changes/major.data-table.explicit-column-comparisons.md
+++ b/packages/remix/.changes/major.data-table.explicit-column-comparisons.md
@@ -1,0 +1,1 @@
+BREAKING CHANGE: `remix/data-table` now treats dotted strings passed as comparison values as scalar values. Use table column references for column-to-column comparisons.


### PR DESCRIPTION
Comparison operators previously inferred column-to-column comparisons whenever both arguments were dotted strings. This updates the predicate contract so string values consistently remain scalar data, while table column references continue to express column comparisons explicitly.

- Treat dotted strings passed to `eq()`, `ne()`, `gt()`, `gte()`, `lt()`, and `lte()` as bound values
- Preserve column-to-column comparisons through typed table column references, including cross-schema references
- Cover the resulting parameter binding behavior in the PostgreSQL, MySQL, and SQLite drivers

```ts
// Before
eq('accounts.id', 'projects.account_id')

// After
eq(accounts.id, projects.account_id)
```
