### PR TITLE
Reject structurally unconditional write filters

### DIFF
--- a/packages/data-table/.changes/patch.reject-always-true-write-filters.md
+++ b/packages/data-table/.changes/patch.reject-always-true-write-filters.md
@@ -1,0 +1,1 @@
+Reject update and delete operations when a supplied `where` clause is structurally unconditional, including empty object filters and empty `notIn` predicates.

--- a/packages/data-table/src/lib/database.test.ts
+++ b/packages/data-table/src/lib/database.test.ts
@@ -6,7 +6,7 @@ import { column } from './column.ts'
 import { Database } from './database.ts'
 import { DataTableDatabaseError, DataTableQueryError, DataTableValidationError } from './errors.ts'
 import { table, hasMany, timestamps } from './table.ts'
-import { eq } from './operators.ts'
+import { and, eq, notInList, or } from './operators.ts'
 import { createRecordingDriver, TestDatabase } from '../../test/recording-driver.ts'
 
 const accounts = table({
@@ -265,6 +265,109 @@ describe('queries', () => {
     assert.equal(result.affectedRows, 2)
     assert.equal(recording.requests.length, 1)
     assert.equal(recording.requests[0].operation.kind, 'insertMany')
+  })
+
+  it('rejects updateMany() when an empty where object is structurally unconditional', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await assert.rejects(
+      async function () {
+        await db.updateMany(accounts, { status: 'inactive' }, { where: {} })
+      },
+      function (error: unknown) {
+        return (
+          error instanceof DataTableQueryError &&
+          error.message === 'update() does not allow a structurally unconditional where clause'
+        )
+      },
+    )
+    assert.equal(recording.requests.length, 0)
+  })
+
+  it('rejects deleteMany() when an empty where object is structurally unconditional', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await assert.rejects(
+      async function () {
+        await db.deleteMany(accounts, { where: {} })
+      },
+      function (error: unknown) {
+        return (
+          error instanceof DataTableQueryError &&
+          error.message === 'delete() does not allow a structurally unconditional where clause'
+        )
+      },
+    )
+    assert.equal(recording.requests.length, 0)
+  })
+
+  it('rejects update() when a nested empty notIn predicate is structurally unconditional', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await assert.rejects(
+      async function () {
+        await db
+          .query(accounts)
+          .where(or(eq('id', 1), notInList('id', [])))
+          .update({ status: 'inactive' })
+      },
+      function (error: unknown) {
+        return (
+          error instanceof DataTableQueryError &&
+          error.message === 'update() does not allow a structurally unconditional where clause'
+        )
+      },
+    )
+    assert.equal(recording.requests.length, 0)
+  })
+
+  it('rejects delete() when a nested empty notIn predicate is structurally unconditional', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await assert.rejects(
+      async function () {
+        await db
+          .query(accounts)
+          .where(and(notInList('id', [])))
+          .delete()
+      },
+      function (error: unknown) {
+        return (
+          error instanceof DataTableQueryError &&
+          error.message === 'delete() does not allow a structurally unconditional where clause'
+        )
+      },
+    )
+    assert.equal(recording.requests.length, 0)
+  })
+
+  it('allows structurally unconditional predicates in read queries', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await db.query(accounts).where({}).all()
+    await db.query(accounts).where(notInList('id', [])).all()
+
+    assert.equal(recording.requests.length, 2)
+    assert.equal(recording.requests[0].operation.kind, 'select')
+    assert.equal(recording.requests[1].operation.kind, 'select')
+  })
+
+  it('allows writes with a restrictive and structurally unconditional predicate', async () => {
+    let recording = createRecordingDriver()
+    let db = createTestDatabase(recording.driver)
+
+    await db
+      .query(accounts)
+      .where(and(eq('id', 1), notInList('id', [])))
+      .delete()
+
+    assert.equal(recording.requests.length, 1)
+    assert.equal(recording.requests[0].operation.kind, 'delete')
   })
 
   it('throws for createMany({ returnRows: true }) when driver has no RETURNING support', async () => {

--- a/packages/data-table/src/lib/database/query-execution.ts
+++ b/packages/data-table/src/lib/database/query-execution.ts
@@ -12,6 +12,7 @@ import type {
 } from '../driver.ts'
 import { DataTableQueryError } from '../errors.ts'
 import type { ReturningInput, WriteResult, WriteRowResult, WriteRowsResult } from '../database.ts'
+import type { Predicate } from '../operators.ts'
 import { normalizeWhereInput } from '../operators.ts'
 import type { AnyQuery, QueryExecutionResult, QueryState } from '../query.ts'
 import { cloneQueryState, querySnapshot } from '../query.ts'
@@ -387,6 +388,8 @@ async function executeUpdate(
     throw new DataTableQueryError('update() requires at least one change')
   }
 
+  assertWhereIsNotStructurallyUnconditional(state.where, 'update')
+
   let result: DataManipulationResult
 
   if (hasScopedWriteModifiers(state)) {
@@ -453,6 +456,7 @@ async function executeDelete(
 ): Promise<WriteResult | WriteRowsResult<Record<string, unknown>>> {
   let returning = options?.returning
   assertReturningCapability(database.capabilities, 'delete', returning)
+  assertWhereIsNotStructurallyUnconditional(state.where, 'delete')
   let tableName = getTableName(table)
   let deleteContext = {
     tableName,
@@ -518,6 +522,37 @@ async function executeDelete(
     insertId: result.insertId,
     rows: applyAfterReadHooksToRows(table, normalizeRows(result.rows)),
   }
+}
+
+function assertWhereIsNotStructurallyUnconditional(
+  where: Predicate[],
+  operation: 'update' | 'delete',
+): void {
+  if (where.length > 0 && where.every(isStructurallyUnconditional)) {
+    throw new DataTableQueryError(
+      operation + '() does not allow a structurally unconditional where clause',
+    )
+  }
+}
+
+function isStructurallyUnconditional(predicate: Predicate): boolean {
+  if (predicate.type === 'comparison') {
+    return (
+      predicate.operator === 'notIn' &&
+      Array.isArray(predicate.value) &&
+      predicate.value.length === 0
+    )
+  }
+
+  if (predicate.type !== 'logical') {
+    return false
+  }
+
+  if (predicate.operator === 'and') {
+    return predicate.predicates.every(isStructurallyUnconditional)
+  }
+
+  return predicate.predicates.some(isStructurallyUnconditional)
 }
 
 async function executeUpsert(


### PR DESCRIPTION
`updateMany` and `deleteMany` require `where` clauses, but dynamically constructed filters can collapse into structurally unconditional predicates. This change rejects those predicates at the shared write boundary while preserving deliberate unfiltered operations.

- Reject structurally unconditional filters for update and delete operations
- Preserve unconditional predicate composition for read queries
- Allow deliberate all-row writes when callers omit `.where()`
- Cover empty object filters, nested empty `notIn` predicates, and restrictive predicates combined with unconditional identities
