### PR TITLE
Reject invalid S3 object keys

### DIFF
--- a/packages/file-storage-s3/.changes/patch.reject-period-only-key-segments.md
+++ b/packages/file-storage-s3/.changes/patch.reject-period-only-key-segments.md
@@ -1,0 +1,1 @@
+Reject empty S3 object keys and keys with period-only path segments instead of sending bucket-level requests or resolving them to a different object URL.

--- a/packages/file-storage-s3/src/lib/s3.test.ts
+++ b/packages/file-storage-s3/src/lib/s3.test.ts
@@ -170,6 +170,106 @@ describe('s3 file storage', () => {
     assert.ok(retrieved)
     assert.equal(await retrieved.text(), 'Hello, world!')
   })
+
+  it('rejects period-only key segments with path-style URLs', async () => {
+    let storage = createS3FileStorage({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      region: 'us-east-1',
+      fetch: async () => new Response(null, { status: 404 }),
+    })
+
+    await assert.rejects(
+      async () => storage.has('a/b/../../../c/d.txt'),
+      /period-only path segments are not supported/,
+    )
+    await assert.rejects(
+      async () => storage.has('a/b/./c.txt'),
+      /period-only path segments are not supported/,
+    )
+  })
+
+  it('rejects period-only key segments with virtual-host style URLs', async () => {
+    let storage = createS3FileStorage({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      region: 'us-east-1',
+      forcePathStyle: false,
+      fetch: async () => new Response(null, { status: 404 }),
+    })
+
+    await assert.rejects(
+      async () => storage.has('a/b/../../c/d.txt'),
+      /period-only path segments are not supported/,
+    )
+  })
+
+  it('rejects empty keys with path-style URLs', async () => {
+    let requestCount = 0
+    let storage = createS3FileStorage({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      region: 'us-east-1',
+      fetch: async () => {
+        requestCount++
+        return new Response(null, { status: 204 })
+      },
+    })
+
+    await assert.rejects(async () => storage.remove(''), /keys must not be empty/)
+    assert.equal(requestCount, 0)
+  })
+
+  it('rejects empty keys with virtual-host style URLs', async () => {
+    let requestCount = 0
+    let storage = createS3FileStorage({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      region: 'us-east-1',
+      forcePathStyle: false,
+      fetch: async () => {
+        requestCount++
+        return new Response(null, { status: 204 })
+      },
+    })
+
+    await assert.rejects(async () => storage.remove(''), /keys must not be empty/)
+    assert.equal(requestCount, 0)
+  })
+
+  it('supports non-period-only key segments', async () => {
+    let storage = createS3FileStorage({
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      region: 'us-east-1',
+      fetch: createMockS3Fetch(),
+    })
+    let file = new File(['Hello, world!'], 'hello.txt')
+
+    await storage.set('folder/.hidden/file.txt', file)
+    await storage.set('folder/..backup/file.txt', file)
+    await storage.set('folder//file.txt', file)
+    await storage.set('folder/%2e%2e/file.txt', file)
+    await storage.set('folder/back\\slash.txt', file)
+    await storage.set('folder/control\u0001.txt', file)
+
+    assert.ok(await storage.has('folder/.hidden/file.txt'))
+    assert.ok(await storage.has('folder/..backup/file.txt'))
+    assert.ok(await storage.has('folder//file.txt'))
+    assert.ok(await storage.has('folder/%2e%2e/file.txt'))
+    assert.ok(await storage.has('folder/back\\slash.txt'))
+    assert.ok(await storage.has('folder/control\u0001.txt'))
+  })
 })
 
 function createMockS3Fetch(): typeof globalThis.fetch {

--- a/packages/file-storage-s3/src/lib/s3.ts
+++ b/packages/file-storage-s3/src/lib/s3.ts
@@ -269,9 +269,19 @@ function createObjectUrl(endpoint: URL, bucket: string, forcePathStyle: boolean,
 }
 
 function encodeS3Key(key: string): string {
+  if (key === '') {
+    throw new TypeError('Invalid S3 object key: keys must not be empty')
+  }
+
   return key
     .split('/')
-    .map((segment) => encodeURIComponent(segment))
+    .map((segment) => {
+      if (segment === '.' || segment === '..') {
+        throw new TypeError('Invalid S3 object key: period-only path segments are not supported')
+      }
+
+      return encodeURIComponent(segment)
+    })
     .join('/')
 }
 


### PR DESCRIPTION
S3 object keys are encoded into a URL before requests are signed. Empty keys resolve to the bucket URL, while WHATWG URL parsing normalizes exact `.` and `..` segments, so object operations can target a different resource than the supplied key.

This validates keys before URL construction while preserving other valid key shapes.

- Rejects empty keys before a bucket-level request can be issued
- Rejects exact period-only segments for both path-style and virtual-hosted URLs
- Preserves `.hidden`, `..backup`, repeated slashes, percent-looking keys, backslashes, and control characters
