### PR TITLE
Preserve HTML streaming through compression

### DIFF
--- a/demos/frames/app/router.ts
+++ b/demos/frames/app/router.ts
@@ -1,5 +1,6 @@
 import { createMiddleware, createRouter, type MiddlewareContext } from 'remix/router'
 import { asyncContext } from 'remix/middleware/async-context'
+import { compression } from 'remix/middleware/compression'
 import { logger } from 'remix/middleware/logger'
 import { render } from 'remix/middleware/render'
 import { staticFiles } from 'remix/middleware/static'
@@ -26,6 +27,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 middleware.push(
+  compression(),
   staticFiles('./public', {
     cacheControl: 'no-store',
     etag: false,

--- a/packages/compression-middleware/README.md
+++ b/packages/compression-middleware/README.md
@@ -117,9 +117,11 @@ let router = createRouter({
 
 ### Compression Options
 
-**Default:** Uses Node.js defaults for [zlib](https://nodejs.org/api/zlib.html#class-options) and [Brotli](https://nodejs.org/api/zlib.html#class-brotlioptions), with automatic flush handling for server-sent events.
+**Default:** Uses Node.js defaults for [zlib](https://nodejs.org/api/zlib.html#class-options) and [Brotli](https://nodejs.org/api/zlib.html#class-brotlioptions), with streaming-safe flush handling for HTML and server-sent events.
 
-You can pass options options to the underlying Node.js `zlib` and `brotli` compressors for fine-grained control:
+For `text/html` and `text/event-stream` responses, gzip and deflate use `Z_SYNC_FLUSH`, while Brotli uses `BROTLI_OPERATION_FLUSH`. This keeps each response chunk available to clients without waiting for the stream to finish. Explicit `flush` options override these defaults.
+
+You can pass options to the underlying Node.js `zlib` and `brotli` compressors for fine-grained control:
 
 ```ts
 import { createRouter } from 'remix/router'

--- a/packages/compression-middleware/src/lib/compression.ts
+++ b/packages/compression-middleware/src/lib/compression.ts
@@ -32,6 +32,7 @@ export interface CompressionOptions {
   /**
    * node:zlib options for gzip/deflate compression.
    * Can be static or a function that returns options based on the response.
+   * HTML and SSE responses use `Z_SYNC_FLUSH` unless you explicitly set a flush value.
    *
    * See: https://nodejs.org/api/zlib.html#class-options
    */
@@ -40,6 +41,7 @@ export interface CompressionOptions {
   /**
    * node:zlib options for Brotli compression.
    * Can be static or a function that returns options based on the response.
+   * HTML and SSE responses use `BROTLI_OPERATION_FLUSH` unless you explicitly set a flush value.
    *
    * See: https://nodejs.org/api/zlib.html#class-brotlioptions
    */

--- a/packages/remix/.changes/patch.response.flush-html-streams.md
+++ b/packages/remix/.changes/patch.response.flush-html-streams.md
@@ -1,0 +1,1 @@
+Compressed HTML from `remix/middleware/compression` now streams incrementally by default, so initial UI and Frame fallbacks can reach the browser before deferred Frames resolve. Explicit zlib and Brotli `flush` options continue to override the streaming-safe defaults.

--- a/packages/response/.changes/patch.flush-html-streams.md
+++ b/packages/response/.changes/patch.flush-html-streams.md
@@ -1,0 +1,1 @@
+Compressed `text/html` responses now flush each chunk as it becomes available, so streamed pages can send initial HTML before deferred content resolves. `compressResponse()` uses `Z_SYNC_FLUSH` for gzip and deflate and `BROTLI_OPERATION_FLUSH` for Brotli unless `flush` is configured explicitly.

--- a/packages/response/README.md
+++ b/packages/response/README.md
@@ -203,16 +203,16 @@ await compressResponse(response, request, {
   encodings: ['br', 'gzip', 'deflate'],
 
   // node:zlib options for gzip/deflate compression.
-  // For SSE responses (text/event-stream), flush: Z_SYNC_FLUSH
-  // is automatically applied unless you explicitly set a flush value.
+  // For HTML and SSE responses (text/html and text/event-stream),
+  // flush: Z_SYNC_FLUSH is applied unless you explicitly set a flush value.
   // See: https://nodejs.org/api/zlib.html#class-options
   zlib: {
     level: 6,
   },
 
   // node:zlib options for Brotli compression.
-  // For SSE responses (text/event-stream), flush: BROTLI_OPERATION_FLUSH
-  // is automatically applied unless you explicitly set a flush value.
+  // For HTML and SSE responses (text/html and text/event-stream),
+  // flush: BROTLI_OPERATION_FLUSH is applied unless you explicitly set a flush value.
   // See: https://nodejs.org/api/zlib.html#class-brotlioptions
   brotli: {
     params: {
@@ -221,6 +221,8 @@ await compressResponse(response, request, {
   },
 })
 ```
+
+The HTML and SSE flush defaults keep each compressed response chunk available to clients without waiting for the stream to finish. Set `zlib.flush` or `brotli.flush` explicitly to override this behavior.
 
 #### Range Requests and Compression
 

--- a/packages/response/src/lib/compress.test.ts
+++ b/packages/response/src/lib/compress.test.ts
@@ -736,11 +736,9 @@ describe('compressResponse()', () => {
     assert.equal(compressed.body, null)
   })
 
-  describe('Server-Sent Events', () => {
-    it('applies flush defaults while preserving custom compression options', () => {
+  describe('Streaming response types', () => {
+    it('applies flush defaults to SSE while preserving custom compression options', () => {
       let options = createCompressionOptions(new Headers({ 'Content-Type': 'text/event-stream' }), {
-        // Provide custom options without flush. compressResponse() should
-        // automatically apply flush for SSE.
         zlib: {
           level: 9,
         },
@@ -757,7 +755,23 @@ describe('compressResponse()', () => {
       assert.equal(options.brotli?.flush, constants.BROTLI_OPERATION_FLUSH)
     })
 
-    it('preserves explicit flush options', () => {
+    it('applies HTML flush defaults unless explicitly configured', () => {
+      let headers = new Headers({ 'Content-Type': 'text/html; charset=UTF-8' })
+      let defaults = createCompressionOptions(headers, {})
+
+      assert.equal(defaults.zlib?.flush, constants.Z_SYNC_FLUSH)
+      assert.equal(defaults.brotli?.flush, constants.BROTLI_OPERATION_FLUSH)
+
+      let configured = createCompressionOptions(headers, {
+        zlib: { flush: constants.Z_FULL_FLUSH },
+        brotli: { flush: constants.BROTLI_OPERATION_PROCESS },
+      })
+
+      assert.equal(configured.zlib?.flush, constants.Z_FULL_FLUSH)
+      assert.equal(configured.brotli?.flush, constants.BROTLI_OPERATION_PROCESS)
+    })
+
+    it('preserves explicit SSE flush options', () => {
       let options = createCompressionOptions(new Headers({ 'Content-Type': 'text/event-stream' }), {
         zlib: {
           flush: constants.Z_FULL_FLUSH,
@@ -771,7 +785,7 @@ describe('compressResponse()', () => {
       assert.equal(options.brotli?.flush, constants.BROTLI_OPERATION_PROCESS)
     })
 
-    it('does not apply flush defaults for non-SSE responses', () => {
+    it('does not apply flush defaults to other response types', () => {
       let options = createCompressionOptions(new Headers({ 'Content-Type': 'text/plain' }), {
         zlib: {
           level: 9,
@@ -984,6 +998,94 @@ describe('compressResponse()', () => {
       let decompressed = decompressStream(compressed.body!, encoding)
       return await streamToString(decompressed)
     }
+
+    async function readChunkWithTimeout(
+      reader: ReadableStreamDefaultReader<Uint8Array>,
+      message: string,
+    ): Promise<ReadableStreamReadResult<Uint8Array>> {
+      let timeout: ReturnType<typeof setTimeout> | undefined
+
+      try {
+        return await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => reject(new Error(message)), 1000)
+          }),
+        ])
+      } finally {
+        if (timeout != null) clearTimeout(timeout)
+      }
+    }
+
+    async function assertHtmlStreamsBeforeCompletion(encoding: Encoding): Promise<void> {
+      let initialHtml = '<!DOCTYPE html><main>Initial content</main>'
+      let frameHtml = '<template>Deferred frame</template>'
+      let releaseFrame = () => {}
+      let source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          let released = false
+          controller.enqueue(new TextEncoder().encode(initialHtml))
+          releaseFrame = () => {
+            if (released) return
+            released = true
+            controller.enqueue(new TextEncoder().encode(frameHtml))
+            controller.close()
+          }
+        },
+      })
+      let request = new Request('https://remix.run', {
+        headers: { 'Accept-Encoding': encoding },
+      })
+      let response = new Response(source, {
+        headers: { 'Content-Type': 'text/html; charset=UTF-8' },
+      })
+      let compressed = await compressResponse(response, request, { encodings: [encoding] })
+      let compressedBody = compressed.body
+      assert.ok(compressedBody)
+      let decompressed = decompressStream(compressedBody, encoding)
+      let reader = decompressed.getReader()
+      let decoder = new TextDecoder()
+      let html = ''
+
+      try {
+        while (html.length < initialHtml.length) {
+          let result = await readChunkWithTimeout(
+            reader,
+            `Initial HTML was buffered by ${encoding} compression`,
+          )
+          assert.ok(!result.done, 'Compressed stream should contain the initial HTML')
+          html += decoder.decode(result.value, { stream: true })
+        }
+
+        assert.equal(html, initialHtml)
+        releaseFrame()
+
+        while (true) {
+          let result = await reader.read()
+          if (result.done) break
+          html += decoder.decode(result.value, { stream: true })
+        }
+        html += decoder.decode()
+
+        assert.equal(html, initialHtml + frameHtml)
+      } finally {
+        releaseFrame()
+      }
+    }
+
+    describe('HTML streaming', () => {
+      it('flushes the initial HTML through Brotli before the source completes', async () => {
+        await assertHtmlStreamsBeforeCompletion('br')
+      })
+
+      it('flushes the initial HTML through gzip before the source completes', async () => {
+        await assertHtmlStreamsBeforeCompletion('gzip')
+      })
+
+      it('flushes the initial HTML through deflate before the source completes', async () => {
+        await assertHtmlStreamsBeforeCompletion('deflate')
+      })
+    })
 
     describe('correctness (round-trip compression)', () => {
       it('handles binary data byte-perfectly', async () => {

--- a/packages/response/src/lib/compress.test.ts
+++ b/packages/response/src/lib/compress.test.ts
@@ -771,6 +771,19 @@ describe('compressResponse()', () => {
       assert.equal(configured.brotli?.flush, constants.BROTLI_OPERATION_PROCESS)
     })
 
+    it('matches streaming media types case-insensitively', () => {
+      let html = createCompressionOptions(
+        new Headers({ 'Content-Type': 'Text/HTML; charset=UTF-8' }),
+        {},
+      )
+      let sse = createCompressionOptions(new Headers({ 'Content-Type': 'TEXT/Event-Stream' }), {})
+
+      assert.equal(html.zlib?.flush, constants.Z_SYNC_FLUSH)
+      assert.equal(html.brotli?.flush, constants.BROTLI_OPERATION_FLUSH)
+      assert.equal(sse.zlib?.flush, constants.Z_SYNC_FLUSH)
+      assert.equal(sse.brotli?.flush, constants.BROTLI_OPERATION_FLUSH)
+    })
+
     it('preserves explicit SSE flush options', () => {
       let options = createCompressionOptions(new Headers({ 'Content-Type': 'text/event-stream' }), {
         zlib: {

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -232,7 +232,7 @@ export function createCompressionOptions(
   options: CompressResponseOptions,
 ): CompressResponseOptions {
   let contentTypeHeader = responseHeaders.get('Content-Type')
-  let mediaType = contentTypeHeader?.split(';')[0].trim()
+  let mediaType = contentTypeHeader?.split(';')[0].trim().toLowerCase()
   let shouldFlush = mediaType === 'text/event-stream' || mediaType === 'text/html'
 
   return {

--- a/packages/response/src/lib/compress.ts
+++ b/packages/response/src/lib/compress.ts
@@ -41,8 +41,8 @@ export interface CompressResponseOptions {
   /**
    * node:zlib options for gzip/deflate compression.
    *
-   * For SSE responses (text/event-stream), `flush: Z_SYNC_FLUSH` is automatically
-   * applied unless you explicitly set a flush value.
+   * For HTML and SSE responses (`text/html` and `text/event-stream`),
+   * `flush: Z_SYNC_FLUSH` is automatically applied unless you explicitly set a flush value.
    *
    * See: https://nodejs.org/api/zlib.html#class-options
    */
@@ -51,8 +51,9 @@ export interface CompressResponseOptions {
   /**
    * node:zlib options for Brotli compression.
    *
-   * For SSE responses (text/event-stream), `flush: BROTLI_OPERATION_FLUSH` is
-   * automatically applied unless you explicitly set a flush value.
+   * For HTML and SSE responses (`text/html` and `text/event-stream`),
+   * `flush: BROTLI_OPERATION_FLUSH` is automatically applied unless you explicitly set a flush
+   * value.
    *
    * See: https://nodejs.org/api/zlib.html#class-brotlioptions
    */
@@ -232,17 +233,17 @@ export function createCompressionOptions(
 ): CompressResponseOptions {
   let contentTypeHeader = responseHeaders.get('Content-Type')
   let mediaType = contentTypeHeader?.split(';')[0].trim()
-  let isSSE = mediaType === 'text/event-stream'
+  let shouldFlush = mediaType === 'text/event-stream' || mediaType === 'text/html'
 
   return {
     ...options,
     brotli: {
       ...options.brotli,
-      ...(isSSE && options.brotli?.flush === undefined ? brotliFlushOptions : null),
+      ...(shouldFlush && options.brotli?.flush === undefined ? brotliFlushOptions : null),
     },
     zlib: {
       ...options.zlib,
-      ...(isSSE && options.zlib?.flush === undefined ? zlibFlushOptions : null),
+      ...(shouldFlush && options.zlib?.flush === undefined ? zlibFlushOptions : null),
     },
   }
 }


### PR DESCRIPTION
`renderToStream()` emits initial HTML before deferred Frames resolve, but the default gzip, deflate, and Brotli settings may buffer that chunk until the response completes. This means adding `compression()` can cancel the user-visible benefit of streaming HTML.

You can see this behavior if you add `compression()` middleware to the frames demo:

https://github.com/user-attachments/assets/d9a85f44-8cf1-4b26-a6d2-70003e2ed49a

This extends the streaming-safe flush policy already used for server-sent events to `text/html` responses.

- Apply `Z_SYNC_FLUSH` to gzip and deflate HTML responses and `BROTLI_OPERATION_FLUSH` to Brotli HTML responses.
- Preserve explicitly configured `flush` values as an escape hatch for applications that prioritize compression efficiency.
- Verify that each supported encoding exposes decodable initial HTML while deferred content is still pending.
- Enable compression in the Frames demo so the standard integration exercises progressive compressed HTML.

Frequent flushing can reduce compression efficiency. In a synthetic comparison, a single-chunk HTML response added 1–6 compressed bytes, while a highly repetitive 21-chunk response added 206–261 bytes.
