### PR TITLE
Vary preflight responses on private network requests

### DIFF
--- a/packages/cors-middleware/.changes/patch.private-network-vary.md
+++ b/packages/cors-middleware/.changes/patch.private-network-vary.md
@@ -1,0 +1,1 @@
+Include `Access-Control-Request-Private-Network` in `Vary` on all allowed preflight responses when `allowPrivateNetwork` is enabled, so caches distinguish ordinary preflights from private network preflights. This also applies when `preflightContinue` is enabled.

--- a/packages/cors-middleware/README.md
+++ b/packages/cors-middleware/README.md
@@ -137,7 +137,9 @@ let router = createRouter({
 })
 ```
 
-When `allowPrivateNetwork` is enabled, the middleware adds `Access-Control-Allow-Private-Network: true` for preflight requests that ask for private network access.
+Private network access is disabled by default. When `allowPrivateNetwork` is enabled, the middleware adds `Access-Control-Allow-Private-Network: true` for preflight requests that ask for private network access and pass the origin policy. The default `origin: '*'` allows all origins; configure `origin` to limit which origins can request private network access.
+
+With this option enabled, preflight responses vary on `Access-Control-Request-Private-Network`, including when the request header is absent or does not request access.
 
 ## Expose Response Headers
 

--- a/packages/cors-middleware/src/lib/cors.test.ts
+++ b/packages/cors-middleware/src/lib/cors.test.ts
@@ -347,7 +347,128 @@ describe('cors middleware', () => {
     })
 
     assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
     assert.equal(response.headers.get('Access-Control-Allow-Private-Network'), 'true')
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(vary.has('Access-Control-Request-Private-Network'))
+  })
+
+  it('does not allow private network requests by default', async () => {
+    let router = createRouter({ middleware: [cors()] })
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    })
+
+    assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
+    assert.equal(response.headers.get('Access-Control-Allow-Private-Network'), null)
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(!vary.has('Access-Control-Request-Private-Network'))
+  })
+
+  it('varies on private network requests when the request header is absent', async () => {
+    let router = createRouter({ middleware: [cors({ allowPrivateNetwork: true })] })
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+      },
+    })
+
+    assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
+    assert.equal(response.headers.get('Access-Control-Allow-Private-Network'), null)
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(vary.has('Access-Control-Request-Private-Network'))
+  })
+
+  it('varies on private network requests when the request header is false', async () => {
+    let router = createRouter({ middleware: [cors({ allowPrivateNetwork: true })] })
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Private-Network': 'false',
+      },
+    })
+
+    assert.equal(response.status, 204)
+    assert.equal(response.headers.get('Access-Control-Allow-Private-Network'), null)
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(vary.has('Access-Control-Request-Private-Network'))
+  })
+
+  it('merges private network Vary values for continued preflight requests', async () => {
+    let router = createRouter({
+      middleware: [cors({ allowPrivateNetwork: true, preflightContinue: true })],
+    })
+
+    router.options('/', () => new Response('continued', { headers: { Vary: 'Accept-Encoding' } }))
+
+    let response = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+      },
+    })
+
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'continued')
+    assert.equal(response.headers.get('Access-Control-Allow-Private-Network'), null)
+
+    let vary = Vary.from(response.headers.get('Vary'))
+    assert.ok(vary.has('Accept-Encoding'))
+    assert.ok(vary.has('Access-Control-Request-Method'))
+    assert.ok(vary.has('Access-Control-Request-Private-Network'))
+  })
+
+  it('applies the origin policy before allowing private network requests', async () => {
+    let router = createRouter({
+      middleware: [cors({ origin: 'https://allowed.example', allowPrivateNetwork: true })],
+    })
+
+    let allowedResponse = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://allowed.example',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    })
+
+    let blockedResponse = await router.fetch('https://remix.run/', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://blocked.example',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    })
+
+    assert.equal(allowedResponse.status, 204)
+    assert.equal(
+      allowedResponse.headers.get('Access-Control-Allow-Origin'),
+      'https://allowed.example',
+    )
+    assert.equal(allowedResponse.headers.get('Access-Control-Allow-Private-Network'), 'true')
+    assert.equal(blockedResponse.status, 403)
+    assert.equal(blockedResponse.headers.get('Access-Control-Allow-Origin'), null)
+    assert.equal(blockedResponse.headers.get('Access-Control-Allow-Private-Network'), null)
   })
 
   it('sets Access-Control-Expose-Headers for actual requests', async () => {

--- a/packages/cors-middleware/src/lib/cors.ts
+++ b/packages/cors-middleware/src/lib/cors.ts
@@ -192,12 +192,14 @@ export function cors(options: CorsOptions = {}): Middleware {
         corsHeaders.set('Access-Control-Max-Age', String(maxAge))
       }
 
-      if (
-        options.allowPrivateNetwork &&
-        context.headers.get('Access-Control-Request-Private-Network')?.toLowerCase() === 'true'
-      ) {
-        corsHeaders.set('Access-Control-Allow-Private-Network', 'true')
+      if (options.allowPrivateNetwork) {
         vary.add('Access-Control-Request-Private-Network')
+
+        if (
+          context.headers.get('Access-Control-Request-Private-Network')?.toLowerCase() === 'true'
+        ) {
+          corsHeaders.set('Access-Control-Allow-Private-Network', 'true')
+        }
       }
 
       if (!preflightContinue) {


### PR DESCRIPTION
When `allowPrivateNetwork` is enabled, preflight responses currently vary on `Access-Control-Request-Private-Network` only when the request asks for access. A cached ordinary preflight can therefore be reused for a private network preflight.

- Include the request header in `Vary` on every allowed preflight response when the option is enabled, including responses from downstream handlers with `preflightContinue`.
- Clarify the existing opt-in and origin policy in the README, preserving wildcard support and origin checks.
