### PR TITLE
fix(navigation): guard window.navigation for browsers without Navigation API

### DIFF
--- a/packages/ui/src/runtime/navigation.ts
+++ b/packages/ui/src/runtime/navigation.ts
@@ -34,6 +34,7 @@ export async function navigate(href: string, options?: NavigationOptions) {
     resetScroll: options?.resetScroll !== false,
     $rmx: true,
   } satisfies NavigationState
+  if (!window.navigation) { window.location.assign(href); return }
   let transition = window.navigation.navigate(href, { state, history: options?.history })
   await transition.finished
 }
@@ -57,6 +58,7 @@ export function startNavigationListenerImpl(
   },
 ) {
   let navigation = window.navigation
+  if (!navigation) return
 
   navigation.updateCurrentEntry({
     state: { target: undefined, src: window.location.href, resetScroll: true, $rmx: true },
@@ -128,6 +130,7 @@ function getTraverseNavigationState(event: NavigateEvent): NavigationState | und
   // Safari returns `null` for destination.getState(), even though its in the
   // navigation.entries(), so we do its job for it and look it up.
   let navigation = window.navigation
+  if (!navigation) return undefined
   let matchingEntry = navigation.entries().find((entry) => entry.key === event.destination.key)
   if (matchingEntry) {
     let state = matchingEntry.getState()


### PR DESCRIPTION
## Summary

Firefox ≤ 146 and iOS Safari ≤ 26.1 do not implement the Navigation API. Accessing `window.navigation.navigate()`, `navigation.updateCurrentEntry()`, or `navigation.entries()` on `undefined` throws a `TypeError` that crashes the runtime.

**Fix:** add three guards:
- `navigate()` — falls back to `window.location.assign()` when the Navigation API is absent
- `startNavigationListenerImpl()` — returns early when `window.navigation` is `undefined`
- `getTraverseNavigationState()` — returns `undefined` when `window.navigation` is `undefined`