### PR TITLE
Restrict frame navigation sources and default fetches to same-origin

### DIFF
--- a/docs/guides/app/actions/docs/chapters/05-interactivity.md
+++ b/docs/guides/app/actions/docs/chapters/05-interactivity.md
@@ -721,10 +721,17 @@ Native anchors and forms can also control frame-aware navigation with attributes
 the `link(...)` and `navigate(...)` options:
 
 - `data-rmx-target` names the frame to reload.
-- `data-rmx-src` provides the URL to fetch for that frame while `href` remains the browser's destination.
+- `data-rmx-src` provides the URL to fetch for the mounted named frame selected by `data-rmx-target` while `href` remains the browser's destination.
 - `data-rmx-history="push|replace"` controls how the navigation updates history, including overriding a form's default.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
 - `data-rmx-document` opts out of interception and lets the browser perform a full-document navigation.
+
+The top frame follows the browser URL. If `data-rmx-target` is omitted or no matching frame is mounted,
+an intercepted navigation reloads the top frame from the link or form destination.
+
+A supplied `data-rmx-src` must be a valid same-origin URL regardless of the target. Invalid or
+cross-origin values disable interception and leave the navigation to the browser. These rules also
+apply to the `src` and `target` options of `link(...)` and `navigate(...)`.
 
 [Streaming UI with Frames](/streaming-ui-with-frames/) shows these attributes with named frames and
 explains when a form can submit directly through the frame resolver.

--- a/docs/guides/app/actions/docs/chapters/06-streaming-ui-with-frames.md
+++ b/docs/guides/app/actions/docs/chapters/06-streaming-ui-with-frames.md
@@ -255,9 +255,9 @@ handler:
 
 The form remains a normal document navigation before the runtime starts. Native constraint
 validation and the form's `submit` event run before Remix intercepts it. `data-rmx-target` chooses a named
-frame, `data-rmx-src` can provide a different frame request URL, `data-rmx-reset-scroll="false"` preserves the
-current scroll position, and `data-rmx-document` opts out of interception. `data-rmx-history="push|replace"`
-controls how the navigation updates history.
+frame, `data-rmx-src` can provide a different request URL for that named frame,
+`data-rmx-reset-scroll="false"` preserves the current scroll position, and `data-rmx-document` opts out of
+interception. `data-rmx-history="push|replace"` controls how the navigation updates history.
 
 GET controls are already encoded in the destination URL. For non-GET forms, `resolveFrame` receives
 `formData`, `method`, and `encType`. The action should return HTML for the targeted frame when it
@@ -328,8 +328,13 @@ A link can keep its public destination in `href` while loading a smaller route i
 </a>
 ```
 
-`data-rmx-target` chooses the frame, while `data-rmx-src` chooses the request used to fill it. The address bar
-still moves to `href`. Add `data-rmx-history="replace"` when it should replace the current history entry. Use
+`data-rmx-target` chooses a mounted named frame, while `data-rmx-src` chooses the request used to fill it.
+The address bar still moves to `href`. If the target is omitted or no matching frame is mounted, Remix
+uses `href` as the top frame's source to keep it in sync with the browser URL. A supplied `data-rmx-src`
+must still be a valid same-origin URL regardless of the target. Invalid or cross-origin values disable
+interception, so the browser performs a document navigation to `href`.
+
+Add `data-rmx-history="replace"` when it should replace the current history entry. Use
 `data-rmx-document` when a same-origin link must perform an ordinary document navigation instead.
 
 ## Handle failures and cancellation

--- a/packages/ui/.changes/minor.frame-navigation-sources.md
+++ b/packages/ui/.changes/minor.frame-navigation-sources.md
@@ -1,0 +1,3 @@
+BREAKING CHANGE: The default `resolveFrame` now only fetches same-origin sources and follows same-origin redirects. Apps that load cross-origin frame content must provide a custom `resolveFrame` to `run()`.
+
+Validate navigation source overrides regardless of the target, falling back to document navigation for invalid or cross-origin overrides.

--- a/packages/ui/docs/frames.md
+++ b/packages/ui/docs/frames.md
@@ -184,6 +184,7 @@ async function resolveFrame(src, options) {
     body: getRequestBody(options),
     headers: { Accept: 'text/html' },
     method: options?.method,
+    mode: 'same-origin',
     signal: options?.signal,
   })
 
@@ -237,6 +238,8 @@ response lets Remix stream its body. When `fetch()` followed a redirect during a
 the final response URL replaces the browser navigation URL and becomes the top frame's canonical `src`;
 other frames render the response without changing either URL.
 
+The default resolver uses Fetch's `same-origin` mode. Cross-origin sources and redirects fail, even if the destination allows CORS. To load trusted cross-origin frame content, provide a custom `resolveFrame` to `run()`. Custom resolvers control their own request and redirect policy.
+
 Because this function defines the trust boundary for frame HTML, only return content from sources you trust.
 
 ## Link navigation
@@ -247,10 +250,14 @@ and reconcile it into the existing document instead of performing a full documen
 soft-navigation behavior applies even when the page does not render an explicit `<Frame>`.
 
 - `data-rmx-target="name"` reloads a named frame.
-- `data-rmx-src="/frame"` overrides the URL resolved into that frame while `href` remains the navigation destination.
+- `data-rmx-src="/frame"` overrides the source of the mounted frame selected by `data-rmx-target`, while `href` remains the navigation destination.
 - `data-rmx-history="push|replace"` controls how the navigation updates history.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
 - `data-rmx-document` leaves the link as a normal document navigation.
+
+During navigation, the top frame's source stays in sync with the browser URL. `data-rmx-src` only changes the requested URL when `data-rmx-target` resolves to a mounted named frame. If the target is omitted or no matching frame is mounted, an intercepted navigation reloads the top frame from `href`. The same behavior applies to form destinations, the `src` and `target` options of `navigate()`, and history traversal.
+
+Every source override must resolve to the document origin, using `document.baseURI` for relative URLs. Invalid or cross-origin overrides disable interception regardless of the target, leaving the browser to navigate to the link's `href` or the form's destination.
 
 To keep links/forms as a document navigations while still hydrating client entries and using explicit
 frames, you can cancel the built-in `navigate` event behavior with your own listener before calling
@@ -269,7 +276,7 @@ Eligible same-origin form submissions use the same frame navigation path as link
 
 - Submissions reload `handle.frames.top` by default.
 - `data-rmx-target="name"` reloads a named frame.
-- `data-rmx-src="/frame"` overrides the URL resolved into that frame while the form action remains the navigation destination.
+- `data-rmx-src="/frame"` overrides the source of the mounted frame selected by `data-rmx-target`, while the form action remains the navigation destination.
 - `data-rmx-history="push|replace"` overrides how the navigation updates history.
 - `data-rmx-reset-scroll="false"` preserves the current scroll position.
 - `data-rmx-document` leaves the submission as a normal document navigation.

--- a/packages/ui/docs/hydration.md
+++ b/packages/ui/docs/hydration.md
@@ -72,6 +72,20 @@ and how to opt out for one navigation or the whole app.
 - **`processClientEntryPreloads(preloads)`** (optional) - Processes module preloads discovered in frame responses before they are added to the document. Return the preload URLs that should remain as native `<link rel="modulepreload">` elements.
 - **`resolveFrame(src, options)`** (optional) - Overrides the default `fetch()` resolver when a `<Frame>` needs to load or reload content and when a link or form performs a frame navigation. `options` may contain `signal` and `target`; non-GET forms also provide `formData`, `method`, and `encType`. GET form values are already encoded in `src`. See [Frames](./frames.md#form-navigation) for request encoding, targeting, and opt-outs.
 
+### Trusted documents and module loading
+
+The initial document and HTML returned by `resolveFrame` are trusted application content. They can
+select client-entry modules and contribute import maps, styles, and nested frames. Only return HTML
+from sources the application trusts to run code in the current page.
+
+Remix passes each serialized module specifier unchanged to `loadModule`. The loader controls how it
+resolves that specifier, so client entries can use CDN URLs, development server URLs, or bare
+specifiers resolved through import maps or a custom loader. With `import(moduleUrl)`, relative
+specifiers resolve from the module containing that import, subject to the document's import map.
+Applications that restrict module sources should enforce that policy in their loader before
+importing code. The runtime's check that the returned export is a function happens after loading;
+it checks the component shape, not whether the module is trusted.
+
 ### `app` properties
 
 - **`app.ready()`** - Returns a promise that resolves when all initial client entries have been hydrated.

--- a/packages/ui/src/runtime/frame.ts
+++ b/packages/ui/src/runtime/frame.ts
@@ -53,7 +53,10 @@ type PendingClientEntries = Map<Comment, [Comment, RemixElement]>
 /**
  * Loads a named client-entry export for hydration.
  *
- * @param moduleUrl Browser-resolvable URL for the module that contains the client entry.
+ * Module specifiers from trusted document metadata are passed through unchanged. The loader
+ * controls resolution, including import maps, CDN URLs, and development server URLs.
+ *
+ * @param moduleUrl Module specifier for the client entry, as serialized by the server.
  * @param exportName Named export to read from the loaded module.
  * @returns The exported component function, or a promise for it.
  *
@@ -71,6 +74,9 @@ export type LoadModule = (moduleUrl: string, exportName: string) => Promise<Func
 
 /**
  * Resolves content for a browser-loaded frame.
+ *
+ * Only return trusted application content. Frame HTML can select client-entry modules and
+ * contribute import maps, styles, and nested frames to the current document.
  *
  * @param src Source string from the `<Frame src>` prop.
  * @param options Information about the active frame load or form submission.

--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -64,6 +64,11 @@ function resyncWebKitScrollAfterNavigation(
  * Options for client-side frame-aware navigation.
  */
 export type NavigationOptions = {
+  /**
+   * Same-origin source override for a mounted named frame, resolved against the document base URL.
+   * Invalid or cross-origin values disable interception even when `target` is omitted or missing.
+   * Top-frame navigations use `href` to keep the frame source in sync with the browser URL.
+   */
   src?: string
   target?: string
   history?: 'push' | 'replace'
@@ -72,6 +77,7 @@ export type NavigationOptions = {
 
 /**
  * Performs a Navigation API transition understood by Remix frame runtime state.
+ * Invalid or cross-origin sources fall back to document navigation.
  *
  * @param href Destination URL.
  * @param options Navigation options.
@@ -136,7 +142,7 @@ export function startNavigationListenerImpl(
       // we do a host check ourselves/. The spec is clear that a different host should prevent
       // interception so this is likely a bug in Safari:
       // https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten
-      if (!event.canIntercept || isCrossOriginDestination(event)) return
+      if (!event.canIntercept || !isSameOriginUrl(event.destination.url)) return
 
       if (isFrameRedirectNavigationInfo(event.info)) {
         interceptNavigation(navigation, event, event.info.resetScroll, {
@@ -155,6 +161,7 @@ export function startNavigationListenerImpl(
         : getRuntimeNavigation(navigation, event, resolveFormNavigation)
       if (!runtimeNavigation) return
       let { state } = runtimeNavigation
+      if (!isSameOriginUrl(state.src)) return
 
       let topFrame = options.getTopFrame()
       let namedFrame = state.target ? options.getNamedFrame(state.target) : undefined
@@ -290,9 +297,12 @@ function isFrameRedirectNavigationInfo(value: unknown): value is FrameRedirectNa
   )
 }
 
-function isCrossOriginDestination(event: NavigateEvent): boolean {
-  let destination = new URL(event.destination.url)
-  return destination.origin !== window.location.origin
+function isSameOriginUrl(src: string): boolean {
+  try {
+    return new URL(src, document.baseURI).origin === window.location.origin
+  } catch {
+    return false
+  }
 }
 
 function interceptNavigation(

--- a/packages/ui/src/runtime/run.ts
+++ b/packages/ui/src/runtime/run.ts
@@ -25,7 +25,9 @@ export interface RunInit {
    * Resolves browser-loaded `<Frame>` content.
    *
    * Defaults to fetching the frame source as HTML with the submitted form data,
-   * method, encoding, and abort signal.
+   * method, encoding, and abort signal. The default resolver only fetches from
+   * the document origin, including redirects. Provide a custom resolver to load
+   * trusted cross-origin frame content.
    */
   resolveFrame?: ResolveFrame
 
@@ -113,6 +115,7 @@ async function defaultResolveFrame(src: string, options?: ResolveFrameOptions): 
     body: getRequestBody(options),
     headers: { Accept: 'text/html' },
     method: options?.method,
+    mode: 'same-origin',
     signal: options?.signal,
   })
 

--- a/packages/ui/src/test/frame.test.tsx
+++ b/packages/ui/src/test/frame.test.tsx
@@ -228,8 +228,86 @@ describe('run', () => {
       expect(init?.body).toBe(formData)
       expect(new Headers(init?.headers).get('Accept')).toBe('text/html')
       expect(init?.method).toBe('post')
+      expect(init?.mode).toBe('same-origin')
       expect(init?.signal).toBeInstanceOf(AbortSignal)
       expect(document.getElementById('account')?.textContent).toBe('Ada')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('uses same-origin requests for explicitly cross-origin frame sources', async (t) => {
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><main id="external">External frame</main></body></html><!-- rmx:flush document -->',
+        ),
+    )
+    let app = run({ loadModule: mock.fn() })
+    await app.ready()
+    app.frames.top.src = 'https://frames.example/partial'
+
+    try {
+      await app.frames.top.reload()
+      expect(fetchMock.mock.calls[0]?.arguments[0]).toBe('https://frames.example/partial')
+      expect(fetchMock.mock.calls[0]?.arguments[1]?.mode).toBe('same-origin')
+    } finally {
+      app.dispose()
+    }
+  })
+
+  it('uses same-origin requests when the document base is cross-origin', async (t) => {
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><main id="external">External frame</main></body></html><!-- rmx:flush document -->',
+        ),
+    )
+    let base = document.createElement('base')
+    base.href = 'https://frames.example/partials/'
+    document.head.prepend(base)
+    let app = run({ loadModule: mock.fn() })
+    await app.ready()
+    app.frames.top.src = 'details'
+
+    try {
+      await app.frames.top.reload()
+      expect(fetchMock.mock.calls[0]?.arguments[0]).toBe('details')
+      expect(fetchMock.mock.calls[0]?.arguments[1]?.mode).toBe('same-origin')
+    } finally {
+      app.dispose()
+      base.remove()
+    }
+  })
+
+  it('allows custom resolvers to fetch cross-origin frame sources', async (t) => {
+    let fetchMock = t.mock.method(
+      globalThis,
+      'fetch',
+      async () =>
+        new Response(
+          '<!DOCTYPE html><html><head></head><body><main id="external">External frame</main></body></html><!-- rmx:flush document -->',
+        ),
+    )
+    let app = run({
+      loadModule: mock.fn(),
+      resolveFrame(src, options) {
+        return fetch(src, { mode: 'cors', signal: options?.signal })
+      },
+    })
+    await app.ready()
+    app.frames.top.src = 'https://frames.example/partial'
+
+    try {
+      await app.frames.top.reload()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock.mock.calls[0]?.arguments[0]).toBe('https://frames.example/partial')
+      expect(fetchMock.mock.calls[0]?.arguments[1]?.mode).toBe('cors')
+      expect(document.getElementById('external')?.textContent).toBe('External frame')
     } finally {
       app.dispose()
     }

--- a/packages/ui/src/test/navigation.test.ts
+++ b/packages/ui/src/test/navigation.test.ts
@@ -92,6 +92,7 @@ function startStubNavigationListener(
 ): (event: Event) => StubNavigationTransition {
   let stubNavigation = Object.assign(new EventTarget(), {
     updateCurrentEntry: mock.fn(),
+    navigate: mock.fn(),
     transition: null as NavigationTransition | null,
   })
   stubGlobalField(t, 'navigation', stubNavigation)
@@ -971,6 +972,204 @@ describe('navigate', () => {
       }
       controller.abort()
     }
+  })
+})
+
+describe('frame navigation sources', () => {
+  function setup(t: TestContext) {
+    let topFrame = { src: window.location.href } as FrameHandle
+    let namedFrame = { src: '/initial-frame' } as FrameHandle
+    let reloadFrame = mock.fn((_frame: FrameHandle) =>
+      createReloadTransition({ signal: new AbortController().signal }),
+    )
+    let dispatch = startStubNavigationListener(t, {
+      getTopFrame: () => topFrame,
+      getNamedFrame: (name) => (name === 'details' ? namedFrame : topFrame),
+      reloadFrame,
+    })
+    let anchor = document.createElement('a')
+    anchor.href = new URL('/destination', window.location.href).href
+    anchor.setAttribute('data-rmx-target', 'details')
+    let intercept = mock.fn()
+    let event = createAnchorNavigateEvent(anchor, {
+      destinationUrl: anchor.href,
+      intercept,
+    })
+    return { topFrame, namedFrame, reloadFrame, dispatch, anchor, intercept, event }
+  }
+
+  async function expectDocumentNavigation(
+    t: TestContext,
+    src: string,
+    target: string | null = 'details',
+  ) {
+    let { anchor, event, dispatch, intercept, reloadFrame, topFrame, namedFrame } = setup(t)
+    anchor.setAttribute('data-rmx-src', src)
+    if (target === null) anchor.removeAttribute('data-rmx-target')
+    else anchor.setAttribute('data-rmx-target', target)
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).not.toHaveBeenCalled()
+    expect(reloadFrame).not.toHaveBeenCalled()
+    expect(topFrame.src).toBe(window.location.href)
+    expect(namedFrame.src).toBe('/initial-frame')
+  }
+
+  it('leaves cross-origin named-frame link sources to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'https://frames.example/partial')
+  })
+
+  it('leaves protocol-relative cross-origin sources to document navigation', async (t) => {
+    await expectDocumentNavigation(t, '//frames.example/partial')
+  })
+
+  it('leaves malformed named-frame sources to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'https://[')
+  })
+
+  it('leaves cross-origin sources without a target to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'https://frames.example/partial', null)
+  })
+
+  it('leaves malformed sources with a missing target to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'https://[', 'missing')
+  })
+
+  it('leaves data URL frame sources to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'data:text/html,<p>Frame</p>')
+  })
+
+  it('leaves javascript URL frame sources to document navigation', async (t) => {
+    await expectDocumentNavigation(t, 'javascript:void(0)')
+  })
+
+  it('checks relative named-frame sources against the document base URL', async (t) => {
+    let base = document.createElement('base')
+    base.href = 'https://frames.example/partials/'
+    document.head.prepend(base)
+    t.after(() => base.remove())
+    await expectDocumentNavigation(t, 'details')
+  })
+
+  it('preserves same-origin relative sources for custom frame resolvers', async (t) => {
+    let { anchor, event, dispatch, intercept, reloadFrame, topFrame, namedFrame } = setup(t)
+    let base = document.createElement('base')
+    base.href = new URL('/partials/', window.location.href).href
+    document.head.prepend(base)
+    t.after(() => base.remove())
+    anchor.setAttribute('data-rmx-src', '../details?tab=one#summary')
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).toHaveBeenCalledTimes(1)
+    expect(reloadFrame.mock.calls[0]?.arguments[0]).toBe(namedFrame)
+    expect(namedFrame.src).toBe('../details?tab=one#summary')
+    expect(topFrame.src).toBe(anchor.href)
+  })
+
+  it('uses the public destination when the top frame ignores a source override', async (t) => {
+    let { anchor, event, dispatch, intercept, topFrame, namedFrame } = setup(t)
+    anchor.removeAttribute('data-rmx-target')
+    anchor.setAttribute('data-rmx-src', '/partial')
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).toHaveBeenCalledTimes(1)
+    expect(topFrame.src).toBe(anchor.href)
+    expect(namedFrame.src).toBe('/initial-frame')
+  })
+
+  it('uses the public destination when the named target does not exist', async (t) => {
+    let { anchor, event, dispatch, intercept, topFrame, namedFrame } = setup(t)
+    anchor.setAttribute('data-rmx-target', 'missing')
+    anchor.setAttribute('data-rmx-src', '/partial')
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).toHaveBeenCalledTimes(1)
+    expect(topFrame.src).toBe(anchor.href)
+    expect(namedFrame.src).toBe('/initial-frame')
+  })
+
+  it('checks sources supplied by programmatic navigate calls', async (t) => {
+    let { anchor, dispatch, intercept, reloadFrame } = setup(t)
+    stubGlobalMethod(
+      t,
+      'navigation',
+      'navigate',
+      (href: string, options: NavigationNavigateOptions) => {
+        let event = createAnchorNavigateEvent(anchor, { destinationUrl: href, intercept })
+        Object.assign(event, {
+          sourceElement: null,
+          destination: { url: href, getState: () => options.state },
+        })
+        let transition = dispatch(event)
+        return { finished: transition.runHandler().then(() => transition.succeed()) }
+      },
+    )
+    await navigate(anchor.href, { src: 'https://frames.example/partial' })
+    expect(intercept).not.toHaveBeenCalled()
+    expect(reloadFrame).not.toHaveBeenCalled()
+  })
+
+  it('checks named-frame sources restored from navigation history', async (t) => {
+    let { event, anchor, dispatch, intercept, reloadFrame } = setup(t)
+    Object.assign(event, {
+      navigationType: 'traverse',
+      sourceElement: null,
+      destination: {
+        url: anchor.href,
+        getState: () => ({
+          target: 'details',
+          src: 'https://frames.example/partial',
+          resetScroll: true,
+          $rmx: true,
+        }),
+      },
+    })
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).not.toHaveBeenCalled()
+    expect(reloadFrame).not.toHaveBeenCalled()
+  })
+
+  it('checks form sources before intercepting a POST submission', async (t) => {
+    let { anchor, dispatch, intercept, reloadFrame } = setup(t)
+    let form = document.createElement('form')
+    form.action = anchor.href
+    form.method = 'post'
+    form.setAttribute('data-rmx-target', 'details')
+    form.setAttribute('data-rmx-src', 'https://frames.example/partial')
+    let event = createFormNavigateEvent(form, { destinationUrl: form.action, intercept })
+    Object.assign(event, { scroll() {} })
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).not.toHaveBeenCalled()
+    expect(reloadFrame).not.toHaveBeenCalled()
+  })
+
+  it('checks GET form sources overridden by the submitter', async (t) => {
+    let { anchor, dispatch, intercept, reloadFrame } = setup(t)
+    let form = document.createElement('form')
+    form.action = anchor.href
+    form.setAttribute('data-rmx-target', 'details')
+    form.setAttribute('data-rmx-src', '/partial')
+    let button = document.createElement('button')
+    button.setAttribute('data-rmx-src', 'https://frames.example/partial')
+    form.append(button)
+    document.body.append(form)
+    t.after(() => form.remove())
+    form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, submitter: button }))
+    let event = createFormNavigateEvent(form, { destinationUrl: form.action, intercept })
+    Object.assign(event, { scroll() {} })
+    let transition = dispatch(event)
+    await transition.runHandler()
+    await transition.succeed()
+    expect(intercept).not.toHaveBeenCalled()
+    expect(reloadFrame).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
Validate frame navigation sources before interception and keep default frame fetches on the document origin. Previously, a same-origin destination could supply a cross-origin `data-rmx-src`, and default frame fetches could follow redirects to another origin.

- Invalid or cross-origin source overrides fall back to document navigation, including when the target is omitted or no matching frame is mounted.
- Default frame fetches now use `mode: 'same-origin'`. Apps that load cross-origin frame content must provide a custom `resolveFrame`; the change file records this as a breaking minor change.
- Clarify that the top frame follows the browser URL, frame HTML is trusted application content, and `loadModule` controls module resolution.
