### PR TITLE
Handle tar entry sizes and body completion

### DIFF
--- a/packages/tar-parser/.changes/patch.entry-size-handling.md
+++ b/packages/tar-parser/.changes/patch.entry-size-handling.md
@@ -1,0 +1,1 @@
+Buffer `TarEntry` content using the bytes received, validate octal, base-256, and PAX entry sizes, and reject unfinished body readers when archive parsing fails.

--- a/packages/tar-parser/README.md
+++ b/packages/tar-parser/README.md
@@ -40,6 +40,43 @@ await parseTar(response.body, { filenameEncoding: 'latin1' }, (entry) => {
 })
 ```
 
+Entry sizes must be non-negative safe integers. Use `entry.body` to stream content, or `entry.bytes()`, `entry.arrayBuffer()`, or `entry.text()` to buffer it. The buffering methods allocate from the bytes received and consume the body once. If parsing fails before an entry's body is complete, reading that body rejects with the parsing error.
+
+```ts
+await parseTar(archive, async (entry) => {
+  if (entry.type === 'file' && entry.name.endsWith('.txt')) {
+    console.log(entry.name, await entry.text())
+  }
+})
+```
+
+## Size Limits
+
+The parser does not impose entry or archive size limits. Check `entry.size` in the handler before buffering an entry, and track the sum of entry sizes to enforce an aggregate limit:
+
+```ts
+let maxEntrySize = 10 * 1024 * 1024
+let maxTotalSize = 100 * 1024 * 1024
+let totalSize = 0
+
+await parseTar(archive, (entry) => {
+  if (entry.size > maxEntrySize) {
+    throw new Error(`Entry exceeds size limit: ${entry.name}`)
+  }
+
+  totalSize += entry.size
+  if (totalSize > maxTotalSize) {
+    throw new Error('Total entry size exceeds limit')
+  }
+
+  return entry.bytes().then((bytes) => {
+    console.log(entry.name, bytes.byteLength)
+  })
+})
+```
+
+Keep the callback synchronous so size-check errors stop parsing immediately; return a promise for subsequent asynchronous work. To also bound headers, padding, and extension metadata, limit the incoming archive stream after decompression.
+
 ## Benchmark
 
 `tar-parser` performs on par with other popular tar parsing libraries on Node.js.

--- a/packages/tar-parser/src/lib/tar-size.test.ts
+++ b/packages/tar-parser/src/lib/tar-size.test.ts
@@ -1,0 +1,412 @@
+import * as assert from '@remix-run/assert'
+import { describe, it } from '@remix-run/test'
+
+import { parseTar, parseTarHeader, TarEntry, TarParseError } from './tar.ts'
+import { computeChecksum } from './utils.ts'
+
+function createHeader(size: number | string | Uint8Array, type = '0'): Uint8Array {
+  let encoder = new TextEncoder()
+  let block = new Uint8Array(512)
+  block.set(encoder.encode('entry.txt'))
+  block.set(
+    size instanceof Uint8Array
+      ? size
+      : encoder.encode(typeof size === 'number' ? size.toString(8).padStart(11, '0') : size),
+    124,
+  )
+  block.set(encoder.encode(type), 156)
+  block.set(encoder.encode('ustar\0' + '00'), 257)
+  setChecksum(block)
+  return block
+}
+
+function setChecksum(block: Uint8Array): void {
+  block.set(
+    new TextEncoder().encode(computeChecksum(block).toString(8).padStart(6, '0') + '\0 '),
+    148,
+  )
+}
+
+function base256(size: bigint): Uint8Array {
+  let field = new Uint8Array(12)
+  field[0] = 0x80
+  for (let i = 11; i > 0; i--) {
+    field[i] = Number(size & 255n)
+    size >>= 8n
+  }
+  return field
+}
+
+function paxSize(size: string): Uint8Array[] {
+  let record = ` size=${size}\n`
+  let length = record.length + 1
+  while (String(length).length + record.length !== length) {
+    length = String(length).length + record.length
+  }
+  let body = new TextEncoder().encode(`${length}${record}`)
+  return [createHeader(body.length, 'x'), body, new Uint8Array(512 - body.length)]
+}
+
+async function assertInvalidArchive(chunks: Uint8Array[]): Promise<void> {
+  let entries = 0
+  await assert.rejects(
+    () =>
+      parseTar([...chunks, createHeader(0)], () => {
+        entries++
+      }),
+    { name: 'TarParseError', message: 'Invalid tar entry size' },
+  )
+  assert.equal(entries, 0)
+}
+
+async function assertNoDeclaredAllocation(chunks: Uint8Array[]): Promise<void> {
+  let native = Uint8Array
+  let allocations: number[] = []
+  let bodyResult: Promise<unknown> | undefined
+  globalThis.Uint8Array = new Proxy(native, {
+    construct(target, args) {
+      if (typeof args[0] === 'number' && args[0] > 4096) {
+        allocations.push(args[0])
+        throw new Error('Unexpected allocation')
+      }
+      return Reflect.construct(target, args)
+    },
+  })
+
+  try {
+    await assert.rejects(
+      () =>
+        parseTar(chunks, (entry) => {
+          bodyResult = entry.bytes().then(
+            () => 'complete',
+            (error: unknown) => error,
+          )
+        }),
+      { name: 'TarParseError', message: 'Unexpected end of archive' },
+    )
+    assert.deepEqual(allocations, [])
+    let error = await bodyResult
+    assert.ok(error instanceof TarParseError)
+    assert.equal(error.message, 'Unexpected end of archive')
+  } finally {
+    globalThis.Uint8Array = native
+  }
+}
+
+describe('tar entry sizes', () => {
+  it('does not allocate the declared octal size', { timeout: 1000 }, async () => {
+    await assertNoDeclaredAllocation([createHeader(1024 ** 3), new Uint8Array(512)])
+  })
+
+  it('does not allocate the declared base-256 size', { timeout: 1000 }, async () => {
+    await assertNoDeclaredAllocation([createHeader(base256(2n ** 40n)), new Uint8Array(512)])
+  })
+
+  it('does not allocate the declared PAX size', { timeout: 1000 }, async () => {
+    await assertNoDeclaredAllocation([...paxSize('9007199254740991'), createHeader(0)])
+  })
+
+  it('rejects non-octal sizes before delivering entries', async () => {
+    await assertInvalidArchive([createHeader('9')])
+  })
+
+  it('rejects partially numeric octal sizes', async () => {
+    assert.throws(() => parseTarHeader(createHeader('17x')), TarParseError)
+  })
+
+  it('rejects negative base-256 sizes before delivering entries', async () => {
+    let size = new Uint8Array(12).fill(255)
+    size[10] = 253
+    await assertInvalidArchive([createHeader(size)])
+  })
+
+  it('rejects base-256 negative one instead of decoding it as zero', async () => {
+    await assertInvalidArchive([createHeader(new Uint8Array(12).fill(255))])
+  })
+
+  it('rejects unsupported base-256 markers', () => {
+    let size = base256(0n)
+    size[0] = 0x81
+    assert.throws(() => parseTarHeader(createHeader(size)), TarParseError)
+  })
+
+  it('rejects base-256 sizes outside the safe integer range', () => {
+    assert.throws(() => parseTarHeader(createHeader(base256(2n ** 53n))), TarParseError)
+  })
+
+  it('rejects invalid extension header sizes', async () => {
+    await assertInvalidArchive([createHeader('9', 'x')])
+  })
+
+  it('rejects nonnumeric PAX sizes', async () => {
+    await assertInvalidArchive([...paxSize('unknown'), createHeader(0)])
+  })
+
+  it('rejects negative PAX sizes', async () => {
+    await assertInvalidArchive([...paxSize('-512'), createHeader(0)])
+  })
+
+  it('rejects fractional PAX sizes', async () => {
+    await assertInvalidArchive([...paxSize('1.5'), createHeader(0)])
+  })
+
+  it('rejects partially numeric PAX sizes', async () => {
+    await assertInvalidArchive([...paxSize('12x'), createHeader(0)])
+  })
+
+  it('rejects PAX sizes outside the safe integer range', async () => {
+    await assertInvalidArchive([...paxSize('9007199254740992'), createHeader(0)])
+  })
+
+  it('preserves empty and padded octal size fields', () => {
+    assert.equal(parseTarHeader(createHeader('')).size, 0)
+    assert.equal(parseTarHeader(createHeader('            ')).size, 0)
+    assert.equal(parseTarHeader(createHeader('   0000014 ')).size, 12)
+    assert.equal(parseTarHeader(createHeader('\0\0' + '14\0')).size, 12)
+    assert.equal(parseTarHeader(createHeader('777777777777')).size, 0o777777777777)
+  })
+
+  it('preserves safe base-256 sizes and signed metadata', () => {
+    let header = createHeader(base256(BigInt(Number.MAX_SAFE_INTEGER)))
+    header.fill(255, 136, 148)
+    header[147] = 253
+    setChecksum(header)
+    assert.equal(parseTarHeader(header).size, Number.MAX_SAFE_INTEGER)
+    assert.ok(Number(parseTarHeader(header).mtime) < 0)
+  })
+
+  it('uses PAX sizes for content and padding', async () => {
+    let content: string[] = []
+    await parseTar(
+      [
+        ...paxSize('0005'),
+        createHeader(0),
+        new TextEncoder().encode('hello'),
+        new Uint8Array(507),
+        createHeader(0),
+      ],
+      async (entry) => {
+        let index = content.length
+        content.push('')
+        content[index] = await entry.text()
+      },
+    )
+    assert.deepEqual(content, ['hello', ''])
+  })
+
+  it('preserves zero PAX sizes and empty PAX size overrides', async () => {
+    let sizes: number[] = []
+    await parseTar(
+      [...paxSize('0'), createHeader(12), ...paxSize(''), createHeader(0)],
+      (entry) => {
+        sizes.push(entry.size)
+      },
+    )
+    assert.deepEqual(sizes, [0, 0])
+  })
+
+  it('uses a valid PAX size instead of the overridden header field', async () => {
+    let content: string | undefined
+    await parseTar(
+      [
+        ...paxSize('5'),
+        createHeader('unknown'),
+        new TextEncoder().encode('hello'),
+        new Uint8Array(507),
+      ],
+      async (entry) => {
+        content = await entry.text()
+      },
+    )
+    assert.equal(content, 'hello')
+  })
+
+  it('validates extension header sizes even when a PAX override is pending', async () => {
+    await assertInvalidArchive([...paxSize('0'), createHeader('unknown', 'L')])
+  })
+})
+
+describe('TarEntry body readers', () => {
+  it('buffers received bytes independently of the header size', async () => {
+    let body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.enqueue(new Uint8Array([3]))
+        controller.close()
+      },
+    })
+    let entry = new TarEntry(parseTarHeader(createHeader(10)), body)
+    assert.equal(entry.bodyUsed, false)
+    let result = entry.bytes()
+    assert.equal(entry.bodyUsed, true)
+    assert.deepEqual(await result, new Uint8Array([1, 2, 3]))
+    await assert.rejects(() => entry.bytes(), /Body is already consumed/)
+  })
+
+  it('returns an exact independent array buffer', async () => {
+    let chunk = new Uint8Array([0, 1, 2, 0])
+    let body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk.subarray(1, 3))
+        controller.close()
+      },
+    })
+    let entry = new TarEntry(parseTarHeader(createHeader(2)), body)
+    let result = await entry.arrayBuffer()
+    chunk.fill(9)
+    assert.ok(result instanceof ArrayBuffer)
+    assert.equal(result.byteLength, 2)
+    assert.deepEqual(new Uint8Array(result), new Uint8Array([1, 2]))
+    await assert.rejects(() => entry.text(), /Body is already consumed/)
+  })
+
+  it('copies each chunk before reading from a stream that reuses its buffer', async () => {
+    let chunk = new Uint8Array([1, 2])
+    let reads = 0
+    let body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          if (reads === 0) {
+            controller.enqueue(chunk)
+          } else if (reads === 1) {
+            chunk.set([3, 4])
+            controller.enqueue(chunk)
+          } else {
+            controller.close()
+          }
+          reads++
+        },
+      },
+      { highWaterMark: 0 },
+    )
+    let entry = new TarEntry(parseTarHeader(createHeader(4)), body)
+    assert.deepEqual(await entry.bytes(), new Uint8Array([1, 2, 3, 4]))
+  })
+
+  it('decodes UTF-8 split across chunks', async () => {
+    let bytes = new TextEncoder().encode('héllo')
+    let values: string[] = []
+    await parseTar(
+      [
+        createHeader(bytes.length),
+        bytes.subarray(0, 2),
+        bytes.subarray(2),
+        new Uint8Array(512 - bytes.length),
+      ],
+      async (entry) => {
+        values.push(await entry.text())
+      },
+    )
+    assert.deepEqual(values, ['héllo'])
+  })
+
+  it('returns empty content for directories with a nonzero size', async () => {
+    await parseTar(createHeader(12, '5'), async (entry) => {
+      assert.equal(entry.size, 12)
+      assert.equal((await entry.bytes()).byteLength, 0)
+    })
+  })
+
+  it(
+    'rejects both parsing and reading a truncated buffered archive',
+    { timeout: 1000 },
+    async () => {
+      let result: Promise<unknown> | undefined
+      await assert.rejects(
+        () =>
+          parseTar(createHeader(12), (entry) => {
+            result = entry.text().catch((error: unknown) => error)
+          }),
+        /Unexpected end of archive/,
+      )
+      assert.ok((await result) instanceof TarParseError)
+    },
+  )
+
+  it('rejects an unfinished reader when the source fails', { timeout: 1000 }, async () => {
+    let error = new Error('Source failed')
+    let result: Promise<unknown> | undefined
+    async function* source() {
+      yield createHeader(12)
+      yield new Uint8Array([1, 2])
+      throw error
+    }
+    await assert.rejects(
+      () =>
+        parseTar(source(), (entry) => {
+          result = entry.arrayBuffer().catch((error: unknown) => error)
+        }),
+      /Source failed/,
+    )
+    assert.equal(await result, error)
+  })
+
+  it('settles a handler reading a truncated source stream', { timeout: 1000 }, async () => {
+    let source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(createHeader(12))
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.close()
+      },
+    })
+    let result: Promise<void> | undefined
+    await assert.rejects(
+      () =>
+        parseTar(source, (entry) => {
+          result = assert.rejects(() => entry.bytes(), /Unexpected end of archive/)
+          return result
+        }),
+      /Unexpected end of archive/,
+    )
+    await result
+  })
+
+  it('rejects missing padding after delivering the complete body', async () => {
+    let result: Promise<string> | undefined
+    await assert.rejects(
+      () =>
+        parseTar([createHeader(5), new TextEncoder().encode('hello')], (entry) => {
+          result = entry.text()
+        }),
+      /Unexpected end of archive/,
+    )
+    assert.equal(await result, 'hello')
+  })
+
+  it('observes rejected handlers while waiting for more input', async () => {
+    let error = new Error('Handler failed')
+    async function* source() {
+      yield createHeader(0)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    await assert.rejects(
+      () =>
+        parseTar(source(), async () => {
+          throw error
+        }),
+      /Handler failed/,
+    )
+  })
+
+  it('streams entry bytes before the archive finishes', { timeout: 1000 }, async () => {
+    let received = Promise.withResolvers<void>()
+    let chunks: number[][] = []
+    async function* source() {
+      yield createHeader(4)
+      yield new Uint8Array([1, 2])
+      await received.promise
+      yield new Uint8Array([3, 4])
+      yield new Uint8Array(508)
+    }
+    await parseTar(source(), async (entry) => {
+      for await (let chunk of entry.body) {
+        chunks.push(Array.from(chunk))
+        received.resolve()
+      }
+    })
+    assert.deepEqual(chunks, [
+      [1, 2],
+      [3, 4],
+    ])
+  })
+})

--- a/packages/tar-parser/src/lib/tar.ts
+++ b/packages/tar-parser/src/lib/tar.ts
@@ -50,7 +50,7 @@ export interface TarHeader {
   gid: number | null
 
   /**
-   * Entry size in bytes.
+   * Entry size in bytes. Parsed sizes are non-negative safe integers.
    */
   size: number
 
@@ -145,6 +145,14 @@ export interface ParseTarHeaderOptions {
  * @returns The parsed tar header
  */
 export function parseTarHeader(block: Uint8Array, options?: ParseTarHeaderOptions): TarHeader {
+  let header = decodeTarHeader(block, options)
+  return { ...header, size: parseEntrySize(block.subarray(124, 136)) }
+}
+
+function decodeTarHeader(
+  block: Uint8Array,
+  options?: ParseTarHeaderOptions,
+): Omit<TarHeader, 'size'> {
   if (block.length !== TarBlockSize) {
     throw new TarParseError('Invalid tar header size')
   }
@@ -179,12 +187,11 @@ export function parseTarHeader(block: Uint8Array, options?: ParseTarHeaderOption
   }
 
   let typeFlag = block[156] === 0 ? 0 : block[156] - ZeroOffset
-  let header: TarHeader = {
+  let header: Omit<TarHeader, 'size'> = {
     name: getString(block, 0, 100, filenameEncoding),
     mode: getOctal(block, 100, 8),
     uid: getOctal(block, 108, 8),
     gid: getOctal(block, 116, 8),
-    size: getOctal(block, 124, 12) ?? 0,
     mtime: getOctal(block, 136, 12),
     type: TarFileTypes[typeFlag] ?? 'unknown',
     linkname: block[157] === 0 ? null : getString(block, 157, 100, filenameEncoding),
@@ -210,6 +217,33 @@ export function parseTarHeader(block: Uint8Array, options?: ParseTarHeaderOption
   }
 
   return header
+}
+
+function parseEntrySize(value: Uint8Array | string): number {
+  let size: number | null
+  if (typeof value === 'string') {
+    size = value === '' || /[^0-9]/.test(value) ? null : Number(value)
+  } else if (value[0] & 0x80) {
+    size = value[0] === 0x80 ? getOctal(value, 0, value.length) : null
+  } else {
+    let octal = new TextDecoder().decode(value).replace(/^[\0 ]+|[\0 ]+$/g, '')
+    size = /[^0-7]/.test(octal) ? null : parseInt(octal || '0', 8)
+  }
+
+  if (size === null || !Number.isSafeInteger(size) || size < 0) {
+    throw new TarParseError('Invalid tar entry size')
+  }
+
+  return size
+}
+
+function isLongHeader(type: string): boolean {
+  return (
+    type === 'gnu-long-path' ||
+    type === 'gnu-long-link-path' ||
+    type === 'pax-global-header' ||
+    type === 'pax-header'
+  )
 }
 
 type TarArchiveSource =
@@ -301,35 +335,44 @@ export class TarParser {
   async parse(archive: TarArchiveSource, handler: TarEntryHandler): Promise<void> {
     this.#reset()
 
-    let results: unknown[] = []
+    let results: Promise<void>[] = []
 
     function handleEntry(entry: TarEntry): void {
-      results.push(handler(entry))
+      let result = Promise.resolve(handler(entry))
+      // A handler may reject before the archive finishes streaming.
+      result.catch(() => {})
+      results.push(result)
     }
 
-    if (archive instanceof ReadableStream) {
-      for await (let chunk of readStream(archive)) {
-        this.#write(chunk, handleEntry)
+    try {
+      if (archive instanceof ReadableStream) {
+        for await (let chunk of readStream(archive)) {
+          this.#write(chunk, handleEntry)
+        }
+      } else if (isAsyncIterable(archive)) {
+        for await (let chunk of archive) {
+          this.#write(chunk, handleEntry)
+        }
+      } else if (archive instanceof Uint8Array) {
+        this.#write(archive, handleEntry)
+      } else if (isIterable(archive)) {
+        for (let chunk of archive) {
+          this.#write(chunk, handleEntry)
+        }
+      } else {
+        throw new TypeError('Cannot parse tar archive; expected a stream or buffer')
       }
-    } else if (isAsyncIterable(archive)) {
-      for await (let chunk of archive) {
-        this.#write(chunk, handleEntry)
-      }
-    } else if (archive instanceof Uint8Array) {
-      this.#write(archive, handleEntry)
-    } else if (isIterable(archive)) {
-      for (let chunk of archive) {
-        this.#write(chunk, handleEntry)
-      }
-    } else {
-      throw new TypeError('Cannot parse tar archive; expected a stream or buffer')
-    }
 
-    if (this.#missing !== 0) {
-      throw new TarParseError('Unexpected end of archive')
-    }
+      if (this.#missing !== 0) {
+        throw new TarParseError('Unexpected end of archive')
+      }
 
-    await Promise.all(results)
+      await Promise.all(results)
+    } catch (error) {
+      this.#bodyController?.error(error)
+      this.#bodyController = null
+      throw error
+    }
   }
 
   #reset(): void {
@@ -387,16 +430,16 @@ export class TarParser {
       return
     }
 
-    this.#header = parseTarHeader(block, this.#options)
+    let header = decodeTarHeader(block, this.#options)
+    this.#longHeader = isLongHeader(header.type)
+    this.#header = {
+      ...header,
+      size: parseEntrySize((!this.#longHeader && this.#pax?.size) || block.subarray(124, 136)),
+    }
 
-    switch (this.#header.type) {
-      case 'gnu-long-path':
-      case 'gnu-long-link-path':
-      case 'pax-global-header':
-      case 'pax-header':
-        this.#longHeader = true
-        this.#missing = this.#header.size
-        return
+    if (this.#longHeader) {
+      this.#missing = this.#header.size
+      return
     }
 
     if (this.#gnuLongPath) {
@@ -412,7 +455,6 @@ export class TarParser {
     if (this.#pax) {
       if (this.#pax.path) this.#header.name = this.#pax.path
       if (this.#pax.linkpath) this.#header.linkname = this.#pax.linkpath
-      if (this.#pax.size) this.#header.size = parseInt(this.#pax.size, 10)
       this.#header.pax = this.#pax
       this.#pax = null
     }
@@ -541,7 +583,8 @@ export class TarEntry {
   }
 
   /**
-   * The content of this entry buffered into a single typed array.
+   * The content of this entry buffered into a single typed array using the bytes received.
+   * Rejects if parsing fails before the entry's body is complete.
    *
    * @returns A promise that resolves to a `Uint8Array`
    */
@@ -552,9 +595,16 @@ export class TarEntry {
 
     this.#bodyUsed = true
 
-    let result = new Uint8Array(this.size)
-    let offset = 0
+    let chunks: Uint8Array[] = []
+    let length = 0
     for await (let chunk of readStream(this.#body)) {
+      chunks.push(new Uint8Array(chunk))
+      length += chunk.length
+    }
+
+    let result = new Uint8Array(length)
+    let offset = 0
+    for (let chunk of chunks) {
       result.set(chunk, offset)
       offset += chunk.length
     }


### PR DESCRIPTION
Tar entry readers currently allocate from the header-declared size and can remain pending when an archive ends before the entry body is complete. Buffer the bytes received and propagate parsing failures to unfinished body readers.

- Validate effective octal, base-256, and PAX sizes before using them for entry boundaries.
- Preserve PAX overrides, large-entry streaming, and streams that reuse buffers.
- Document how applications can enforce entry and archive size limits.
